### PR TITLE
Fix language server tests for windows

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/util/HoverUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/util/HoverUtil.java
@@ -234,7 +234,7 @@ public class HoverUtil {
      * @return string formatted using markdown.
      */
     private static String getFormattedHoverContent(String header, String content) {
-        return String.format("**%s**\r%n```\r%n%s\r%n```\r%n", header, content);
+        return "**" + header + "**\r\n```\r\n" + content + "\r\n```\r\n";
     }
 
     /**

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/util/CompletionTestUtil.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/util/CompletionTestUtil.java
@@ -36,9 +36,7 @@ import org.slf4j.LoggerFactory;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
-import java.net.URL;
+
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -53,8 +51,6 @@ public class CompletionTestUtil {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FileUtils.class);
 
-    private static final String SCHEME = "file://";
-
     /**
      * Get a new request message from the content.
      * @param position      position of the cursor
@@ -64,8 +60,8 @@ public class CompletionTestUtil {
     public static TextDocumentPositionParams getPositionParams(Position position, String uri) {
         TextDocumentPositionParams textDocumentPositionParams = new TextDocumentPositionParams();
         TextDocumentIdentifier documentIdentifier = new TextDocumentIdentifier();
+        documentIdentifier.setUri(Paths.get(uri).toUri().toString());
 
-        documentIdentifier.setUri(SCHEME + uri);
         textDocumentPositionParams.setPosition(position);
         textDocumentPositionParams.setTextDocument(documentIdentifier);
 
@@ -147,12 +143,8 @@ public class CompletionTestUtil {
         Path openedPath;
         WorkspaceDocumentManagerImpl documentManager = new WorkspaceDocumentManagerImpl();
 
-        try {
-            openedPath = Paths.get(new URL(SCHEME + uri).toURI());
-            documentManager.openFile(openedPath, balContent);
-        } catch (URISyntaxException | MalformedURLException e) {
-            LOGGER.error(e.getMessage());
-        }
+        openedPath = Paths.get(uri);
+        documentManager.openFile(openedPath, balContent);
 
         return documentManager;
     }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/hover/HoverProviderTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/hover/HoverProviderTest.java
@@ -140,7 +140,7 @@ public class HoverProviderTest {
     private String getHoverResponseMessageAsString(Position position) throws InterruptedException {
         TextDocumentPositionParams positionParams = new TextDocumentPositionParams();
         TextDocumentIdentifier identifier = new TextDocumentIdentifier();
-        identifier.setUri("file://" + balPath);
+        identifier.setUri(Paths.get(balPath).toUri().toString());
         positionParams.setTextDocument(identifier);
         positionParams.setPosition(position);
 


### PR DESCRIPTION
## Purpose
Language server tests were failing in windows because the URI string created by test utils is invalid for windows paths.

## Approach
Create the URI in a platform independent way.