### PR TITLE
Fix #4338: stop all server connectors if one fails to start up 

### DIFF
--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConnectionManager.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConnectionManager.java
@@ -43,7 +43,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
 import java.util.logging.LogManager;
 
 /**
@@ -137,7 +136,7 @@ public class HttpConnectionManager {
      */
     void startPendingHTTPConnectors(BallerinaHttpServerConnector httpServerConnector) throws ServerConnectorException {
         ConnectorStartupSynchronizer startupSyncer =
-                new ConnectorStartupSynchronizer(new CountDownLatch(startupDelayedHTTPServerConnectors.size()));
+                new ConnectorStartupSynchronizer(startupDelayedHTTPServerConnectors.size());
 
         for (Map.Entry<String, ServerConnector> serverConnectorEntry : startupDelayedHTTPServerConnectors.entrySet()) {
             ServerConnector serverConnector = serverConnectorEntry.getValue();
@@ -147,7 +146,7 @@ public class HttpConnectionManager {
         }
         try {
             // Wait for all the connectors to start
-            startupSyncer.getCountDownLatch().await();
+            startupSyncer.syncConnectors();
         } catch (InterruptedException e) {
             throw new BallerinaConnectorException("Error in starting HTTP server connector(s)");
         }
@@ -222,18 +221,21 @@ public class HttpConnectionManager {
     }
 
     private void validateConnectorStartup(ConnectorStartupSynchronizer startupSyncer) {
-        int noOfExceptions = startupSyncer.getExceptions().size();
+        int noOfExceptions = startupSyncer.getNoOfFailedConnectors();
         if (noOfExceptions <= 0) {
             return;
         }
         PrintStream console = System.err;
 
-        startupSyncer.getExceptions().forEach((connectorId, e) ->
-            console.println("ballerina: " + makeFirstLetterLowerCase(e.getMessage()) + ": [" + connectorId + "]"));
+        startupSyncer.failedConnectorsIterator()
+                .forEachRemaining(exceptionEntry -> console.println(
+                        "ballerina: " + makeFirstLetterLowerCase(exceptionEntry.getValue().getMessage())
+                                + ": [" + exceptionEntry.getKey() + "]"));
 
-        if (noOfExceptions == startupDelayedHTTPServerConnectors.size()) {
-            // If the no. of exceptions is equal to the no. of connectors to be started, then none of the
-            // connectors have started properly and we can terminate the runtime
+        if (noOfExceptions > 0) {
+            // If there are any exceptions, stop all the connectors which started correctly and terminate the runtime.
+            startupSyncer.inUseConnectorsIterator()
+                    .forEachRemaining(connectorId -> startupDelayedHTTPServerConnectors.get(connectorId).stop());
             throw new BallerinaConnectorException("failed to start the server connectors");
         }
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConnectorPortBindingListener.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConnectorPortBindingListener.java
@@ -52,7 +52,7 @@ public class HttpConnectorPortBindingListener implements PortBindingEventListene
         } else {
             console.println("ballerina: started HTTP/WS server connector " + serverConnectorId);
         }
-        connectorStartupSynchronizer.getCountDownLatch().countDown();
+        connectorStartupSynchronizer.addServerConnector(serverConnectorId);
     }
 
     @Override
@@ -70,7 +70,6 @@ public class HttpConnectorPortBindingListener implements PortBindingEventListene
 
         if (throwable instanceof BindException) {
             connectorStartupSynchronizer.addException(serverConnectorId, (BindException) throwable);
-            connectorStartupSynchronizer.getCountDownLatch().countDown();
         }
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/util/ConnectorStartupSynchronizer.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/util/ConnectorStartupSynchronizer.java
@@ -35,15 +35,15 @@ public class ConnectorStartupSynchronizer {
 
     private List<String> inUseConnectors = new ArrayList<>();
     private Map<String, Exception> exceptions = new HashMap<>();
-    private CountDownLatch countDownLatch;
+    private CountDownLatch connectorStartupLatch;
 
     public ConnectorStartupSynchronizer(int noOfConnectors) {
-        this.countDownLatch = new CountDownLatch(noOfConnectors);
+        this.connectorStartupLatch = new CountDownLatch(noOfConnectors);
     }
 
     public void addServerConnector(String connectorId) {
         inUseConnectors.add(connectorId);
-        countDownLatch.countDown();
+        connectorStartupLatch.countDown();
     }
 
     public Iterator<String> inUseConnectorsIterator() {
@@ -52,7 +52,7 @@ public class ConnectorStartupSynchronizer {
 
     public void addException(String connectorId, Exception ex) {
         exceptions.put(connectorId, ex);
-        countDownLatch.countDown();
+        connectorStartupLatch.countDown();
     }
 
     public Iterator<Map.Entry<String, Exception>> failedConnectorsIterator() {
@@ -64,6 +64,6 @@ public class ConnectorStartupSynchronizer {
     }
 
     public void syncConnectors() throws InterruptedException {
-        countDownLatch.await();
+        connectorStartupLatch.await();
     }
 }


### PR DESCRIPTION
## Purpose
> Currently, if at least one server connector starts up correctly, the runtime keeps running. However the desired behaviour is that if at least one server connector fails to start, the others should stop and the runtime should terminate. Fix #4338 

## Goals
> Gracefully stop all server connectors and quit the runtime if a server connector fails to start.

## Approach
> Changed the way connector start-up was validated. Previously, connectors were deemed correctly started if at least one connector started. By changing that logic to look for at least one failure instead, the desired behaviour was achieved.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? no

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> OS: Ubuntu 16.04
> JDK: 1.8
 
## Learning
> N/A