### PR TITLE
[WebSocket] Add Query Param Support

### DIFF
--- a/docs/ballerina-by-example/examples/websocket-chat-application/websocket-chat-application.bal
+++ b/docs/ballerina-by-example/examples/websocket-chat-application/websocket-chat-application.bal
@@ -1,27 +1,34 @@
 import ballerina.net.ws;
 
 @ws:configuration {
-    basePath: "/chat/{fname}+{lname}/{age}",
+    basePath: "/chat/{name}",
     port:9090
 }
 service<ws> ChatApp {
 
     map consMap = {};
 
-    resource onOpen(ws:Connection conn, string fname, string lname, string age) {
+    resource onOpen(ws:Connection conn, string name) {
         consMap[conn.getID()] = conn;
-        string msg = string `{{fname}} {{lname}} with age {{age}} connected to chat`;
+        map params = conn.getQueryParams();
+        var age, err = (string)params.age;
+        string msg;
+        if (err == null) {
+            msg = string `{{name}} with age {{age}} connected to chat`;
+        } else {
+            msg = string `{{name}} connected to chat`;
+        }
         broadcast(consMap, msg);
     }
 
-    resource onTextMessage(ws:Connection con, ws:TextFrame frame, string fname) {
-        string msg = string `{{fname}}: {{frame.text}}`;
+    resource onTextMessage(ws:Connection con, ws:TextFrame frame, string name) {
+        string msg = string `{{name}}: {{frame.text}}`;
         println(msg);
         broadcast(consMap, msg);
     }
 
-    resource onClose(ws:Connection con, ws:CloseFrame frame, string fname) {
-        string msg = string `{{fname}} left the chat`;
+    resource onClose(ws:Connection con, ws:CloseFrame frame, string name) {
+        string msg = string `{{name}} left the chat`;
         consMap.remove(con.getID());
         broadcast(consMap, msg);
     }

--- a/docs/ballerina-by-example/examples/websocket-chat-application/websocket-chat-application.sh
+++ b/docs/ballerina-by-example/examples/websocket-chat-application/websocket-chat-application.sh
@@ -5,7 +5,7 @@ $ ballerina run websocket-chat-application.bal
 # To check the sample,use Chrome or Firefox javascript console and run the below commands <br>
 # Run first 3 lines of the below code in two or more consoles and see how the messages are received by sending messages
 # To check the capability of change the names the URI such that /chat/fistName+LastName/age with multiple clients
-$ var ws = new WebSocket("ws://localhost:9090/chat/bruce+wayne/30");
+$ var ws = new WebSocket("ws://localhost:9090/chat/bruce?age=30");
 $ ws.onmessage = function(frame) {console.log(frame.data)};
 $ ws.onclose = function(frame) {console.log(frame)};
 

--- a/stdlib/ballerina-http/src/main/ballerina/ballerina/net/ws/natives.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/ballerina/net/ws/natives.bal
@@ -47,6 +47,11 @@ public struct HandshakeConnection {
     map<string> upgradeHeaders;
 }
 
+@Description {value:"Gets the query parameters from the HandshakeConnection as a map"}
+@Param {value:"req: The HandshakeConnection struct" }
+@Return {value:"The map of query params" }
+public native function <HandshakeConnection conn> getQueryParams () (map);
+
 @Description {value:"Cancels the handshake"}
 @Param {value:"conn: A HandshakeConnection struct"}
 @Param {value:"statusCode: Status code for closing the connection"}
@@ -121,6 +126,10 @@ public native function <Connection conn> pong(blob data);
 @Param {value:"reason: Reason for closing the connection"}
 public native function <Connection conn> closeConnection(int statusCode, string reason);
 
+@Description {value:"Gets the query parameters from the Connection as a map"}
+@Param {value:"req: The Connection struct" }
+@Return {value:"The map of query params" }
+public native function <Connection conn> getQueryParams () (map);
 
 @Description {value:"Configuration struct for WebSocket client connection"}
 @Field {value: "subProtocols: Negotiable sub protocols for the client"}

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -72,9 +72,7 @@ import org.wso2.transport.http.netty.message.MultipartRequestDecoder;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
-import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -290,24 +288,6 @@ public class HttpUtil {
         } catch (IOException e) {
             log.error("Couldn't close message output stream", e);
         }
-    }
-
-    public static BMap<String, BValue> getParamMap(String payload) throws UnsupportedEncodingException {
-        BMap<String, BValue> params = new BMap<>();
-        String[] entries = payload.split("&");
-        for (String entry : entries) {
-            int index = entry.indexOf('=');
-            if (index != -1) {
-                String name = entry.substring(0, index).trim();
-                String value = URLDecoder.decode(entry.substring(index + 1).trim(), "UTF-8");
-                if (value.matches("")) {
-                    params.put(name, new BString(""));
-                    continue;
-                }
-                params.put(name, new BString(value));
-            }
-        }
-        return params;
     }
 
     /**

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/uri/URIUtil.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/uri/URIUtil.java
@@ -18,6 +18,12 @@
 
 package org.ballerinalang.net.uri;
 
+import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BString;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
 /**
  * Utilities related to URI processing.
  */
@@ -38,5 +44,22 @@ public class URIUtil {
         }
 
         return path.substring(basePath.length());
+    }
+
+    public static void populateQueryParamMap(String queryParamString, BMap<String, BString> queryParamsMap)
+            throws UnsupportedEncodingException {
+        String[] queryParamVals = queryParamString.split("&");
+        for (String queryParam : queryParamVals) {
+            int index = queryParam.indexOf('=');
+            if (index != -1) {
+                String queryParamName = queryParam.substring(0, index).trim();
+                String queryParamValue = URLDecoder.decode(queryParam.substring(index + 1).trim(), "UTF-8");
+                if (queryParamValue.matches("")) {
+                    queryParamsMap.put(queryParamName, new BString(""));
+                    continue;
+                }
+                queryParamsMap.put(queryParamName, new BString(queryParamValue));
+            }
+        }
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/Constants.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/Constants.java
@@ -67,4 +67,7 @@ public class Constants extends org.ballerinalang.net.http.Constants {
     public static final String NATIVE_DATA_UPGRADE_HEADERS = "NATIVE_DATA_UPGRADE_HEADERS";
     public static final String NATIVE_DATA_PARENT_CONNECTION_ID = "NATIVE_DATA_PARENT_CONNECTION_ID";
     public static final String NATIVE_DATA_PING_TIME_VALIDATOR = "NATIVE_DATA_PING_TIME_VALIDATOR";
+
+    public static final String NATIVE_DATA_QUERY_PARAMS = "NATIVE_DATA_QUERY_PARAMS";
+
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/WebSocketUtil.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/WebSocketUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.net.ws;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BStruct;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+
+/**
+ * Utility class for websockets.
+ */
+public abstract class WebSocketUtil {
+    public static BValue[] getQueryParams(Context context, AbstractNativeFunction abstractNativeFunction) {
+        BStruct wsConnection = (BStruct) abstractNativeFunction.getRefArgument(context, 0);
+        Object queryParams = wsConnection.getNativeData(Constants.NATIVE_DATA_QUERY_PARAMS);
+        if (queryParams != null && queryParams instanceof BMap) {
+            return abstractNativeFunction.getBValues(
+                    (BMap) wsConnection.getNativeData(Constants.NATIVE_DATA_QUERY_PARAMS));
+        }
+        return abstractNativeFunction.getBValues(new BMap<>());
+    }
+}

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/GetID.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/GetID.java
@@ -16,11 +16,11 @@
  *  under the License.
  */
 
-package org.ballerinalang.net.ws.nativeimpl;
+package org.ballerinalang.net.ws.nativeimpl.connection;
 
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.model.types.TypeKind;
-import org.ballerinalang.model.values.BBoolean;
+import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.AbstractNativeFunction;
@@ -32,26 +32,26 @@ import org.ballerinalang.net.ws.Constants;
 import javax.websocket.Session;
 
 /**
- * Check whether the connection is secure connection or not.
+ * Get the ID of the connection.
  *
  * @since 0.94
  */
 
 @BallerinaFunction(
         packageName = "ballerina.net.ws",
-        functionName = "isOpen",
+        functionName = "getID",
         receiver = @Receiver(type = TypeKind.STRUCT, structType = "Connection",
                              structPackage = "ballerina.net.ws"),
-        returnType = {@ReturnType(type = TypeKind.BOOLEAN)},
+        returnType = {@ReturnType(type = TypeKind.STRING)},
         isPublic = true
 )
-public class IsOpen extends AbstractNativeFunction {
+public class GetID extends AbstractNativeFunction {
 
     @Override
     public BValue[] execute(Context context) {
         BStruct wsConnection = (BStruct) getRefArgument(context, 0);
         Session session = (Session) wsConnection.getNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION);
-        boolean isOpen = session.isOpen();
-        return getBValues(new BBoolean(isOpen));
+        String id = session.getId();
+        return getBValues(new BString(id));
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/GetNegotiatedSubProtocol.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/GetNegotiatedSubProtocol.java
@@ -16,48 +16,42 @@
  *  under the License.
  */
 
-package org.ballerinalang.net.ws.nativeimpl;
+package org.ballerinalang.net.ws.nativeimpl.connection;
 
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.AbstractNativeFunction;
-import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.net.ws.Constants;
-import org.ballerinalang.util.exceptions.BallerinaException;
 
-import java.nio.ByteBuffer;
 import javax.websocket.Session;
 
 /**
- * Push binary data to the other end of the connection.
+ * Get negotiated sub protocol.
  *
  * @since 0.94
  */
 
 @BallerinaFunction(
         packageName = "ballerina.net.ws",
-        functionName = "pong",
+        functionName = "getNegotiatedSubProtocol",
         receiver = @Receiver(type = TypeKind.STRUCT, structType = "Connection",
                              structPackage = "ballerina.net.ws"),
-        args = {@Argument(name = "binaryData", type = TypeKind.BLOB)},
+        returnType = {@ReturnType(type = TypeKind.STRING)},
         isPublic = true
 )
-public class Pong extends AbstractNativeFunction {
+public class GetNegotiatedSubProtocol extends AbstractNativeFunction {
 
     @Override
     public BValue[] execute(Context context) {
-        try {
-            BStruct wsConnection = (BStruct) getRefArgument(context, 0);
-            Session session = (Session) wsConnection.getNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION);
-            byte[] binaryData = getBlobArgument(context, 0);
-            session.getBasicRemote().sendPong(ByteBuffer.wrap(binaryData));
-        } catch (Throwable e) {
-            throw new BallerinaException("Cannot send the message. Error occurred.");
-        }
-        return VOID_RETURN;
+        BStruct wsConnection = (BStruct) getRefArgument(context, 0);
+        Session session = (Session) wsConnection.getNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION);
+        String negotiatedSubProtocol = session.getNegotiatedSubprotocol();
+        return getBValues(new BString(negotiatedSubProtocol));
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/GetParentConnection.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/GetParentConnection.java
@@ -16,44 +16,43 @@
  *  under the License.
  */
 
-package org.ballerinalang.net.ws.nativeimpl;
+package org.ballerinalang.net.ws.nativeimpl.connection;
 
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.AbstractNativeFunction;
-import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.net.ws.Constants;
-import org.wso2.transport.http.netty.contract.websocket.WebSocketInitMessage;
+import org.ballerinalang.net.ws.WebSocketConnectionManager;
+import org.ballerinalang.net.ws.WsOpenConnectionInfo;
 
 /**
- * Get the ID of the connection.
+ * Get parent connection is exists.
  *
  * @since 0.94
  */
 
 @BallerinaFunction(
         packageName = "ballerina.net.ws",
-        functionName = "cancelHandshake",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = "HandshakeConnection",
+        functionName = "getParentConnection",
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = "Connection",
                              structPackage = "ballerina.net.ws"),
-        args = {@Argument(name = "statusCode", type = TypeKind.INT),
-                @Argument(name = "reason", type = TypeKind.STRING)},
+        returnType = {@ReturnType(type = TypeKind.STRUCT, structType = "Connection",
+                                  structPackage = "ballerina.net.ws")},
         isPublic = true
 )
-public class CancelHandshake extends AbstractNativeFunction {
+public class GetParentConnection extends AbstractNativeFunction {
 
     @Override
     public BValue[] execute(Context context) {
-        BStruct handshakeConnection = (BStruct) getRefArgument(context, 0);
-        int statusCode = (int) getIntArgument(context, 0);
-        String reason = getStringArgument(context, 0);
-        WebSocketInitMessage initMessage =
-                (WebSocketInitMessage) handshakeConnection.getNativeData(Constants.WEBSOCKET_MESSAGE);
-        initMessage.cancelHandShake(statusCode, reason);
-        return VOID_RETURN;
+        BStruct wsConnection = (BStruct) getRefArgument(context, 0);
+        String parentConnectionID = (String) wsConnection.getNativeData(Constants.NATIVE_DATA_PARENT_CONNECTION_ID);
+        WsOpenConnectionInfo connectionInfo =
+                WebSocketConnectionManager.getInstance().getConnectionInfo(parentConnectionID);
+        return getBValues(connectionInfo.getWsConnection());
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/GetQueryParams.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/GetQueryParams.java
@@ -16,54 +16,40 @@
  * under the License.
  */
 
-package org.ballerinalang.net.http.nativeimpl.inbound.request;
+package org.ballerinalang.net.ws.nativeimpl.connection;
 
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.model.types.TypeKind;
-import org.ballerinalang.model.values.BMap;
-import org.ballerinalang.model.values.BString;
-import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
-import org.ballerinalang.net.uri.URIUtil;
+import org.ballerinalang.net.ws.WebSocketUtil;
 import org.ballerinalang.util.exceptions.BallerinaException;
-import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
 /**
- * Get the Query params from HTTP message and return a map.
+ * Get the Query params from Websocket Connection and return a map.
  *
- * @since 0.94
+ * @since 0.961.0
  */
 @BallerinaFunction(
-        packageName = "ballerina.net.http",
+        packageName = "ballerina.net.ws",
         functionName = "getQueryParams",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = "InRequest",
-                             structPackage = "ballerina.net.http"),
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = "Connection",
+                             structPackage = "ballerina.net.ws"),
         returnType = {@ReturnType(type = TypeKind.MAP, elementType = TypeKind.STRING)},
         isPublic = true
 )
 public class GetQueryParams extends AbstractNativeFunction {
+
     @Override
     public BValue[] execute(Context context) {
         try {
-            BStruct requestStruct  = ((BStruct) getRefArgument(context, 0));
-            HTTPCarbonMessage httpCarbonMessage = (HTTPCarbonMessage) requestStruct
-                    .getNativeData(Constants.TRANSPORT_MESSAGE);
-
-            if (httpCarbonMessage.getProperty(Constants.QUERY_STR) != null) {
-                String queryString = (String) httpCarbonMessage.getProperty(Constants.QUERY_STR);
-                BMap<String, BString> params = new BMap<>();
-                URIUtil.populateQueryParamMap(queryString, params);
-                return getBValues(params);
-            } else {
-                return getBValues(new BMap<>());
-            }
+            return WebSocketUtil.getQueryParams(context, this);
         } catch (Throwable e) {
-            throw new BallerinaException("Error while retrieving query param from message: " + e.getMessage());
+            throw new BallerinaException(
+                    "Error occurred while retrieving query parameters from Connection: " + e.getMessage());
         }
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/GetUpgradeHeader.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/GetUpgradeHeader.java
@@ -16,42 +16,46 @@
  *  under the License.
  */
 
-package org.ballerinalang.net.ws.nativeimpl;
+package org.ballerinalang.net.ws.nativeimpl.connection;
 
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.model.types.TypeKind;
-import org.ballerinalang.model.values.BBoolean;
+import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.net.ws.Constants;
 
-import javax.websocket.Session;
+import java.util.Locale;
+import java.util.Map;
 
 /**
- * Check whether the connection is secure connection or not.
+ * Get upgrade header for a given key.
  *
  * @since 0.94
  */
 
 @BallerinaFunction(
         packageName = "ballerina.net.ws",
-        functionName = "isSecure",
+        functionName = "getUpgradeHeader",
         receiver = @Receiver(type = TypeKind.STRUCT, structType = "Connection",
                              structPackage = "ballerina.net.ws"),
-        returnType = {@ReturnType(type = TypeKind.BOOLEAN)},
+        args = {@Argument(name = "text", type = TypeKind.STRING)},
+        returnType = {@ReturnType(type = TypeKind.STRING)},
         isPublic = true
 )
-public class IsSecure extends AbstractNativeFunction {
+public class GetUpgradeHeader extends AbstractNativeFunction {
 
     @Override
     public BValue[] execute(Context context) {
         BStruct wsConnection = (BStruct) getRefArgument(context, 0);
-        Session session = (Session) wsConnection.getNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION);
-        boolean isSecuredConnection = session.isSecure();
-        return getBValues(new BBoolean(isSecuredConnection));
+        String key = getStringArgument(context, 0).toLowerCase(Locale.ENGLISH);
+        Map<String, String> upgradeHeaders =
+                (Map<String, String>) wsConnection.getNativeData(Constants.NATIVE_DATA_UPGRADE_HEADERS);
+        return getBValues(new BString(upgradeHeaders.get(key)));
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/GetUpgradeHeaders.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/GetUpgradeHeaders.java
@@ -16,10 +16,12 @@
  *  under the License.
  */
 
-package org.ballerinalang.net.ws.nativeimpl;
+package org.ballerinalang.net.ws.nativeimpl.connection;
 
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.AbstractNativeFunction;
@@ -27,32 +29,33 @@ import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.net.ws.Constants;
-import org.ballerinalang.net.ws.WebSocketConnectionManager;
-import org.ballerinalang.net.ws.WsOpenConnectionInfo;
+
+import java.util.Map;
 
 /**
- * Get parent connection is exists.
+ * Get all the upgrade headers.
  *
  * @since 0.94
  */
 
 @BallerinaFunction(
         packageName = "ballerina.net.ws",
-        functionName = "getParentConnection",
+        functionName = "getUpgradeHeaders",
         receiver = @Receiver(type = TypeKind.STRUCT, structType = "Connection",
                              structPackage = "ballerina.net.ws"),
-        returnType = {@ReturnType(type = TypeKind.STRUCT, structType = "Connection",
-                                  structPackage = "ballerina.net.ws")},
+        returnType = {@ReturnType(type = TypeKind.MAP)},
         isPublic = true
 )
-public class GetParentConnection extends AbstractNativeFunction {
+public class GetUpgradeHeaders extends AbstractNativeFunction {
 
     @Override
     public BValue[] execute(Context context) {
         BStruct wsConnection = (BStruct) getRefArgument(context, 0);
-        String parentConnectionID = (String) wsConnection.getNativeData(Constants.NATIVE_DATA_PARENT_CONNECTION_ID);
-        WsOpenConnectionInfo connectionInfo =
-                WebSocketConnectionManager.getInstance().getConnectionInfo(parentConnectionID);
-        return getBValues(connectionInfo.getWsConnection());
+        Map<String, String> upgradeHeaders =
+                (Map<String, String>) wsConnection.getNativeData(Constants.NATIVE_DATA_UPGRADE_HEADERS);
+        BMap<String, BString> bUpgradeHeaders = new BMap<>();
+        upgradeHeaders.entrySet().forEach(
+                upgradeHeader -> bUpgradeHeaders.put(upgradeHeader.getKey(), new BString(upgradeHeader.getValue())));
+        return getBValues(bUpgradeHeaders);
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/IsOpen.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/IsOpen.java
@@ -16,11 +16,11 @@
  *  under the License.
  */
 
-package org.ballerinalang.net.ws.nativeimpl;
+package org.ballerinalang.net.ws.nativeimpl.connection;
 
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.model.types.TypeKind;
-import org.ballerinalang.model.values.BString;
+import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.AbstractNativeFunction;
@@ -32,26 +32,26 @@ import org.ballerinalang.net.ws.Constants;
 import javax.websocket.Session;
 
 /**
- * Get the ID of the connection.
+ * Check whether the connection is secure connection or not.
  *
  * @since 0.94
  */
 
 @BallerinaFunction(
         packageName = "ballerina.net.ws",
-        functionName = "getID",
+        functionName = "isOpen",
         receiver = @Receiver(type = TypeKind.STRUCT, structType = "Connection",
                              structPackage = "ballerina.net.ws"),
-        returnType = {@ReturnType(type = TypeKind.STRING)},
+        returnType = {@ReturnType(type = TypeKind.BOOLEAN)},
         isPublic = true
 )
-public class GetID extends AbstractNativeFunction {
+public class IsOpen extends AbstractNativeFunction {
 
     @Override
     public BValue[] execute(Context context) {
         BStruct wsConnection = (BStruct) getRefArgument(context, 0);
         Session session = (Session) wsConnection.getNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION);
-        String id = session.getId();
-        return getBValues(new BString(id));
+        boolean isOpen = session.isOpen();
+        return getBValues(new BBoolean(isOpen));
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/IsSecure.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/IsSecure.java
@@ -16,48 +16,42 @@
  *  under the License.
  */
 
-package org.ballerinalang.net.ws.nativeimpl;
+package org.ballerinalang.net.ws.nativeimpl.connection;
 
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.AbstractNativeFunction;
-import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.net.ws.Constants;
-import org.ballerinalang.util.exceptions.BallerinaException;
 
-import java.nio.ByteBuffer;
 import javax.websocket.Session;
 
 /**
- * Push binary data to the other end of the connection.
+ * Check whether the connection is secure connection or not.
  *
  * @since 0.94
  */
 
 @BallerinaFunction(
         packageName = "ballerina.net.ws",
-        functionName = "pushBinary",
+        functionName = "isSecure",
         receiver = @Receiver(type = TypeKind.STRUCT, structType = "Connection",
                              structPackage = "ballerina.net.ws"),
-        args = {@Argument(name = "binaryData", type = TypeKind.BLOB)},
+        returnType = {@ReturnType(type = TypeKind.BOOLEAN)},
         isPublic = true
 )
-public class PushBinary extends AbstractNativeFunction {
+public class IsSecure extends AbstractNativeFunction {
 
     @Override
     public BValue[] execute(Context context) {
-        try {
-            BStruct wsConnection = (BStruct) getRefArgument(context, 0);
-            Session session = (Session) wsConnection.getNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION);
-            byte[] binaryData = getBlobArgument(context, 0);
-            session.getBasicRemote().sendBinary(ByteBuffer.wrap(binaryData));
-        } catch (Throwable e) {
-            throw new BallerinaException("Cannot send the message. Error occurred.");
-        }
-        return VOID_RETURN;
+        BStruct wsConnection = (BStruct) getRefArgument(context, 0);
+        Session session = (Session) wsConnection.getNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION);
+        boolean isSecuredConnection = session.isSecure();
+        return getBValues(new BBoolean(isSecuredConnection));
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/Ping.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/Ping.java
@@ -16,7 +16,7 @@
  *  under the License.
  */
 
-package org.ballerinalang.net.ws.nativeimpl;
+package org.ballerinalang.net.ws.nativeimpl.connection;
 
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.model.types.TypeKind;

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/Pong.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/Pong.java
@@ -16,42 +16,48 @@
  *  under the License.
  */
 
-package org.ballerinalang.net.ws.nativeimpl;
+package org.ballerinalang.net.ws.nativeimpl.connection;
 
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.model.types.TypeKind;
-import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
-import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.net.ws.Constants;
+import org.ballerinalang.util.exceptions.BallerinaException;
 
+import java.nio.ByteBuffer;
 import javax.websocket.Session;
 
 /**
- * Get negotiated sub protocol.
+ * Push binary data to the other end of the connection.
  *
  * @since 0.94
  */
 
 @BallerinaFunction(
         packageName = "ballerina.net.ws",
-        functionName = "getNegotiatedSubProtocol",
+        functionName = "pong",
         receiver = @Receiver(type = TypeKind.STRUCT, structType = "Connection",
                              structPackage = "ballerina.net.ws"),
-        returnType = {@ReturnType(type = TypeKind.STRING)},
+        args = {@Argument(name = "binaryData", type = TypeKind.BLOB)},
         isPublic = true
 )
-public class GetNegotiatedSubProtocol extends AbstractNativeFunction {
+public class Pong extends AbstractNativeFunction {
 
     @Override
     public BValue[] execute(Context context) {
-        BStruct wsConnection = (BStruct) getRefArgument(context, 0);
-        Session session = (Session) wsConnection.getNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION);
-        String negotiatedSubProtocol = session.getNegotiatedSubprotocol();
-        return getBValues(new BString(negotiatedSubProtocol));
+        try {
+            BStruct wsConnection = (BStruct) getRefArgument(context, 0);
+            Session session = (Session) wsConnection.getNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION);
+            byte[] binaryData = getBlobArgument(context, 0);
+            session.getBasicRemote().sendPong(ByteBuffer.wrap(binaryData));
+        } catch (Throwable e) {
+            throw new BallerinaException("Cannot send the message. Error occurred.");
+        }
+        return VOID_RETURN;
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/PushBinary.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/PushBinary.java
@@ -16,7 +16,7 @@
  *  under the License.
  */
 
-package org.ballerinalang.net.ws.nativeimpl;
+package org.ballerinalang.net.ws.nativeimpl.connection;
 
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.model.types.TypeKind;
@@ -27,42 +27,36 @@ import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.net.ws.Constants;
-import org.ballerinalang.net.ws.WebSocketConnectionManager;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
-import java.io.IOException;
-import javax.websocket.CloseReason;
+import java.nio.ByteBuffer;
 import javax.websocket.Session;
 
 /**
- * Get the ID of the connection.
+ * Push binary data to the other end of the connection.
  *
  * @since 0.94
  */
 
 @BallerinaFunction(
         packageName = "ballerina.net.ws",
-        functionName = "closeConnection",
+        functionName = "pushBinary",
         receiver = @Receiver(type = TypeKind.STRUCT, structType = "Connection",
                              structPackage = "ballerina.net.ws"),
-        args = {@Argument(name = "statusCode", type = TypeKind.INT),
-                @Argument(name = "reason", type = TypeKind.STRING)},
+        args = {@Argument(name = "binaryData", type = TypeKind.BLOB)},
         isPublic = true
 )
-public class CloseConnection extends AbstractNativeFunction {
+public class PushBinary extends AbstractNativeFunction {
 
     @Override
     public BValue[] execute(Context context) {
-        BStruct wsConnection = (BStruct) getRefArgument(context, 0);
-        int statusCode = (int) getIntArgument(context, 0);
-        String reason = getStringArgument(context, 0);
-        Session session = (Session) wsConnection.getNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION);
         try {
-            session.close(new CloseReason(() -> statusCode, reason));
-        } catch (IOException e) {
-            throw new BallerinaException("Could not close the connection: " + e.getMessage());
-        } finally {
-            WebSocketConnectionManager.getInstance().removeConnection(session.getId());
+            BStruct wsConnection = (BStruct) getRefArgument(context, 0);
+            Session session = (Session) wsConnection.getNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION);
+            byte[] binaryData = getBlobArgument(context, 0);
+            session.getBasicRemote().sendBinary(ByteBuffer.wrap(binaryData));
+        } catch (Throwable e) {
+            throw new BallerinaException("Cannot send the message. Error occurred.");
         }
         return VOID_RETURN;
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/PushText.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/PushText.java
@@ -16,7 +16,7 @@
  *  under the License.
  */
 
-package org.ballerinalang.net.ws.nativeimpl;
+package org.ballerinalang.net.ws.nativeimpl.connection;
 
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.model.types.TypeKind;

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/handshakeconnection/CancelHandshake.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/handshakeconnection/CancelHandshake.java
@@ -16,46 +16,44 @@
  *  under the License.
  */
 
-package org.ballerinalang.net.ws.nativeimpl;
+package org.ballerinalang.net.ws.nativeimpl.handshakeconnection;
 
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.model.types.TypeKind;
-import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
-import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.net.ws.Constants;
-
-import java.util.Locale;
-import java.util.Map;
+import org.wso2.transport.http.netty.contract.websocket.WebSocketInitMessage;
 
 /**
- * Get upgrade header for a given key.
+ * Get the ID of the connection.
  *
  * @since 0.94
  */
 
 @BallerinaFunction(
         packageName = "ballerina.net.ws",
-        functionName = "getUpgradeHeader",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = "Connection",
+        functionName = "cancelHandshake",
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = "HandshakeConnection",
                              structPackage = "ballerina.net.ws"),
-        args = {@Argument(name = "text", type = TypeKind.STRING)},
-        returnType = {@ReturnType(type = TypeKind.STRING)},
+        args = {@Argument(name = "statusCode", type = TypeKind.INT),
+                @Argument(name = "reason", type = TypeKind.STRING)},
         isPublic = true
 )
-public class GetUpgradeHeader extends AbstractNativeFunction {
+public class CancelHandshake extends AbstractNativeFunction {
 
     @Override
     public BValue[] execute(Context context) {
-        BStruct wsConnection = (BStruct) getRefArgument(context, 0);
-        String key = getStringArgument(context, 0).toLowerCase(Locale.ENGLISH);
-        Map<String, String> upgradeHeaders =
-                (Map<String, String>) wsConnection.getNativeData(Constants.NATIVE_DATA_UPGRADE_HEADERS);
-        return getBValues(new BString(upgradeHeaders.get(key)));
+        BStruct handshakeConnection = (BStruct) getRefArgument(context, 0);
+        int statusCode = (int) getIntArgument(context, 0);
+        String reason = getStringArgument(context, 0);
+        WebSocketInitMessage initMessage =
+                (WebSocketInitMessage) handshakeConnection.getNativeData(Constants.WEBSOCKET_MESSAGE);
+        initMessage.cancelHandShake(statusCode, reason);
+        return VOID_RETURN;
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/handshakeconnection/GetQueryParams.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/handshakeconnection/GetQueryParams.java
@@ -16,33 +16,28 @@
  * under the License.
  */
 
-package org.ballerinalang.net.http.nativeimpl.inbound.request;
+package org.ballerinalang.net.ws.nativeimpl.handshakeconnection;
 
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.model.types.TypeKind;
-import org.ballerinalang.model.values.BMap;
-import org.ballerinalang.model.values.BString;
-import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
-import org.ballerinalang.net.uri.URIUtil;
+import org.ballerinalang.net.ws.WebSocketUtil;
 import org.ballerinalang.util.exceptions.BallerinaException;
-import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
 /**
- * Get the Query params from HTTP message and return a map.
+ * Get the Query params from HandshakeConnection and return a map.
  *
- * @since 0.94
+ * @since 0.961.0
  */
 @BallerinaFunction(
-        packageName = "ballerina.net.http",
+        packageName = "ballerina.net.ws",
         functionName = "getQueryParams",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = "InRequest",
-                             structPackage = "ballerina.net.http"),
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = "HandshakeConnection",
+                             structPackage = "ballerina.net.ws"),
         returnType = {@ReturnType(type = TypeKind.MAP, elementType = TypeKind.STRING)},
         isPublic = true
 )
@@ -50,20 +45,10 @@ public class GetQueryParams extends AbstractNativeFunction {
     @Override
     public BValue[] execute(Context context) {
         try {
-            BStruct requestStruct  = ((BStruct) getRefArgument(context, 0));
-            HTTPCarbonMessage httpCarbonMessage = (HTTPCarbonMessage) requestStruct
-                    .getNativeData(Constants.TRANSPORT_MESSAGE);
-
-            if (httpCarbonMessage.getProperty(Constants.QUERY_STR) != null) {
-                String queryString = (String) httpCarbonMessage.getProperty(Constants.QUERY_STR);
-                BMap<String, BString> params = new BMap<>();
-                URIUtil.populateQueryParamMap(queryString, params);
-                return getBValues(params);
-            } else {
-                return getBValues(new BMap<>());
-            }
+            return WebSocketUtil.getQueryParams(context, this);
         } catch (Throwable e) {
-            throw new BallerinaException("Error while retrieving query param from message: " + e.getMessage());
+            throw new BallerinaException(
+                    "Error occurred while retrieving query parameters from HandShakeConnection: " + e.getMessage());
         }
     }
 }

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/websocket/sample/WebSocketPassThroughTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/websocket/sample/WebSocketPassThroughTestCase.java
@@ -47,6 +47,7 @@ public class WebSocketPassThroughTestCase extends WebSocketIntegrationTest {
     private ServerInstance ballerinaServer;
     private WebSocketRemoteServer webSocketRemoteServer;
     private final String name = "john";
+    private final String age = "25";
 
     @BeforeClass
     private void setup() throws Exception {
@@ -62,7 +63,7 @@ public class WebSocketPassThroughTestCase extends WebSocketIntegrationTest {
 
         // Initializing and handshaking WebSocket clients.
         for (int i = 0; i < clientCount; i++) {
-            wsClients[i] = new WebSocketClient("ws://localhost:9090/proxy/ws/" + name);
+            wsClients[i] = new WebSocketClient("ws://localhost:9090/proxy/ws/" + name + "?age=" + age);
         }
         handshakeAllClients(wsClients);
     }
@@ -71,7 +72,7 @@ public class WebSocketPassThroughTestCase extends WebSocketIntegrationTest {
     public void testFullTextMediation() throws Exception {
         for (int i = 0; i < clientCount; i++) {
             final int clientNo = i;
-            final String expectedMessage = name + " client service: " + name + " " + clientNo;
+            final String expectedMessage = name + "(" + age + ") client service: " + name + "(" + age + ") " + clientNo;
             await().atMost(awaitTimeInSecs, SECONDS).until(() -> {
                 wsClients[clientNo].sendText(clientNo + "");
                 return expectedMessage.equals(wsClients[clientNo].getTextReceived());

--- a/tests/ballerina-test-integration/src/test/resources/websocket/SimpleProxyServer.bal
+++ b/tests/ballerina-test-integration/src/test/resources/websocket/SimpleProxyServer.bal
@@ -20,6 +20,11 @@ service<ws> SimpleProxyServer {
         } else {
             clientConn.attributes["name"] = name;
             clientConnMap[con.connectionID] = clientConn;
+            map queryParams = con.getQueryParams();
+            var age, err = (string)queryParams.age;
+            if (err == null) {
+                clientConn.attributes["age"] = age;
+            }
         }
     }
 
@@ -37,7 +42,13 @@ service<ws> SimpleProxyServer {
         } else if (text == "client_ping_req") {
             clientConn.pushText("ping");
         } else if (clientConn != null) {
-            clientConn.pushText(name + " " + text);
+            map params = conn.getQueryParams();
+            var age, err = (string)params.age;
+            if (err != null) {
+                clientConn.pushText(name + " " + text);
+            } else {
+                clientConn.pushText(name + "(" + age + ") " + text);
+            }
         }
     }
 
@@ -62,7 +73,12 @@ service<ws> ClientService {
     resource onTextMessage(ws:Connection conn, ws:TextFrame frame) {
         ws:Connection parentConn = conn.getParentConnection();
         var parentName, _ = (string) conn.attributes["name"];
-        parentConn.pushText(parentName + " client service: " + frame.text);
+        var age, err = (string) conn.attributes["age"];
+        if(err != null) {
+            parentConn.pushText(parentName + " client service: " + frame.text);
+        } else {
+            parentConn.pushText(parentName + "(" + age + ") client service: " + frame.text);
+        }
     }
 
     resource onPing(ws:Connection conn, ws:PingFrame frame) {

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/net/ws/NativeFunctionsTestCase.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/net/ws/NativeFunctionsTestCase.java
@@ -62,6 +62,8 @@ public class NativeFunctionsTestCase {
     String header2Key = "my_header_2";
     String header2Value = "my_header_value_2";
 
+    private String paramKey = "age";
+    private BString paramVal = new BString("25");
 
     @BeforeClass
     public void setup() {
@@ -84,10 +86,14 @@ public class NativeFunctionsTestCase {
         upgradeHeaders.put(header1Key, header1Value);
         upgradeHeaders.put(header2Key, header2Value);
 
+        BMap<String, BString> queryParams = new BMap<>();
+        queryParams.put(paramKey, paramVal);
+
         wsConnection = BCompileUtil.createAndGetStruct(programFile, Constants.PROTOCOL_PACKAGE_WS,
                                                      Constants.STRUCT_WEBSOCKET_CONNECTION);
         wsConnection.addNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION, session);
         wsConnection.addNativeData(Constants.NATIVE_DATA_UPGRADE_HEADERS, upgradeHeaders);
+        wsConnection.addNativeData(Constants.NATIVE_DATA_QUERY_PARAMS, queryParams);
     }
 
     @Test
@@ -190,6 +196,18 @@ public class NativeFunctionsTestCase {
         Assert.assertTrue(returnResultBValues[0] instanceof BString, "Invalid return type");
         BString result = (BString) returnResultBValues[0];
         Assert.assertEquals(result.stringValue(), testSessionID);
+    }
+
+    @Test
+    public void testGetQueryParams() {
+        BValue[] inputBValues = {wsConnection};
+        BValue[] returnBValues = BRunUtil.invoke(compileResult, "testGetQueryParams", inputBValues);
+        Assert.assertFalse(returnBValues == null || returnBValues.length == 0
+                                   || returnBValues[0] == null, "Invalid output");
+        Assert.assertTrue(returnBValues[0] instanceof BMap, "Invalid return type");
+        BMap<String, BString> result = (BMap<String, BString>) returnBValues[0];
+        Assert.assertTrue(result.hasKey(paramKey));
+        Assert.assertEquals(result.get(paramKey), paramVal);
     }
 
     @Test

--- a/tests/ballerina-test/src/test/resources/test-src/net/ws/native-functions-for-connection.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/ws/native-functions-for-connection.bal
@@ -28,6 +28,10 @@ function testGetParentConnection(ws:Connection conn) (ws:Connection) {
     return conn.getParentConnection();
 }
 
+function testGetQueryParams(ws:Connection conn) (map) {
+    return conn.getQueryParams();
+}
+
 function testPushText(ws:Connection conn, string text) {
     conn.pushText(text);
 }


### PR DESCRIPTION
## Purpose
> Resolve https://github.com/ballerina-lang/ballerina/issues/4275

## Goals
> Add Query Param Support for Websockets

## Approach
> The `getQueryParam` function would be used to access the query params. This PR adds query params as a native data to the connection and creates the `getQueryParam` function for both HandShakeConnection and Connection structs to access the query params by the user. A package refactoring also has been done.

## User stories
>N/A

## Release note
> Add Query Param Support for Websockets

## Documentation
> Will add

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > https://github.com/ballerina-lang/tools-distribution/pull/250

## Security checks
N/A

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> java version "1.8.0_161" | Ubuntu 17.10 | Chromium version 64.0 for websocket testing

## Learning
>N/A