### PR TITLE
Fixed missing return variables and return descriptions on docgen.

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -279,6 +279,7 @@ public class Generator {
                 returnParams.add(variable);
             }
         }
+        processedReturnAnnots.clear();
         return new FunctionDoc(functionName, description(functionNode), new ArrayList<>(), parameters, returnParams);
     }
 
@@ -310,6 +311,7 @@ public class Generator {
                 returnParams.add(variable);
             }
         }
+        processedReturnAnnots.clear();
         return new ActionDoc(actionName, description(actionNode), new ArrayList<>(),
                 parameters, returnParams);
     }

--- a/misc/docerina/src/main/resources/docerina-templates/html/page.hbs
+++ b/misc/docerina/src/main/resources/docerina-templates/html/page.hbs
@@ -244,7 +244,7 @@
                                         {{/each}}
                                     </table>
                                 {{/if}}
-                                {{#if bLangNode.retParams}}
+                                {{#if returnParams}}
                                     <p>
                                         <label class="table-header-text">Return Parameters:</label>
                                     </p>


### PR DESCRIPTION
## Purpose
> Fixing docerina issue.

## Goals
> Fixes https://github.com/ballerina-lang/docerina/issues/161

## Approach
> There was an error in the page.hbs file which neglected return variables of functions. Hence corrected the page.hbs file. Also the return descriptions were missing. This was fixed by clearing a hashmap which was used in tracking the positions of @Return annotations.
