### PR TITLE
Completion resolving improvements

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/TreeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/TreeVisitor.java
@@ -178,7 +178,8 @@ public class TreeVisitor extends BLangNodeVisitor {
     }
 
     public void visit(BLangXMLNS xmlnsNode) {
-        throw new AssertionError();
+        CursorScopeResolver.getResolverByClass(cursorPositionResolver)
+                .isCursorBeforeNode(xmlnsNode.getPosition(), xmlnsNode, this, this.documentServiceContext);
     }
 
     public void visit(BLangFunction funcNode) {
@@ -474,6 +475,8 @@ public class TreeVisitor extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangAbort abortNode) {
+        CursorScopeResolver.getResolverByClass(cursorPositionResolver)
+                .isCursorBeforeNode(abortNode.getPosition(), abortNode, this, this.documentServiceContext);
     }
 
     private BLangVariableDef createVarDef(BLangVariable var) {
@@ -568,7 +571,6 @@ public class TreeVisitor extends BLangNodeVisitor {
     public void visit(BLangEnum enumNode) {
         CursorScopeResolver.getResolverByClass(cursorPositionResolver).isCursorBeforeNode(enumNode.getPosition(),
                 enumNode, this, this.documentServiceContext);
-            // TODO: Implementation Required
     }
 
     @Override
@@ -603,12 +605,15 @@ public class TreeVisitor extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangBind bindNode) {
-        // No Implementation
+        CursorScopeResolver.getResolverByClass(cursorPositionResolver).isCursorBeforeNode(bindNode.getPosition(),
+                bindNode, this, this.documentServiceContext);
+        // TODO: need to implement the bind context related suggestions. Implementation on hold - grammar inconsistency
     }
 
     @Override
     public void visit(BLangBreak breakNode) {
-        // No Implementation
+        CursorScopeResolver.getResolverByClass(cursorPositionResolver).isCursorBeforeNode(breakNode.getPosition(),
+                breakNode, this, this.documentServiceContext);
     }
 
     @Override
@@ -618,7 +623,8 @@ public class TreeVisitor extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangThrow throwNode) {
-        // No Implementation
+        CursorScopeResolver.getResolverByClass(cursorPositionResolver).isCursorBeforeNode(throwNode.getPosition(),
+                throwNode, this, this.documentServiceContext);
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/StatementContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/StatementContextResolver.java
@@ -21,6 +21,8 @@ import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.util.filters.StatementTemplateFilter;
 import org.eclipse.lsp4j.CompletionItem;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 
 import java.util.ArrayList;
 
@@ -36,6 +38,11 @@ public class StatementContextResolver extends AbstractItemResolver {
         StatementTemplateFilter statementTemplateFilter = new StatementTemplateFilter();
         // Add the statement templates
         completionItems.addAll(statementTemplateFilter.filterItems(completionContext));
+        // We need to remove the functions having a receiver symbol
+        completionContext.get(CompletionKeys.VISIBLE_SYMBOLS_KEY).removeIf(symbolInfo -> {
+            BSymbol bSymbol = symbolInfo.getScopeEntry().symbol;
+            return bSymbol instanceof BInvokableSymbol && ((BInvokableSymbol) bSymbol).receiverSymbol != null;
+        });
         populateCompletionItemList(completionContext.get(CompletionKeys.VISIBLE_SYMBOLS_KEY), completionItems);
 
         return completionItems;


### PR DESCRIPTION
## Purpose
With this PR, following improvements are introduced
- Fix issue of incorrect completions when there are abort statements
- Fix issue of incorrect completions when there are bind statements
- Fix issue of incorrect completions when there are break statements
- Fix issue of incorrect completions when there are throw statements
- Fix issue of suggesting unnecessary invokable symbols inside the block statements. Here we remove invokable symbols which are having a receiver symbol

## Approach
> 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/1329674/35900497-43b832fc-0bf8-11e8-8c82-692f6d7c46a6.gif)
Here all the functions suggested are without a receiver symbols