### PR TITLE
Write font-ballerina codepoints before webpack compile

### DIFF
--- a/composer/modules/web/webpack.config.js
+++ b/composer/modules/web/webpack.config.js
@@ -155,10 +155,12 @@ const config = [{
             hash: new Date().getTime(),
         }), {
             apply: function(compiler) {
-                compiler.plugin('done', function() {
-                    fs.writeFileSync(
+                compiler.plugin('compile', function(compilation, callback) {
+                    fs.writeFile(
                         path.resolve(__dirname, './font/dist/font-ballerina/codepoints.json'),
-                        JSON.stringify(codepoints)
+                        JSON.stringify(codepoints),
+                        'utf8',
+                        callback
                     );
                 });
             }


### PR DESCRIPTION
## Purpose
Fix the build failure at webpack compile because the codepoints.json is not present.