### PR TITLE
Add url encode/decode functions

### DIFF
--- a/stdlib/ballerina-http/src/main/ballerina/ballerina/net/uri/natives.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/ballerina/net/uri/natives.bal
@@ -1,7 +1,15 @@
 package ballerina.net.uri;
 
-@Description { value:"Encodes the given URL"}
-@Param { value:"url: URL to be encoded" }
-@Return { value:"The encoded url" }
-public native function encode (string url) (string);
+@Description {value:"Encodes the given URL"}
+@Param {value:"url: URL to be encoded"}
+@Param {value:"charset: Charactor set that URL to be encoded"}
+@Return {value:"The encoded URL"}
+@Return {value:"Error occured during encoding the URL"}
+public native function encode (string url, string charset) (string, error);
 
+@Description {value:"Decodes the given URL"}
+@Param {value:"url: URL to be decoded"}
+@Param {value:"charset: Charactor set that URL to be decoded"}
+@Return {value:"The decoded URL"}
+@Return {value:"Error occured during decoding the URL"}
+public native function decode (string url, string charset) (string, error);

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -82,6 +82,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.ballerinalang.bre.bvm.BLangVMErrors.BUILTIN_PACKAGE;
+import static org.ballerinalang.bre.bvm.BLangVMErrors.STRUCT_GENERIC_ERROR;
 import static org.ballerinalang.mime.util.Constants.APPLICATION_JSON;
 import static org.ballerinalang.mime.util.Constants.APPLICATION_XML;
 import static org.ballerinalang.mime.util.Constants.CONTENT_TYPE;
@@ -999,4 +1001,21 @@ public class HttpUtil {
 
         return intVal;
     }
+
+    /**
+     * Extract generic error message.
+     *
+     * @param context Represent ballerina context.
+     * @param errMsg  Error message.
+     * @return Generic error message.
+     */
+    public static BStruct getGenericError(Context context, String errMsg) {
+        PackageInfo errorPackageInfo = context.getProgramFile().getPackageInfo(BUILTIN_PACKAGE);
+        StructInfo errorStructInfo = errorPackageInfo.getStructInfo(STRUCT_GENERIC_ERROR);
+
+        BStruct genericError = new BStruct(errorStructInfo.getType());
+        genericError.setStringField(0, errMsg);
+        return genericError;
+    }
 }
+

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/uri/nativeimpl/Decode.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/uri/nativeimpl/Decode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -29,57 +29,32 @@ import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.net.http.HttpUtil;
 
 import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
+import java.net.URLDecoder;
 
 /**
- * Native function to encode URLs.
- * ballerina.net.uri:encode
+ * Native function to decode URLs.
+ * ballerina.net.uri:decode
  */
 
 @BallerinaFunction(
         packageName = "ballerina.net.uri",
-        functionName = "encode",
+        functionName = "decode",
         args = {@Argument(name = "url", type = TypeKind.STRING)},
         returnType = {@ReturnType(type = TypeKind.STRING),
                       @ReturnType(type = TypeKind.STRUCT, structType = "Error")},
         isPublic = true
 )
-public class Encode extends AbstractNativeFunction {
+public class Decode extends AbstractNativeFunction {
 
     @Override
     public BValue[] execute(Context context) {
         String url = getStringArgument(context, 0);
         String charset = getStringArgument(context, 1);
         try {
-            return getBValues(new BString(encode(url, charset)), null);
-        } catch (Throwable e) {
+            return getBValues(new BString(URLDecoder.decode(url, charset)), null);
+        } catch (UnsupportedEncodingException e) {
             return getBValues(null,
-                    HttpUtil.getGenericError(context, "Error occurred while encoding the url. " + e.getMessage()));
+                    HttpUtil.getGenericError(context, "Error occurred while decoding the url. " + e.getMessage()));
         }
-    }
-
-    private String encode(String url, String charset) throws UnsupportedEncodingException {
-        String encoded;
-
-        encoded = URLEncoder.encode(url, charset);
-
-        StringBuilder buf = new StringBuilder(encoded.length());
-        char focus;
-        for (int i = 0; i < encoded.length(); i++) {
-            focus = encoded.charAt(i);
-            if (focus == '*') {
-                buf.append("%2A");
-            } else if (focus == '+') {
-                buf.append("%20");
-            } else if (focus == '%' && (i + 1) < encoded.length() && encoded.charAt(i + 1) == '7'
-                    && encoded.charAt(i + 2) == 'E') {
-                buf.append('~');
-                i += 2;
-            } else {
-                buf.append(focus);
-            }
-
-        }
-        return buf.toString();
     }
 }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/NetURITest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/NetURITest.java
