### PR TITLE
Make it possible to skip js tests using `-DskipTests`

### DIFF
--- a/composer/modules/js-tests/pom.xml
+++ b/composer/modules/js-tests/pom.xml
@@ -124,6 +124,7 @@
                             <arguments>
                                 <argument>install</argument>
                             </arguments>
+                            <skip>${skipTests}</skip>
                         </configuration>
                     </execution>
                     <execution>
@@ -138,6 +139,7 @@
                                 <argument>run</argument>
                                 <argument>compile</argument>
                             </arguments>
+                            <skip>${skipTests}</skip>
                         </configuration>
                     </execution>
                     <execution>
@@ -153,6 +155,7 @@
                                 <argument>--</argument>
                                 <argument>--projectVersion=${project.version}</argument>
                             </arguments>
+                            <skip>${skipTests}</skip>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Purpose
Resolve ballerina-lang/composer#5024

## Goals
Skip test js to seeped up dev builds when working with Java.