### PR TITLE
Moved diagram to the right hand side in split mode.

### DIFF
--- a/composer/modules/web/src/plugins/ballerina/plugin.js
+++ b/composer/modules/web/src/plugins/ballerina/plugin.js
@@ -126,7 +126,6 @@ class BallerinaPlugin extends Plugin {
                             ballerinaPlugin: this,
                         };
                     },
-                    tabTitleClass: CLASSES.TAB_TITLE.DESIGN_VIEW,
                     newFileContentProvider: (fileFullPath) => {
                         if (!fileFullPath) {
                             return '';

--- a/composer/modules/web/src/plugins/ballerina/views/ballerina-file-editor.jsx
+++ b/composer/modules/web/src/plugins/ballerina/views/ballerina-file-editor.jsx
@@ -21,7 +21,6 @@ import React from 'react';
 import cn from 'classnames';
 import PropTypes from 'prop-types';
 import SplitPane from 'react-split-pane';
-import { Scrollbars } from 'react-custom-scrollbars';
 import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 import DebugManager from 'plugins/debugger/DebugManager/DebugManager'; // FIXME: Importing from debugger plugin
 import TreeUtil from 'plugins/ballerina/model/tree-util.js';
@@ -29,7 +28,8 @@ import { parseFile } from 'api-client/api-client';
 import { CONTENT_MODIFIED, UNDO_EVENT, REDO_EVENT } from 'plugins/ballerina/constants/events';
 import { GO_TO_POSITION, FORMAT } from 'plugins/ballerina/constants/commands';
 import File from 'core/workspace/model/file';
-import { EVENTS as WORKSPACE_EVENTS } from 'core/workspace/constants';
+import { COMMANDS as LAYOUT_COMMANDS } from 'core/layout/constants';
+import { DOC_VIEW_ID } from 'plugins/ballerina/constants';
 import DesignView from './design-view.jsx';
 import SourceView from './source-view.jsx';
 import SwaggerView from './swagger-view.jsx';
@@ -44,8 +44,6 @@ import TreeUtils from './../model/tree-util';
 import TreeBuilder from './../model/tree-builder';
 import CompilationUnitNode from './../model/tree/compilation-unit-node';
 import FragmentUtils from '../utils/fragment-utils';
-import { COMMANDS as LAYOUT_COMMANDS } from 'core/layout/constants';
-import { DOC_VIEW_ID } from 'plugins/ballerina/constants';
 import ErrorMappingVisitor from './../visitors/error-mapping-visitor';
 import SyncErrorsVisitor from './../visitors/sync-errors';
 import { EVENTS } from '../constants';
@@ -720,8 +718,9 @@ class BallerinaFileEditor extends React.Component {
         const showLoadingOverlay = !this.skipLoadingOverlay && this.state.parsePending;
 
         const sourceWidth = (this.state.activeView === SOURCE_VIEW) ? this.props.width :
+            this.state.splitSize;
+        const designWidth = (this.state.activeView === DESIGN_VIEW) ? this.props.width :
             this.props.width - this.state.splitSize;
-        const designWidth = (this.state.activeView === DESIGN_VIEW) ? this.props.width : this.state.splitSize;
 
         const sourceView = (
             <SourceView
@@ -777,6 +776,7 @@ class BallerinaFileEditor extends React.Component {
                                         defaultSize={(this.props.width / 2)}
                                         onChange={this.handleSplitChange}
                                     >
+                                        {sourceView}
                                         <div>
                                             {this.state.activeView === SPLIT_VIEW
                                                 && !_.isEmpty(this.state.syntaxErrors) &&
@@ -790,12 +790,11 @@ class BallerinaFileEditor extends React.Component {
                                             }
                                             {designView}
                                         </div>
-                                        {sourceView}
                                     </SplitPane>
                                 </div>
                             );
                         default:
-                            return [designView, sourceView];
+                            return [sourceView, designView];
                     }
                 })()}
                 <div style={{ display: showSwaggerView ? 'block' : 'none' }}>

--- a/composer/modules/web/src/plugins/ballerina/views/ballerina-file-editor.jsx
+++ b/composer/modules/web/src/plugins/ballerina/views/ballerina-file-editor.jsx
@@ -151,17 +151,6 @@ class BallerinaFileEditor extends React.Component {
         this.handleSplitChange = this.handleSplitChange.bind(this);
     }
 
-
-    /**
-     * @override
-     * @param {any} nextProps next props.
-     * @memberof BallerinaFileEditor
-     */
-    componentWillReceiveProps(nextProps) {
-        this.state.splitSize = nextProps.width / 2;
-    }
-
-
     /**
      * @override
      * @memberof Diagram

--- a/composer/modules/web/src/plugins/ballerina/views/ballerina-file-editor.jsx
+++ b/composer/modules/web/src/plugins/ballerina/views/ballerina-file-editor.jsx
@@ -773,7 +773,7 @@ class BallerinaFileEditor extends React.Component {
                                 <div className='split-view-container'>
                                     <SplitPane
                                         split='vertical'
-                                        defaultSize={(this.props.width / 2)}
+                                        defaultSize={this.state.splitSize}
                                         onChange={this.handleSplitChange}
                                     >
                                         {sourceView}
@@ -805,26 +805,28 @@ class BallerinaFileEditor extends React.Component {
                         resetSwaggerViewFun={this.resetSwaggerView}
                     />
                 </div>
-                <div className={cn('bottom-right-controls-container')}>
-                    <ViewButton
-                        label='Design View'
-                        icon='design-view'
-                        onClick={() => { this.setActiveView(DESIGN_VIEW); }}
-                        active={this.state.activeView === DESIGN_VIEW}
-                    />
-                    <ViewButton
-                        label='Source View'
-                        icon='code'
-                        onClick={() => { this.setActiveView(SOURCE_VIEW); }}
-                        active={this.state.activeView === SOURCE_VIEW}
-                    />
-                    <ViewButton
-                        label='Split View'
-                        icon='split-view'
-                        onClick={() => { this.setActiveView(SPLIT_VIEW); }}
-                        active={this.state.activeView === SPLIT_VIEW}
-                    />
-                </div>
+                { !showSwaggerView &&
+                    <div className={cn('bottom-right-controls-container')}>
+                        <ViewButton
+                            label='Design View'
+                            icon='design-view'
+                            onClick={() => { this.setActiveView(DESIGN_VIEW); }}
+                            active={this.state.activeView === DESIGN_VIEW}
+                        />
+                        <ViewButton
+                            label='Source View'
+                            icon='code'
+                            onClick={() => { this.setActiveView(SOURCE_VIEW); }}
+                            active={this.state.activeView === SOURCE_VIEW}
+                        />
+                        <ViewButton
+                            label='Split View'
+                            icon='split-view'
+                            onClick={() => { this.setActiveView(SPLIT_VIEW); }}
+                            active={this.state.activeView === SPLIT_VIEW}
+                        />
+                    </div>
+                }
             </div>
         );
     }


### PR DESCRIPTION
## Purpose
In composer split view the design view was moved to right side. 

## Goals
The motivation was that it is more natural/common to have the diagram view on to right in split mode.

## Approach
![screenshot from 2018-02-06 14-24-09](https://user-images.githubusercontent.com/323846/35849997-71c00224-0b49-11e8-966d-eeb79160aa89.png)

