### PR TITLE
Added correct position calculation for incorrect positions return for enum node

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/definition/util/DefinitionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/definition/util/DefinitionUtil.java
@@ -72,6 +72,9 @@ public class DefinitionUtil {
                         .filter(enm -> enm.name.getValue()
                                 .equals(definitionContext.get(NodeContextKeys.NAME_OF_NODE_KEY)))
                         .findAny().orElse(null);
+                // Fixing the position issue with enum node.
+                bLangNode.getPosition().eLine = bLangNode.getPosition().sLine;
+                bLangNode.getPosition().eCol = bLangNode.getPosition().sCol;
                 break;
             case ContextConstants.CONNECTOR:
                 bLangNode = currentBLangPackage.connectors.stream()


### PR DESCRIPTION
## Purpose
Locally fix the position calculation for the enum node to fix the issue mentioned in https://github.com/ballerina-lang/ballerina/issues/4582. But still this issue needs to be fixed from the ballerina side hence keeping the issue open.

## Goals
> This will fix the issue where enum node available in the package containing minus values making it difficult to get the range for go to definition on enums. With this PR go to definition support for enum is added.

## Approach
### Enum
![ezgif com-video-to-gif 13](https://user-images.githubusercontent.com/9109762/35916646-1a6d8314-0c31-11e8-913f-10433eac8b8b.gif)
