### PR TITLE
Avoid base64 encoding of paths to allow unicode chars & Refactor FS-Service

### DIFF
--- a/composer/modules/server/services/file-system/src/main/java/org/ballerinalang/composer/service/fs/service/FileSystemService.java
+++ b/composer/modules/server/services/file-system/src/main/java/org/ballerinalang/composer/service/fs/service/FileSystemService.java
@@ -23,6 +23,12 @@ import org.ballerinalang.composer.server.spi.ServiceInfo;
 import org.ballerinalang.composer.server.spi.ServiceType;
 import org.ballerinalang.composer.service.fs.Constants;
 import org.ballerinalang.composer.service.fs.FileSystem;
+import org.ballerinalang.composer.service.fs.service.request.CreateFileRequest;
+import org.ballerinalang.composer.service.fs.service.request.DeleteFileRequest;
+import org.ballerinalang.composer.service.fs.service.request.FileExistsRequest;
+import org.ballerinalang.composer.service.fs.service.request.ListFilesRequest;
+import org.ballerinalang.composer.service.fs.service.request.MoveCopyFileRequest;
+import org.ballerinalang.composer.service.fs.service.request.ReadFileRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,13 +48,11 @@ import java.util.Base64;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.FormParam;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -63,6 +67,7 @@ public class FileSystemService implements ComposerService {
     private static final String STATUS = "status";
     private static final String SUCCESS = "success";
     private static final String ACCESS_CONTROL_ALLOW_ORIGIN_HEADER = "Access-Control-Allow-Origin";
+    private static final String MIME_APPLICATION_JSON = "application/json";
 
     private List<java.nio.file.Path> rootPaths;
 
@@ -72,12 +77,13 @@ public class FileSystemService implements ComposerService {
         this.fileSystem = fileSystem;
     }
 
-    @GET
-    @Path("/root")
-    @Produces("application/json")
-    public Response root(@DefaultValue(".bal") @QueryParam("extensions") String extensions) {
+    @POST
+    @Path("/list/roots")
+    @Consumes(MIME_APPLICATION_JSON)
+    @Produces(MIME_APPLICATION_JSON)
+    public Response root(ListFilesRequest request) {
         try {
-            List<String> extensionList = Arrays.asList(extensions.split(","));
+            List<String> extensionList = Arrays.asList(request.getExtensions().split(","));
             JsonArray roots = (rootPaths == null || rootPaths.isEmpty()) ? fileSystem.listRoots(extensionList) :
                     fileSystem.getJsonForRoots(rootPaths, extensionList);
             return createOKResponse(roots);
@@ -87,13 +93,13 @@ public class FileSystemService implements ComposerService {
         }
     }
 
-    @GET
+    @POST
     @Path("/exists")
-    @Produces("application/json")
-    public Response pathExists(@QueryParam("path") String path) {
+    @Consumes(MIME_APPLICATION_JSON)
+    @Produces(MIME_APPLICATION_JSON)
+    public Response pathExists(FileExistsRequest request) {
         try {
-            JsonObject exists = fileSystem.exists(new String(Base64.getDecoder().decode(path),
-                    Charset.defaultCharset()));
+            JsonObject exists = fileSystem.exists(request.getPath());
             return createOKResponse(exists);
         } catch (Throwable throwable) {
             logger.error("/exists service error", throwable.getMessage(), throwable);
@@ -103,14 +109,11 @@ public class FileSystemService implements ComposerService {
 
     @POST
     @Path("/create")
-    @Produces("application/json")
-    public Response create(@FormParam("path") String pathParam, @FormParam("type") String typeParam,
-                           @FormParam("content") String contentParam) {
+    @Consumes(MIME_APPLICATION_JSON)
+    @Produces(MIME_APPLICATION_JSON)
+    public Response create(CreateFileRequest request) {
         try {
-            String path = new String(Base64.getDecoder().decode(pathParam), Charset.defaultCharset()),
-                    type = new String(Base64.getDecoder().decode(typeParam), Charset.defaultCharset()),
-                    content = new String(Base64.getDecoder().decode(contentParam), Charset.defaultCharset());
-            fileSystem.create(path, type, content);
+            fileSystem.create(request.getPath(), request.getType(), request.getContent());
             JsonObject entity = new JsonObject();
             entity.addProperty(STATUS, SUCCESS);
             return createOKResponse(entity);
@@ -122,12 +125,11 @@ public class FileSystemService implements ComposerService {
 
     @POST
     @Path("/move")
-    @Produces("application/json")
-    public Response move(@FormParam("srcPath") String srcPath, @FormParam("destPath") String destPath) {
+    @Consumes(MIME_APPLICATION_JSON)
+    @Produces(MIME_APPLICATION_JSON)
+    public Response move(MoveCopyFileRequest request) {
         try {
-            String src = new String(Base64.getDecoder().decode(srcPath), Charset.defaultCharset()),
-                    dest = new String(Base64.getDecoder().decode(destPath), Charset.defaultCharset());
-            fileSystem.move(src, dest);
+            fileSystem.move(request.getSrcPath(), request.getDestPath());
             JsonObject entity = new JsonObject();
             entity.addProperty(STATUS, SUCCESS);
             return createOKResponse(entity);
@@ -139,12 +141,11 @@ public class FileSystemService implements ComposerService {
 
     @POST
     @Path("/copy")
-    @Produces("application/json")
-    public Response copy(@FormParam("srcPath") String srcPath, @FormParam("destPath") String destPath) {
+    @Consumes(MIME_APPLICATION_JSON)
+    @Produces(MIME_APPLICATION_JSON)
+    public Response copy(MoveCopyFileRequest request) {
         try {
-            String src = new String(Base64.getDecoder().decode(srcPath), Charset.defaultCharset()),
-                    dest = new String(Base64.getDecoder().decode(destPath), Charset.defaultCharset());
-            fileSystem.copy(src, dest);
+            fileSystem.copy(request.getSrcPath(), request.getDestPath());
             JsonObject entity = new JsonObject();
             entity.addProperty(STATUS, SUCCESS);
             return createOKResponse(entity);
@@ -156,11 +157,11 @@ public class FileSystemService implements ComposerService {
 
     @POST
     @Path("/delete")
-    @Produces("application/json")
-    public Response delete(@FormParam("path") String pathParam) {
+    @Consumes(MIME_APPLICATION_JSON)
+    @Produces(MIME_APPLICATION_JSON)
+    public Response delete(DeleteFileRequest request) {
         try {
-            String path = new String(Base64.getDecoder().decode(pathParam), Charset.defaultCharset());
-            fileSystem.delete(path);
+            fileSystem.delete(request.getPath());
             JsonObject entity = new JsonObject();
             entity.addProperty(STATUS, SUCCESS);
             return createOKResponse(entity);
@@ -170,15 +171,14 @@ public class FileSystemService implements ComposerService {
         }
     }
 
-    @GET
-    @Path("/listFiles")
-    @Produces("application/json")
-    public Response filesInPath(@QueryParam("path") String path,
-                                @DefaultValue(".bal") @QueryParam("extensions") String extensions) {
+    @POST
+    @Path("/list/files")
+    @Consumes(MIME_APPLICATION_JSON)
+    @Produces(MIME_APPLICATION_JSON)
+    public Response filesInPath(ListFilesRequest request) {
         try {
-            List<String> extensionList = Arrays.asList(extensions.split(","));
-            JsonArray filesInPath = fileSystem.listFilesInPath(new String(Base64.getDecoder().decode(path),
-                    Charset.defaultCharset()), extensionList);
+            List<String> extensionList = Arrays.asList(request.getExtensions().split(","));
+            JsonArray filesInPath = fileSystem.listFilesInPath(request.getPath(), extensionList);
             return createOKResponse(filesInPath);
         } catch (Throwable throwable) {
             logger.error("/list service error", throwable.getMessage(), throwable);
@@ -188,7 +188,7 @@ public class FileSystemService implements ComposerService {
 
     @POST
     @Path("/write")
-    @Produces("application/json")
+    @Produces(MIME_APPLICATION_JSON)
     public Response write(String payload) {
         try {
             String location = "";
@@ -238,10 +238,11 @@ public class FileSystemService implements ComposerService {
 
     @POST
     @Path("/read")
-    @Produces("application/json")
-    public Response read(String path) {
+    @Consumes(MIME_APPLICATION_JSON)
+    @Produces(MIME_APPLICATION_JSON)
+    public Response read(ReadFileRequest request) {
         try {
-            return createOKResponse(fileSystem.read(path));
+            return createOKResponse(fileSystem.read(request.getPath()));
         } catch (Throwable throwable) {
             logger.error("/read service error", throwable.getMessage(), throwable);
             return createErrorResponse(throwable);
@@ -249,8 +250,8 @@ public class FileSystemService implements ComposerService {
     }
 
     @GET
-    @Path("/userHome")
-    @Produces("text/plain")
+    @Path("/user/home")
+    @Produces(MIME_APPLICATION_JSON)
     public Response userHome() {
         try {
             return createOKResponse(fileSystem.getUserHome());
@@ -262,6 +263,7 @@ public class FileSystemService implements ComposerService {
 
     /**
      * Creates the JSON response for given entity.
+     *
      * @param entity Response
      * @return Response
      */
@@ -274,7 +276,8 @@ public class FileSystemService implements ComposerService {
     }
 
     /**
-     * Creates an error response for the given IO Exception
+     * Creates an error response for the given IO Exception.
+     *
      * @param ex Thrown Exception
      * @return Error Message
      */
@@ -299,7 +302,7 @@ public class FileSystemService implements ComposerService {
         entity.addProperty("Error", errMsg);
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                 .entity(entity)
-                .header("Access-Control-Allow-Origin", '*')
+                .header(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, '*')
                 .type(MediaType.APPLICATION_JSON)
                 .build();
     }

--- a/composer/modules/server/services/file-system/src/main/java/org/ballerinalang/composer/service/fs/service/request/CreateFileRequest.java
+++ b/composer/modules/server/services/file-system/src/main/java/org/ballerinalang/composer/service/fs/service/request/CreateFileRequest.java
@@ -20,11 +20,33 @@ package org.ballerinalang.composer.service.fs.service.request;
  */
 public class CreateFileRequest {
 
+    private String fullPath;
+
     private String path;
+
+    private String name;
 
     private String type;
 
     private String content;
+
+    private boolean isBase64Encoded;
+
+    public String getFullPath() {
+        return fullPath;
+    }
+
+    public void setFullPath(String fullPath) {
+        this.fullPath = fullPath;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
 
     public String getPath() {
         return path;
@@ -49,4 +71,14 @@ public class CreateFileRequest {
     public void setContent(String content) {
         this.content = content;
     }
+
+    public boolean isBase64Encoded() {
+        return isBase64Encoded;
+    }
+
+    public void setBase64Encoded(boolean base64Encoded) {
+        isBase64Encoded = base64Encoded;
+    }
+
+
 }

--- a/composer/modules/server/services/file-system/src/main/java/org/ballerinalang/composer/service/fs/service/request/CreateFileRequest.java
+++ b/composer/modules/server/services/file-system/src/main/java/org/ballerinalang/composer/service/fs/service/request/CreateFileRequest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.composer.service.fs.service.request;
+
+/**
+ * Create File Request.
+ */
+public class CreateFileRequest {
+
+    private String path;
+
+    private String type;
+
+    private String content;
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+}

--- a/composer/modules/server/services/file-system/src/main/java/org/ballerinalang/composer/service/fs/service/request/DeleteFileRequest.java
+++ b/composer/modules/server/services/file-system/src/main/java/org/ballerinalang/composer/service/fs/service/request/DeleteFileRequest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.composer.service.fs.service.request;
+
+/**
+ * Delete File Request.
+ */
+public class DeleteFileRequest {
+    private String path;
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+}

--- a/composer/modules/server/services/file-system/src/main/java/org/ballerinalang/composer/service/fs/service/request/FileExistsRequest.java
+++ b/composer/modules/server/services/file-system/src/main/java/org/ballerinalang/composer/service/fs/service/request/FileExistsRequest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.composer.service.fs.service.request;
+
+/**
+ * File Exists Request.
+ */
+public class FileExistsRequest {
+    private String path;
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+}

--- a/composer/modules/server/services/file-system/src/main/java/org/ballerinalang/composer/service/fs/service/request/ListFilesRequest.java
+++ b/composer/modules/server/services/file-system/src/main/java/org/ballerinalang/composer/service/fs/service/request/ListFilesRequest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.composer.service.fs.service.request;
+
+/**
+ * List Files Request.
+ */
+public class ListFilesRequest {
+
+    private String path;
+
+    private String extensions = ".bal";
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getExtensions() {
+        return extensions;
+    }
+
+    public void setExtensions(String extensions) {
+        this.extensions = extensions;
+    }
+}

--- a/composer/modules/server/services/file-system/src/main/java/org/ballerinalang/composer/service/fs/service/request/MoveCopyFileRequest.java
+++ b/composer/modules/server/services/file-system/src/main/java/org/ballerinalang/composer/service/fs/service/request/MoveCopyFileRequest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.composer.service.fs.service.request;
+
+/**
+ * Move File Request.
+ */
+public class MoveCopyFileRequest {
+
+    private String srcPath;
+
+    private String destPath;
+
+    public String getSrcPath() {
+        return srcPath;
+    }
+
+    public void setSrcPath(String srcPath) {
+        this.srcPath = srcPath;
+    }
+
+    public String getDestPath() {
+        return destPath;
+    }
+
+    public void setDestPath(String destPath) {
+        this.destPath = destPath;
+    }
+}

--- a/composer/modules/server/services/file-system/src/main/java/org/ballerinalang/composer/service/fs/service/request/ReadFileRequest.java
+++ b/composer/modules/server/services/file-system/src/main/java/org/ballerinalang/composer/service/fs/service/request/ReadFileRequest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.composer.service.fs.service.request;
+
+/**
+ * Read File Request.
+ */
+public class ReadFileRequest {
+    private String path;
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+}

--- a/composer/modules/web/src/api-client/api-client.js
+++ b/composer/modules/web/src/api-client/api-client.js
@@ -21,6 +21,9 @@ import $ from 'jquery';
 import hardcodedTypeLattice from './hardcoded-type-lattice';
 import hardcodedOperatorLattice from './hardcoded-operator-lattice';
 
+const CONTENT_TYPE_JSON_HEADER = {
+    'content-type': 'application/json; charset=utf-8',
+};
 
 // updating this with endpoints upon initial fetchConfigs()
 let endpoints = {};
@@ -77,12 +80,9 @@ export function parseFile(file) {
         includeProgramDir: true,
     };
     const endpoint = getServiceEndpoint('ballerina-parser') + '/file/validate-and-parse';
-    const headers = {
-        'content-type': 'application/json; charset=utf-8',
-    };
 
     return new Promise((resolve, reject) => {
-        axios.post(endpoint, payload, { headers })
+        axios.post(endpoint, payload, { headers: CONTENT_TYPE_JSON_HEADER })
             .then((response) => {
                 resolve(response.data);
             }).catch(error => reject(error));
@@ -104,12 +104,9 @@ export function parseContent(content) {
         content,
     };
     const endpoint = getServiceEndpoint('ballerina-parser') + '/file/validate-and-parse';
-    const headers = {
-        'content-type': 'application/json; charset=utf-8',
-    };
 
     return new Promise((resolve, reject) => {
-        axios.post(endpoint, payload, { headers })
+        axios.post(endpoint, payload, { headers: CONTENT_TYPE_JSON_HEADER })
             .then((response) => {
                 resolve(response.data);
             }).catch(error => reject(error));
@@ -121,12 +118,9 @@ export function parseContent(content) {
  */
 export function getPackages() {
     const endpoint = getServiceEndpoint('ballerina-parser') + '/built-in-packages';
-    const headers = {
-        'content-type': 'application/json; charset=utf-8',
-    };
 
     return new Promise((resolve, reject) => {
-        axios.get(endpoint, { headers })
+        axios.get(endpoint, { headers: CONTENT_TYPE_JSON_HEADER })
             .then((response) => {
                 resolve(response.data);
             }).catch(error => reject(error));
@@ -138,12 +132,9 @@ export function getPackages() {
  */
 export function getBuiltInTypes() {
     const endpoint = getServiceEndpoint('ballerina-parser') + '/built-in-types';
-    const headers = {
-        'content-type': 'application/json; charset=utf-8',
-    };
 
     return new Promise((resolve, reject) => {
-        axios.get(endpoint, { headers })
+        axios.get(endpoint, { headers: CONTENT_TYPE_JSON_HEADER })
             .then((response) => {
                 resolve(response.data);
             }).catch(error => reject(error));
@@ -154,14 +145,13 @@ export function getBuiltInTypes() {
  * Get FS Roots
  */
 export function getFSRoots(extensions) {
-    const exts = _.join(extensions, ',');
-    const endpoint = `${getServiceEndpoint('filesystem')}/root?extensions=${exts}`;
-    const headers = {
-        'content-type': 'application/json; charset=utf-8',
+    const endpoint = `${getServiceEndpoint('filesystem')}/list/roots`;
+    const data = {
+        extensions: _.join(extensions, ','),
     };
 
     return new Promise((resolve, reject) => {
-        axios.get(endpoint, { headers })
+        axios.post(endpoint, data, { headers: CONTENT_TYPE_JSON_HEADER })
             .then((response) => {
                 resolve(response.data);
             }).catch(error => reject(error));
@@ -172,17 +162,14 @@ export function getFSRoots(extensions) {
  * Get File List
  */
 export function listFiles(path, extensions) {
-    const endpoint = `${getServiceEndpoint('filesystem')}/listFiles`;
-    const headers = {
-        'content-type': 'application/json; charset=utf-8',
-    };
-    const params = {
-        path: btoa(path),
+    const endpoint = `${getServiceEndpoint('filesystem')}/list/files`;
+    const data = {
+        path,
         extensions: _.join(extensions, ','),
     };
 
     return new Promise((resolve, reject) => {
-        axios.get(endpoint, { headers, params })
+        axios.post(endpoint, data, { headers: CONTENT_TYPE_JSON_HEADER })
             .then((response) => {
                 resolve(response.data);
             }).catch(error => reject(error));
@@ -192,15 +179,12 @@ export function listFiles(path, extensions) {
 
 export function getSwaggerDefinition(ballerinaSource, serviceName) {
     const endpoint = `${getServiceEndpoint('ballerina-to-swagger')}/ballerina-to-swagger?serviceName=${serviceName}`;
-    const headers = {
-        'content-type': 'application/json; charset=utf-8',
-    };
     const payload = {
         ballerinaDefinition: ballerinaSource,
     };
 
     return new Promise((resolve, reject) => {
-        axios.post(endpoint, payload, { headers })
+        axios.post(endpoint, payload, { headers: CONTENT_TYPE_JSON_HEADER })
             .then((response) => {
                 resolve(response.data.swaggerDefinition);
             }).catch(error => reject(error));
@@ -297,12 +281,9 @@ export function getPathSeperator() {
  */
 export function invokeTryIt(tryItPayload, protocol) {
     const endpoint = getServiceEndpoint('try-it') + '/' + protocol;
-    const headers = {
-        'Content-Type': 'text/plain; charset=utf-8',
-    };
 
     return new Promise((resolve, reject) => {
-        axios.post(endpoint, tryItPayload, { headers })
+        axios.post(endpoint, tryItPayload, { headers: CONTENT_TYPE_JSON_HEADER })
             .then((response) => {
                 resolve(response.data);
             }).catch(error => reject(error));
@@ -330,7 +311,7 @@ export function getTryItUrl() {
  * @returns {Promise} Resolves string path
  */
 export function getUserHome() {
-    const endpoint = `${getServiceEndpoint('filesystem')}/userHome`;
+    const endpoint = `${getServiceEndpoint('filesystem')}/user/home`;
     return new Promise((resolve, reject) => {
         axios.get(endpoint, {})
             .then((response) => {

--- a/composer/modules/web/src/core/workspace/fs-util.js
+++ b/composer/modules/web/src/core/workspace/fs-util.js
@@ -24,8 +24,8 @@ const COMMON_HEADERS = {
     'content-type': 'text/plain; charset=utf-8',
 };
 
-const FORM_CONTENT_COMMON_HEADERS = {
-    'content-type': 'application/x-www-form-urlencoded; charset=utf-8',
+const CONTENT_TYPE_JSON_HEADER = {
+    'content-type': 'application/json; charset=utf-8',
 };
 
 const FS_SERVICE = 'filesystem';
@@ -38,7 +38,10 @@ const FS_SERVICE = 'filesystem';
  */
 export function read(targetFilePath) {
     const serviceEP = `${getServiceEndpoint(FS_SERVICE)}/read`;
-    return axios.post(serviceEP, targetFilePath, { headers: COMMON_HEADERS })
+    const data = {
+        path: targetFilePath,
+    };
+    return axios.post(serviceEP, data, { headers: CONTENT_TYPE_JSON_HEADER })
                 .then((response) => {
                     const { fileContent, fileName, filePath, fileFullPath, extension } = response.data;
                     const name = fileName;
@@ -86,8 +89,10 @@ export function createOrUpdate(path, name, content, isCustomContent) {
  */
 export function remove(path) {
     const serviceEP = `${getServiceEndpoint(FS_SERVICE)}/delete`;
-    const data = `path=${btoa(path)}`;
-    return axios.post(serviceEP, data, { headers: FORM_CONTENT_COMMON_HEADERS })
+    const data = {
+        path,
+    };
+    return axios.post(serviceEP, data, { headers: CONTENT_TYPE_JSON_HEADER })
         .then((response) => {
             return response.data;
         });
@@ -105,9 +110,12 @@ export function remove(path) {
  */
 export function create(path, type, content) {
     const serviceEP = `${getServiceEndpoint(FS_SERVICE)}/create`;
-    // FIXME: Refactor backend params
-    const data = `path=${btoa(path)}&type=${btoa(type)}&content=${btoa(content)}`;
-    return axios.post(serviceEP, data, { headers: FORM_CONTENT_COMMON_HEADERS })
+    const data = {
+        path,
+        type,
+        content,
+    };
+    return axios.post(serviceEP, data, { headers: CONTENT_TYPE_JSON_HEADER })
         .then((response) => {
             return response.data;
         });
@@ -124,8 +132,11 @@ export function create(path, type, content) {
  */
 export function move(srcPath, destPath) {
     const serviceEP = `${getServiceEndpoint(FS_SERVICE)}/move`;
-    const data = `srcPath=${btoa(srcPath)}&destPath=${btoa(destPath)}`;
-    return axios.post(serviceEP, data, { headers: FORM_CONTENT_COMMON_HEADERS })
+    const data = {
+        srcPath,
+        destPath,
+    };
+    return axios.post(serviceEP, data, { headers: CONTENT_TYPE_JSON_HEADER })
             .then((response) => {
                 return response.data;
             });
@@ -141,8 +152,11 @@ export function move(srcPath, destPath) {
  */
 export function copy(srcPath, destPath) {
     const serviceEP = `${getServiceEndpoint(FS_SERVICE)}/copy`;
-    const data = `srcPath=${btoa(srcPath)}&destPath=${btoa(destPath)}`;
-    return axios.post(serviceEP, data, { headers: FORM_CONTENT_COMMON_HEADERS })
+    const data = {
+        srcPath,
+        destPath,
+    };
+    return axios.post(serviceEP, data, { headers: CONTENT_TYPE_JSON_HEADER })
             .then((response) => {
                 return response.data;
             });
@@ -154,9 +168,12 @@ export function copy(srcPath, destPath) {
  * @returns {Promise} Resolves boolean file exists
  */
 export function exists(path) {
-    const endpoint = `${getServiceEndpoint(FS_SERVICE)}/exists?path=${btoa(path)}`;
+    const endpoint = `${getServiceEndpoint(FS_SERVICE)}/exists`;
+    const data = {
+        path,
+    };
     return new Promise((resolve, reject) => {
-        axios.get(endpoint, { headers: COMMON_HEADERS })
+        axios.post(endpoint, data, { headers: COMMON_HEADERS })
             .then((response) => {
                 resolve(response.data);
             }).catch(error => reject(error));

--- a/composer/modules/web/src/core/workspace/fs-util.js
+++ b/composer/modules/web/src/core/workspace/fs-util.js
@@ -20,12 +20,8 @@ import { getServiceEndpoint } from 'api-client/api-client';
 import axios from 'axios';
 import File from './model/file';
 
-const COMMON_HEADERS = {
-    'content-type': 'text/plain; charset=utf-8',
-};
-
 const CONTENT_TYPE_JSON_HEADER = {
-    'content-type': 'application/json; charset=utf-8',
+    'content-type': 'application/json;charset=utf-8',
 };
 
 const FS_SERVICE = 'filesystem';
@@ -66,16 +62,19 @@ export function read(targetFilePath) {
  * @param {String} path Path of the folder
  * @param {String} name Name of the file
  * @param {String} content Content of the file
- * @param {Boolean} isCustomContent is content to be sent custom.
+ * @param {Boolean} isBase64Encoded is content to be sent encoded in base64.
  *
  * @returns {Promise} Resolves file path or reject with error.
  */
-export function createOrUpdate(path, name, content, isCustomContent) {
+export function createOrUpdate(path, name, content, isBase64Encoded) {
     const serviceEP = `${getServiceEndpoint(FS_SERVICE)}/write`;
-    // FIXME: Refactor backend params
-    const data = isCustomContent ? content : `location=${btoa(path)}&configName=${btoa(name)}&config=${
-                            encodeURIComponent(content)}`;
-    return axios.post(serviceEP, data, { headers: COMMON_HEADERS })
+    const data = {
+        path,
+        name,
+        content,
+        isBase64Encoded,
+    };
+    return axios.post(serviceEP, data, { headers: CONTENT_TYPE_JSON_HEADER })
         .then((response) => {
             return response.data;
         });
@@ -102,16 +101,16 @@ export function remove(path) {
 /**
  * Creates given file/folder in file system.
  *
- * @param {String} path Path of the file/folder
+ * @param {String} fullPath Path of the file/folder
  * @param {String} type file or folder
  * @param {String} content file content - if creating a file
  *
  * @returns {Promise} Resolves created file path or reject with error.
  */
-export function create(path, type, content) {
+export function create(fullPath, type, content) {
     const serviceEP = `${getServiceEndpoint(FS_SERVICE)}/create`;
     const data = {
-        path,
+        fullPath,
         type,
         content,
     };
@@ -173,7 +172,7 @@ export function exists(path) {
         path,
     };
     return new Promise((resolve, reject) => {
-        axios.post(endpoint, data, { headers: COMMON_HEADERS })
+        axios.post(endpoint, data, { headers: CONTENT_TYPE_JSON_HEADER })
             .then((response) => {
                 resolve(response.data);
             }).catch(error => reject(error));

--- a/composer/modules/web/src/plugins/export-diagram/dialogs/export-diagram-dialog.jsx
+++ b/composer/modules/web/src/plugins/export-diagram/dialogs/export-diagram-dialog.jsx
@@ -353,11 +353,9 @@ class ExportDiagramDialog extends React.Component {
      * @param {function} callServer - call back to server.
      * */
     sendPayload(location, configName, fileType, callServer) {
-        let payload = '';
-        const config = this.getSVG();
+        const svgContent = this.getSVG();
         if (fileType === 'SVG') {
-            payload = `location=${btoa(location)}&configName=${btoa(configName)}&config=${encodeURIComponent(config)}`;
-            callServer(payload);
+            callServer(btoa(svgContent));
         } else if (fileType === 'PNG') {
             const tab = $(('#bal-file-editor-' + this.props.file.id).replace(/(:|\.|\[|\]|\/|,|=)/g, '\\$1'));
             const svgElement = tab.find('.svg-container');
@@ -369,11 +367,9 @@ class ExportDiagramDialog extends React.Component {
                 const png = canvas.toDataURL('image/png');
                 let img = png.replace('data:image/png;base64,', '');
                 img = img.replace(' ', '+');
-                payload = `location=${btoa(location)}&configName=${btoa(configName)}`
-                    + `&imageFile=true&config=${encodeURIComponent(img)}`;
-                callServer(payload);
+                callServer(img);
             };
-            image.src = 'data:image/svg+xml;charset-utf-8,' + encodeURIComponent(config);
+            image.src = 'data:image/svg+xml;charset-utf-8,' + svgContent;
         }
     }
 


### PR DESCRIPTION
## Purpose
- Resolves: https://github.com/ballerina-lang/ballerina/issues/4504
- Refactor file-system service to remove redundant logic
- Restructure resource paths

## Goals
To fix the issue https://github.com/ballerina-lang/ballerina/issues/4504, we need to allow unicode chars in paths.

## Approach
Refactored file-system apis to accept a JSON POST payload without the need for sending base64 encoded paths over query param