### PR TITLE
Added skip test flag to js tests in composer

### DIFF
--- a/composer/modules/js-tests/pom.xml
+++ b/composer/modules/js-tests/pom.xml
@@ -39,6 +39,9 @@
                         <goals>
                             <goal>copy</goal>
                         </goals>
+                        <configuration>
+                            <skip>${maven.test.skip}</skip>
+                        </configuration>
                     </execution>
                 </executions>
                 <configuration>
@@ -65,6 +68,7 @@
                             <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
+                            <skip>${maven.test.skip}</skip>
                             <includeArtifactIds>ballerina-composer-web</includeArtifactIds>
                             <outputDirectory>${project.build.directory}/extracted-web</outputDirectory>
                             <overWriteReleases>false</overWriteReleases>
@@ -90,6 +94,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
+                            <skip>${maven.test.skip}</skip>
                             <target name="copy js files to target">
                                 <mkdir dir="${build.directory}/js-files-from-web" />
                                 <copy todir="${build.directory}/js-files-from-web" overwrite="true" flatten="true">
@@ -120,11 +125,11 @@
                         </goals>
                         <phase>initialize</phase>
                         <configuration>
+                            <skip>${maven.test.skip}</skip>
                             <executable>${npm.executable}</executable>
                             <arguments>
                                 <argument>install</argument>
                             </arguments>
-                            <skip>${skipTests}</skip>
                         </configuration>
                     </execution>
                     <execution>
@@ -139,7 +144,7 @@
                                 <argument>run</argument>
                                 <argument>compile</argument>
                             </arguments>
-                            <skip>${skipTests}</skip>
+                            <skip>${maven.test.skip}</skip>
                         </configuration>
                     </execution>
                     <execution>
@@ -155,7 +160,7 @@
                                 <argument>--</argument>
                                 <argument>--projectVersion=${project.version}</argument>
                             </arguments>
-                            <skip>${skipTests}</skip>
+                            <skip>${maven.test.skip}</skip>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Purpose
Skip the js tests from building by passing Dmaven.test.skip=true with the build.