@@ -67,7 +67,123 @@ public class NetURITest {
 
     @Test(expectedExceptions = BLangRuntimeException.class)
     public void testEncodeNegative() {
-        BValue[] inputArg = {new BString(null)};
+        BValue[] inputArg = { new BString(null) };
         BRunUtil.invoke(compileResult, "testEncode", inputArg);
     }
+
+    @Test(description = "Test url encode function with invalid character set in ballerina.net.uri package")
+    public void testUrlEncodeWithInvalidCharset() {
+        BString url = new BString("http://localhost:9090/echoService#abc");
+        BString expected = new BString("Error occurred while encoding the url. abc");
+        BValue[] inputArg = { url };
+        BValue[] returnVals = BRunUtil.invoke(compileResult, "testInvalidEncode", inputArg);
+        Assert.assertTrue(returnVals[1].stringValue().contains(expected.stringValue()),
+                "Error message is not propagated.");
+    }
+
+    @Test(description = "Test url decode function against simple url in ballerina.net.uri package")
+    public void testSimpleUrlDecode() {
+        BString url = new BString("http%3A%2F%2Flocalhost%3A9090");
+        BString expected = new BString("http://localhost:9090");
+        BValue[] inputArg = { url };
+        BValue[] returnVals = BRunUtil.invoke(compileResult, "testDecode", inputArg);
+        Assert.assertFalse(returnVals == null || returnVals.length == 0 || returnVals[0] == null,
+                "Invalid Return Values for " + url.stringValue());
+        Assert.assertEquals(returnVals[0].stringValue(), expected.stringValue(), "Decoded url string is not correct.");
+    }
+
+    @Test(description = "Test url decode function against url with spaces in ballerina.net.uri package")
+    public void testUrlDecodeWithSpaces() {
+        BString url = new BString("http%3A%2F%2Flocalhost%3A9090%2FechoService%2Fhello%20world%2F");
+        BString expected = new BString("http://localhost:9090/echoService/hello world/");
+        BValue[] inputArg = { url };
+        BValue[] returnVals = BRunUtil.invoke(compileResult, "testDecode", inputArg);
+        Assert.assertFalse(returnVals == null || returnVals.length == 0 || returnVals[0] == null,
+                "Invalid Return Values for " + url.stringValue());
+        Assert.assertEquals(returnVals[0].stringValue(), expected.stringValue(), "Decoded url string is not correct.");
+        Assert.assertTrue(returnVals[0].stringValue().contains(" "), "Decoded url string doesn't contain spaces.");
+    }
+
+    @Test(description = "Test url decode function against url with # in ballerina.net.uri package")
+    public void testUrlDecodeWithHashSign() {
+        BString url = new BString("http%3A%2F%2Flocalhost%3A9090%2FechoService%23abc");
+        BString expected = new BString("http://localhost:9090/echoService#abc");
+        BValue[] inputArg = { url };
+        BValue[] returnVals = BRunUtil.invoke(compileResult, "testDecode", inputArg);
+        Assert.assertFalse(returnVals == null || returnVals.length == 0 || returnVals[0] == null,
+                "Invalid Return Values for " + url.stringValue());
+        Assert.assertEquals(returnVals[0].stringValue(), expected.stringValue(), "Decoded url string is not correct.");
+        Assert.assertTrue(returnVals[0].stringValue().contains("#"), "Decoded url string doesn't contain # character.");
+    }
+
+    @Test(description = "Test url decode function against url with colon(:) in ballerina.net.uri package")
+    public void testUrlDecodeWithColon() {
+        BString url = new BString("http%3A%2F%2Flocalhost%3A9090%2FechoService%3Aabc");
+        BString expected = new BString("http://localhost:9090/echoService:abc");
+        BValue[] inputArg = { url };
+        BValue[] returnVals = BRunUtil.invoke(compileResult, "testDecode", inputArg);
+        Assert.assertFalse(returnVals == null || returnVals.length == 0 || returnVals[0] == null,
+                "Invalid Return Values for " + url.stringValue());
+        Assert.assertEquals(returnVals[0].stringValue(), expected.stringValue(), "Decoded url string is not correct.");
+        Assert.assertTrue(returnVals[0].stringValue().contains(":"), "Decoded url string doesn't contain : character.");
+    }
+
+    @Test(description = "Test url decode function against url with plus(+) in ballerina.net.uri package")
+    public void testUrlDecodeWithPlusSign() {
+        BString url = new BString("http%3A%2F%2Flocalhost%3A9090%2FechoService%2Babc");
+        BString expected = new BString("http://localhost:9090/echoService+abc");
+        BValue[] inputArg = { url };
+        BValue[] returnVals = BRunUtil.invoke(compileResult, "testDecode", inputArg);
+        Assert.assertFalse(returnVals == null || returnVals.length == 0 || returnVals[0] == null,
+                "Invalid Return Values for " + url.stringValue());
+        Assert.assertEquals(returnVals[0].stringValue(), expected.stringValue(), "Decoded url string is not correct.");
+        Assert.assertTrue(returnVals[0].stringValue().contains(":"), "Decoded url string doesn't contain + character.");
+    }
+
+    @Test(description = "Test url decode function against url with asterisk(*) in ballerina.net.uri package")
+    public void testUrlDecodeWithAsterisk() {
+        BString url = new BString("http%3A%2F%2Flocalhost%3A9090%2FechoService%2Aabc");
+        BString expected = new BString("http://localhost:9090/echoService*abc");
+        BValue[] inputArg = { url };
+        BValue[] returnVals = BRunUtil.invoke(compileResult, "testDecode", inputArg);
+        Assert.assertFalse(returnVals == null || returnVals.length == 0 || returnVals[0] == null,
+                "Invalid Return Values for " + url.stringValue());
+        Assert.assertEquals(returnVals[0].stringValue(), expected.stringValue(), "Decoded url string is not correct.");
+        Assert.assertTrue(returnVals[0].stringValue().contains(":"), "Decoded url string doesn't contain * character.");
+    }
+
+    @Test(description = "Test url decode function against url with percentage(%) in ballerina.net.uri package")
+    public void testUrlDecodeWithPercentageMark() {
+        BString url = new BString("http%3A%2F%2Flocalhost%3A9090%2FechoService%25abc");
+        BString expected = new BString("http://localhost:9090/echoService%abc");
+        BValue[] inputArg = { url };
+        BValue[] returnVals = BRunUtil.invoke(compileResult, "testDecode", inputArg);
+        Assert.assertFalse(returnVals == null || returnVals.length == 0 || returnVals[0] == null,
+                "Invalid Return Values for " + url.stringValue());
+        Assert.assertEquals(returnVals[0].stringValue(), expected.stringValue(), "Decoded url string is not correct.");
+        Assert.assertTrue(returnVals[0].stringValue().contains(":"), "Decoded url string doesn't contain % mark.");
+    }
+
+    @Test(description = "Test url decode function against url with tilde(~) in ballerina.net.uri package")
+    public void testUrlDecodeWithTilde() {
+        BString url = new BString("http%3A%2F%2Flocalhost%3A9090%2FechoService~abc");
+        BString expected = new BString("http://localhost:9090/echoService~abc");
+        BValue[] inputArg = { url };
+        BValue[] returnVals = BRunUtil.invoke(compileResult, "testDecode", inputArg);
+        Assert.assertFalse(returnVals == null || returnVals.length == 0 || returnVals[0] == null,
+                "Invalid Return Values for " + url.stringValue());
+        Assert.assertEquals(returnVals[0].stringValue(), expected.stringValue(), "Decoded url string is not correct.");
+        Assert.assertTrue(returnVals[0].stringValue().contains(":"), "Decoded url string doesn't contain ~ character.");
+    }
+
+    @Test(description = "Test url decode function with invalid character set in ballerina.net.uri package")
+    public void testUrlDecodeWithInvalidCharset() {
+        BString url = new BString("http%3A%2F%2Flocalhost%3A9090%2FechoService~abc");
+        BString expected = new BString("Error occurred while decoding the url. abc");
+        BValue[] inputArg = { url };
+        BValue[] returnVals = BRunUtil.invoke(compileResult, "testInvalidDecode", inputArg);
+        Assert.assertTrue(returnVals[1].stringValue().contains(expected.stringValue()),
+                "Error message is not propagated.");
+    }
+
 }

