### PR TITLE
Add new native method and refactoring method names

### DIFF
--- a/docs/ballerina-by-example/examples/record-i-o/record-i-o.bal
+++ b/docs/ballerina-by-example/examples/record-i-o/record-i-o.bal
@@ -12,21 +12,19 @@ function getFileRecordChannel (string filePath, string permission, string encodi
     //Finally we convert the character channel to record channel
     //to read content as records.
     io:TextRecordChannel textRecordChannel = characterChannel.
-                                             toTextRecordChannel(rs, fs);
+                                                             toTextRecordChannel(rs, fs);
     return textRecordChannel;
 }
 
 @Description{value:"This function will process CSV file and write content back as text with '|' delimiter."}
 function process (io:TextRecordChannel srcRecordChannel,
                   io:TextRecordChannel dstRecordChannel) {
-    int numberOfFields = -1;
     //We read all the records from the provided file until there're no records returned.
-    while (numberOfFields != 0) {
+    while (srcRecordChannel.hasNextTextRecord()) {
         //Here's how we read records.
-        string[] records = srcRecordChannel.readTextRecord();
+        string[] records = srcRecordChannel.nextTextRecord();
         //Here's how we write records.
         dstRecordChannel.writeTextRecord(records);
-        numberOfFields = lengthof records;
     }
 }
 

--- a/docs/getting_started/csvFileProcessor/processFile.bal
+++ b/docs/getting_started/csvFileProcessor/processFile.bal
@@ -10,11 +10,9 @@ function getFileRecordChannel (string filePath, string permission, string encodi
 }
 
 function process (io:TextRecordChannel srcRecordChannel, io:TextRecordChannel dstRecordChannel) {
-    int numberOfFields = -1;
-    while (numberOfFields != 0) {
-        string[] records = srcRecordChannel.readTextRecord();
+    while (srcRecordChannel.hasNextTextRecord()) {
+        string[] records = srcRecordChannel.nextTextRecord();
         dstRecordChannel.writeTextRecord(records);
-        numberOfFields = lengthof records;
     }
 }
 

--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/io/natives.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/io/natives.bal
@@ -25,12 +25,12 @@ public native function <ByteChannel channel> toCharacterChannel(string encoding)
 @Return {value:"TextRecordChannel converted from CharacterChannel"}
 public native function <CharacterChannel channel> toTextRecordChannel(string recordSeparator,
                                                                       string fieldSeparator)
-                                                                      (TextRecordChannel);
+(TextRecordChannel);
 
 @Description {value:"Function to read text records"}
 @Param {value:"channel: The TextRecordChannel to read text records from"}
 @Return {value:"Fields listed in the record"}
-public native function <TextRecordChannel channel> readTextRecord()(string []);
+public native function <TextRecordChannel channel> nextTextRecord()(string []);
 
 @Description {value:"Function to write text records"}
 @Param {value:"channel: The TextRecordChannel to write text records to"}
@@ -83,3 +83,8 @@ public native function <ByteChannel channel> writeBytes(blob content,int startOf
 @Description { value:"Function to close a byte channel"}
 @Param {value:"channel: The ByteChannel to be closed"}
 public native function <ByteChannel channel> close();
+
+@Description {value:"Function to check whether next record is available or not"}
+@Param {value:"channel: The TextRecordChannel to read text records from"}
+@Return {value:"True if the channel has more records; false otherwise"}
+public native function <TextRecordChannel channel> hasNextTextRecord () (boolean);

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/HasNextTextRecord.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/HasNextTextRecord.java
@@ -1,16 +1,17 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
@@ -19,7 +20,7 @@ package org.ballerinalang.nativeimpl.io;
 
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.model.types.TypeKind;
-import org.ballerinalang.model.values.BStringArray;
+import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.nativeimpl.io.channels.base.TextRecordChannel;
@@ -30,20 +31,20 @@ import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
 /**
- * Native function ballerina.io#readTextRecords.
+ * Native function ballerina.io#hasNextTextRecord.
  *
- * @since 0.94
+ * @since 0.961.0
  */
 @BallerinaFunction(
         packageName = "ballerina.io",
-        functionName = "readTextRecord",
+        functionName = "hasNextTextRecord",
         receiver = @Receiver(type = TypeKind.STRUCT, structType = "TextRecordChannel", structPackage = "ballerina.io"),
-        returnType = {@ReturnType(type = TypeKind.ARRAY, elementType = TypeKind.STRING)},
+        returnType = {@ReturnType(type = TypeKind.BOOLEAN)},
         isPublic = true
 )
-public class ReadTextRecord extends AbstractNativeFunction {
+public class HasNextTextRecord extends AbstractNativeFunction {
     /**
-     * Specifies the index which contains the byte channel in ballerina.lo#readTextRecord.
+     * Specifies the index which contains the byte channel in ballerina.io#hasNextTextRecord.
      */
     private static final int TXT_RECORD_CHANNEL_INDEX = 0;
 
@@ -52,19 +53,16 @@ public class ReadTextRecord extends AbstractNativeFunction {
      */
     @Override
     public BValue[] execute(Context context) {
-        BStruct channel;
-        BStringArray record;
-        try {
-            channel = (BStruct) getRefArgument(context, TXT_RECORD_CHANNEL_INDEX);
-
-            TextRecordChannel textRecordChannel = (TextRecordChannel) channel.getNativeData(IOConstants
-                    .TXT_RECORD_CHANNEL_NAME);
-            String[] recordValue = textRecordChannel.read();
-            record = new BStringArray(recordValue);
-        } catch (Throwable e) {
-            String message = "Error occurred while reading text records:" + e.getMessage();
+        BBoolean hasNext;
+        BStruct channel = (BStruct) getRefArgument(context, TXT_RECORD_CHANNEL_INDEX);
+        if (channel.getNativeData(IOConstants.TXT_RECORD_CHANNEL_NAME) != null) {
+            TextRecordChannel textRecordChannel =
+                    (TextRecordChannel) channel.getNativeData(IOConstants.TXT_RECORD_CHANNEL_NAME);
+            hasNext = new BBoolean(textRecordChannel.hasNext());
+        } else {
+            String message = "Error occurred while checking the next record availability: Null channel returned.";
             throw new BallerinaException(message, context);
         }
-        return getBValues(record);
+        return getBValues(hasNext);
     }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/NextTextRecord.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/NextTextRecord.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.nativeimpl.io;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BStringArray;
+import org.ballerinalang.model.values.BStruct;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.nativeimpl.io.channels.base.TextRecordChannel;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.natives.annotations.ReturnType;
+import org.ballerinalang.util.exceptions.BallerinaException;
+
+/**
+ * Native function ballerina.io#nextTextRecords.
+ *
+ * @since 0.94
+ */
+@BallerinaFunction(
+        packageName = "ballerina.io",
+        functionName = "nextTextRecord",
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = "TextRecordChannel", structPackage = "ballerina.io"),
+        returnType = {@ReturnType(type = TypeKind.ARRAY, elementType = TypeKind.STRING)},
+        isPublic = true
+)
+public class NextTextRecord extends AbstractNativeFunction {
+    /**
+     * Specifies the index which contains the byte channel in ballerina.io#nextTextRecord.
+     */
+    private static final int TXT_RECORD_CHANNEL_INDEX = 0;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public BValue[] execute(Context context) {
+        BStruct channel;
+        BStringArray record;
+        try {
+            channel = (BStruct) getRefArgument(context, TXT_RECORD_CHANNEL_INDEX);
+
+            TextRecordChannel textRecordChannel = (TextRecordChannel) channel.getNativeData(IOConstants
+                    .TXT_RECORD_CHANNEL_NAME);
+            String[] recordValue = textRecordChannel.read();
+            record = new BStringArray(recordValue);
+        } catch (Throwable e) {
+            String message = "Error occurred while reading text records:" + e.getMessage();
+            throw new BallerinaException(message, context);
+        }
+        return getBValues(record);
+    }
+}

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/TextRecordChannel.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/TextRecordChannel.java
@@ -309,4 +309,13 @@ public class TextRecordChannel {
     public void close() {
         channel.close();
     }
+
+    /**
+     * Check whether there are more records or not.
+     *
+     * @return true if more records in the channel else false.
+     */
+    public boolean hasNext() {
+        return remaining;
+    }
 }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/IOTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/IOTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.launcher.util.BRunUtil;
 import org.ballerinalang.launcher.util.BServiceUtil;
 import org.ballerinalang.launcher.util.CompileResult;
 import org.ballerinalang.model.values.BBlob;
+import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStringArray;
@@ -104,7 +105,6 @@ public class IOTest {
 
     @Test(description = "Test 'readAllBytes' function in ballerina.io.package ")
     public void testReadAllBytes() throws URISyntaxException {
-        int numberOfBytesToRead = 3;
         String resourceToRead = "datafiles/io/text/6charfile.txt";
         BBlob readBytes;
 
@@ -158,7 +158,6 @@ public class IOTest {
     @Test(description = "Test 'readAllCharacters' function in ballerina.io package")
     public void testReadAllCharacters() throws URISyntaxException {
         String resourceToRead = "datafiles/io/text/utf8file.txt";
-        int numberOfCharactersToRead = 3;
         BString readCharacters;
 
         //Will initialize the channel
@@ -178,6 +177,7 @@ public class IOTest {
     public void testReadRecords() throws URISyntaxException {
         String resourceToRead = "datafiles/io/records/sample.csv";
         BStringArray records;
+        BBoolean hasNextRecord;
         int expectedRecordLength = 3;
 
         //Will initialize the channel
@@ -185,25 +185,31 @@ public class IOTest {
                 new BString("\n"), new BString(",")};
         BRunUtil.invoke(recordsInputOutputProgramFile, "initFileChannel", args);
 
-        BValue[] returns = BRunUtil.invoke(recordsInputOutputProgramFile, "readRecord");
+        BValue[] returns = BRunUtil.invoke(recordsInputOutputProgramFile, "nextRecord");
+        records = (BStringArray) returns[0];
+        Assert.assertEquals(records.size(), expectedRecordLength);
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "hasNextRecord");
+        hasNextRecord = (BBoolean) returns[0];
+        Assert.assertTrue(hasNextRecord.booleanValue(), "Expecting more records");
+
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "nextRecord");
+        records = (BStringArray) returns[0];
+        Assert.assertEquals(records.size(), expectedRecordLength);
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "hasNextRecord");
+        hasNextRecord = (BBoolean) returns[0];
+        Assert.assertTrue(hasNextRecord.booleanValue(), "Expecting more records");
+
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "nextRecord");
         records = (BStringArray) returns[0];
 
         Assert.assertEquals(records.size(), expectedRecordLength);
 
-        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "readRecord");
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "nextRecord");
         records = (BStringArray) returns[0];
-
-        Assert.assertEquals(records.size(), expectedRecordLength);
-
-        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "readRecord");
-        records = (BStringArray) returns[0];
-
-        Assert.assertEquals(records.size(), expectedRecordLength);
-
-        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "readRecord");
-        records = (BStringArray) returns[0];
-
         Assert.assertEquals(records.size(), 0);
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "hasNextRecord");
+        hasNextRecord = (BBoolean) returns[0];
+        Assert.assertFalse(hasNextRecord.booleanValue(), "Not expecting anymore records");
 
         BRunUtil.invoke(recordsInputOutputProgramFile, "close");
     }
@@ -218,7 +224,7 @@ public class IOTest {
         BRunUtil.invoke(bytesInputOutputProgramFile, "initFileChannel", args);
 
         args = new BValue[]{new BBlob(content), new BInteger(0)};
-        BValue[] returns = BRunUtil.invoke(bytesInputOutputProgramFile, "writeBytes", args);
+        BRunUtil.invoke(bytesInputOutputProgramFile, "writeBytes", args);
 
         BRunUtil.invoke(bytesInputOutputProgramFile, "close");
     }
@@ -233,7 +239,7 @@ public class IOTest {
         BRunUtil.invoke(characterInputOutputProgramFile, "initFileChannel", args);
 
         args = new BValue[]{new BString(content), new BInteger(0)};
-        BValue[] returns = BRunUtil.invoke(characterInputOutputProgramFile, "writeCharacters", args);
+        BRunUtil.invoke(characterInputOutputProgramFile, "writeCharacters", args);
 
         BRunUtil.invoke(characterInputOutputProgramFile, "close");
     }
@@ -250,9 +256,10 @@ public class IOTest {
         BRunUtil.invoke(recordsInputOutputProgramFile, "initFileChannel", args);
 
         args = new BValue[]{record};
-        BValue[] returns = BRunUtil.invoke(recordsInputOutputProgramFile, "writeRecord", args);
+        BRunUtil.invoke(recordsInputOutputProgramFile, "writeRecord", args);
 
         BRunUtil.invoke(recordsInputOutputProgramFile, "close");
     }
 
 }
+

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/records/RecordInputOutputTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/records/RecordInputOutputTest.java
@@ -96,13 +96,17 @@ public class RecordInputOutputTest {
 
         String[] readRecord = recordChannel.read();
         Assert.assertEquals(readRecord.length, 9);
+        Assert.assertTrue(recordChannel.hasNext(), "Expecting more records but but received as EOL.");
 
         //This will be a blank record
         readRecord = recordChannel.read();
         Assert.assertEquals(readRecord.length, 1);
+        Assert.assertTrue(recordChannel.hasNext(), "Expecting more records but but received as EOL.");
 
         readRecord = recordChannel.read();
         Assert.assertEquals(readRecord.length, 9);
+        Assert.assertFalse(recordChannel.hasNext(),
+                "Last record received, but indicate as more records available.");
 
         recordChannel.close();
     }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/records/RecordInputOutputTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/records/RecordInputOutputTest.java
@@ -96,12 +96,12 @@ public class RecordInputOutputTest {
 
         String[] readRecord = recordChannel.read();
         Assert.assertEquals(readRecord.length, 9);
-        Assert.assertTrue(recordChannel.hasNext(), "Expecting more records but but received as EOL.");
+        Assert.assertTrue(recordChannel.hasNext(), "Expecting more records but received as EOL.");
 
         //This will be a blank record
         readRecord = recordChannel.read();
         Assert.assertEquals(readRecord.length, 1);
-        Assert.assertTrue(recordChannel.hasNext(), "Expecting more records but but received as EOL.");
+        Assert.assertTrue(recordChannel.hasNext(), "Expecting more records but received as EOL.");
 
         readRecord = recordChannel.read();
         Assert.assertEquals(readRecord.length, 9);

--- a/tests/ballerina-test/src/test/resources/test-src/io/recordio.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/recordio.bal
@@ -10,8 +10,8 @@ function initFileChannel(string filePath,string permission,string encoding,strin
     textRecordChannel = characterChannel.toTextRecordChannel(rs,fs);
 }
 
-function readRecord () (string[]) {
-    string[] fields = textRecordChannel.readTextRecord();
+function nextRecord () (string[]) {
+    string[] fields = textRecordChannel.nextTextRecord();
     return fields;
 }
 
@@ -21,4 +21,8 @@ function writeRecord (string[] fields) {
 
 function close(){
     textRecordChannel.closeTextRecordChannel();
+}
+
+function hasNextRecord () (boolean) {
+    return textRecordChannel.hasNextTextRecord();
 }


### PR DESCRIPTION
## Purpose
Add  a new native method to check the next record availability. Rename existing readTextRecord native method to nextTextRecord while keeping the current functionality.
Resolve https://github.com/ballerina-lang/ballerina/issues/4530

## Goals
We should able to read content from a large file as a stream. To support that we need to have a way to check the content availability of the open channel.

## Release note
A new method to check the availability of the remaining content.

