### PR TITLE
Use `<text>` tag for icons inside svg

### DIFF
--- a/composer/modules/web/src/plugins/ballerina/diagram/image-util.jsx
+++ b/composer/modules/web/src/plugins/ballerina/diagram/image-util.jsx
@@ -18,6 +18,7 @@
 
 import $ from 'jquery';
 import { getServiceEndpoint } from 'api-client/api-client';
+import codepoints from 'font-ballerina/codepoints.json';
 
 /**
  * Gets the base name of a file.
@@ -65,6 +66,18 @@ class ImageUtils {
      */
     static getSVGIconString(iconName) {
         return images[iconName];
+    }
+
+    /**
+     * Gets the unicode codepoint for an icon name.
+     *
+     * @static
+     * @param {string} iconName The name of the icon.
+     * @returns {string} The codepoint.
+     * @memberof ImageUtils
+     */
+    static getCodePoint(iconName) {
+        return codepoints[iconName];
     }
 
     /**

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/connector-declaration-decorator.jsx
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/connector-declaration-decorator.jsx
@@ -104,7 +104,7 @@ class ConnectorDeclarationDecorator extends React.Component {
                     title={this.props.title}
                     bBox={this.props.bBox}
                     classes={connectorClasses}
-                    icon={ImageUtil.getConnectorIcon(packageAlias)}
+                    icon={ImageUtil.getCodePoint('endpoint')}
                     editorOptions={this.editorOptions}
                     iconColor='#17a085'
                     onDelete={this.onDelete}

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/endpoint-decorator.jsx
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/endpoint-decorator.jsx
@@ -107,7 +107,7 @@ class ConnectorDeclarationDecorator extends React.Component {
                     title={this.props.title}
                     bBox={this.props.bBox}
                     classes={connectorClasses}
-                    icon={ImageUtil.getConnectorIcon(packageAlias)}
+                    icon={ImageUtil.getCodePoint('endpoint')}
                     editorOptions={this.editorOptions}
                     iconColor='#17a085'
                     onDelete={this.onDelete}

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/lifeline.jsx
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/lifeline.jsx
@@ -28,6 +28,7 @@ import OverlayComponentsRenderingUtil from './../utils/overlay-component-renderi
 import ActionBox from './action-box';
 import ActiveArbiter from './active-arbiter';
 import ArrowDecorator from '../decorators/arrow-decorator';
+import codepoints from 'font-ballerina/codepoints.json';
 
 class LifeLine extends React.Component {
 
@@ -174,13 +175,15 @@ class LifeLine extends React.Component {
             />
             {this.props.icon &&
             <g onClick={this.handleConnectorProps}>
-                <image
+                <text
                     x={startX - (iconSize / 2)}
                     y={bBox.y - 25}
-                    width={iconSize}
-                    height={iconSize}
-                    xlinkHref={this.props.icon}
-                />
+                    fontFamily='font-ballerina'
+                    fontSize={iconSize}
+                    fill={this.props.iconColor}
+                >
+                    {this.props.icon}
+                </text>
             </g>
             }
             <line

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/action-node.jsx
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/action-node.jsx
@@ -133,7 +133,7 @@ class ActionNode extends React.Component {
                                     title='default'
                                     bBox={this.props.model.viewState.components.defaultWorkerLine}
                                     classes={classes}
-                                    icon={ImageUtil.getSVGIconString('tool-icons/worker')}
+                                    icon={ImageUtil.getCodePoint('worker')}
                                     iconColor='#025482'
                                 />
                                 {blockNode}

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/function-node.jsx
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/function-node.jsx
@@ -144,7 +144,7 @@ class FunctionNode extends React.Component {
                             title='default'
                             bBox={this.props.model.viewState.components.defaultWorkerLine}
                             classes={classes}
-                            icon={ImageUtil.getSVGIconString('tool-icons/worker')}
+                            icon={ImageUtil.getCodePoint('worker')}
                             iconColor='#025482'
                         />
                         {blockNode}

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/resource-node.jsx
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/resource-node.jsx
@@ -148,7 +148,7 @@ class ResourceNode extends React.Component {
                                     title='default'
                                     bBox={this.props.model.viewState.components.defaultWorkerLine}
                                     classes={classes}
-                                    icon={ImageUtil.getSVGIconString('tool-icons/worker')}
+                                    icon={ImageUtil.getCodePoint('worker')}
                                     iconColor='#2980b9'
                                 />
                                 {blockNode}

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/worker-node.jsx
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/nodes/worker-node.jsx
@@ -97,7 +97,7 @@ class WorkerNode extends React.Component {
                     bBox={model.viewState.components.lifeLine}
                     editorOptions={editorOptions}
                     classes={classes}
-                    icon={ImageUtil.getSVGIconString('tool-icons/worker')}
+                    icon={ImageUtil.getCodePoint('worker')}
                     iconColor='#0070af'
                     onDelete={this.onDelete}
                 />

--- a/composer/modules/web/webpack.config.js
+++ b/composer/modules/web/webpack.config.js
@@ -19,6 +19,7 @@
 
  /* eslint-disable */
 const path = require('path');
+const fs = require('fs');
 const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const UnusedFilesWebpackPlugin = require('unused-files-webpack-plugin').UnusedFilesWebpackPlugin;
@@ -36,6 +37,10 @@ const extractCSSBundle = new ExtractTextPlugin({ filename: './bundle-[name]-[has
 
 const isProductionBuild = process.env.NODE_ENV === 'production';
 let exportConfig = {};
+
+// Keeps unicode codepoints of font-ballerina for each icon name
+const codepoints = {}
+
 const config = [{
     target: 'web',
     entry: {
@@ -133,20 +138,31 @@ const config = [{
         new webpack.WatchIgnorePlugin([path.resolve(__dirname, './font/dist/')]),
         new WebfontPlugin({
             files: path.resolve(__dirname, './font/font-ballerina/icons/**/*.svg'),
-            css: true,
             cssTemplateFontPath: '../fonts/',
             fontName: 'font-ballerina',
             fontHeight: 1000,
             normalize: true,
             cssTemplateClassName: 'fw', // TODO: map with proper class name
             template: path.resolve(__dirname, './font/font-ballerina/template.css.njk'),
+            glyphTransformFn: (obj) => {
+                codepoints[obj.name] = obj.unicode;
+            },
             dest: {
                 fontsDir: path.resolve(__dirname, './font/dist/font-ballerina/fonts'),
                 stylesDir: path.resolve(__dirname, './font/dist/font-ballerina/css'),
                 outputFilename: 'font-ballerina.css',
             },
             hash: new Date().getTime(),
-        }),
+        }), {
+            apply: function(compiler) {
+                compiler.plugin('done', function() {
+                    fs.writeFileSync(
+                        path.resolve(__dirname, './font/dist/font-ballerina/codepoints.json'),
+                        JSON.stringify(codepoints)
+                    );
+                });
+            }
+        },
         new WriteFilePlugin(),
         new CopyWebpackPlugin([
             {


### PR DESCRIPTION
Instead of `<image>` tags use `<text>` tags containing unicode codepoints of
font-ballerina. Only the icons of lifeLine component is replaced in this commit.

## Purpose
Currently in the diagram view svg `<image>` tags are used to display icons. Since these are images the fill color cannot be changed.

## Goals
Use `<text>` tags instead, containing the relevant unicode code point. The color can then be changed easily by specifying a `fill`.

## Approach
* When building `font-ballerina` save each codepoint against the icon name in a json.
* Get the codepoint by icon name to be inserted inside a `<text>`