--- a/tests/ballerina-test/src/test/resources/test-src/nativeimpl/functions/net-uri.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/nativeimpl/functions/net-uri.bal
@@ -1,5 +1,37 @@
 import ballerina.net.uri;
 
-function testEncode(string url)(string){
-    return uri:encode(url);
+function testEncode (string url) (string, error) {
+    var encodedUrl, err = uri:encode(url, "UTF-8");
+
+    if (err != null) {
+        return null, err;
+    }
+    return encodedUrl, null;
+}
+
+function testInvalidEncode (string url) (string, error) {
+    var encodedUrl, err = uri:encode(url, "abc");
+
+    if (err != null) {
+        return null, err;
+    }
+    return encodedUrl, null;
+}
+
+function testDecode (string url) (string, error) {
+    var decodedUrl, err = uri:decode(url, "UTF-8");
+
+    if (err != null) {
+        return null, err;
+    }
+    return decodedUrl, null;
+}
+
+function testInvalidDecode (string url) (string, error) {
+    var decodedUrl, err = uri:decode(url, "abc");
+
+    if (err != null) {
+        return null, err;
+    }
+    return decodedUrl, null;
 }


### PR DESCRIPTION
Introduce the url encode/decode functionalities to the ballerina. Fixes https://github.com/ballerina-lang/ballerina/issues/4509

## Purpose
Adding url encode/decode functionalities to the ballerina.

## Goals
Support url encoding and decoding from ballerina language.

## Approach
Provide native utility functions to encode/decode url strings with given encoding type.