### PR TITLE
Improve add button colors and styles

### DIFF
--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/controllers/compilation-unit-ctrl.jsx
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/controllers/compilation-unit-ctrl.jsx
@@ -80,6 +80,7 @@ class CompilationUnitCtrl extends React.Component {
                     buttonX={0}
                     buttonY={0}
                     showAlways
+                    menuOverButton
                     buttonRadius={12}
                 >
                     <Menu>

--- a/composer/modules/web/src/plugins/ballerina/interactions/button.jsx
+++ b/composer/modules/web/src/plugins/ballerina/interactions/button.jsx
@@ -101,9 +101,8 @@ class Button extends React.Component {
         const btnX = this.props.buttonX;
         const btnY = this.props.buttonY;
         const btnRadius = this.props.buttonRadius;
-        const btnColor = this.props.buttonColor;
         const btnIconColor = this.props.buttonIconColor;
-        const IconOpacity = this.props.hideIconBackground ? 0 : 1;
+        let IconOpacity = 1;
         const buttonArea = btnRadius + 2 + (btnRadius / 4);
         const topPadding = (-3 * btnRadius) + (btnRadius / 2);
         let menuCss = 'interaction-menu-area';
@@ -113,6 +112,15 @@ class Button extends React.Component {
             display: 'block',
             position: 'relative',
             float: 'left' };
+
+        let buttonBackgroundClass = 'button-background';
+
+        if (this.props.type === 'secondary') {
+            buttonBackgroundClass = 'button-background-secondary';
+        } if (this.props.type === 'default') {
+            buttonBackgroundClass = 'button-background-default';
+            IconOpacity = 0;
+        }
 
         if (this.props.menuOverButton) {
             menuStyle.zIndex = 22;
@@ -141,8 +149,8 @@ class Button extends React.Component {
                         title={this.props.tooltip}
                     >
                         <i
-                            style={{ color: btnColor, opacity: IconOpacity }}
-                            className='fw button-background fw-circle fw-stack-2x'
+                            style={{ opacity: IconOpacity }}
+                            className={'fw fw-circle fw-stack-2x ' + buttonBackgroundClass}
                         />
                         <i style={{ color: btnIconColor }} className={`fw fw-${this.props.icon} fw-stack-1x`} />
                     </span>
@@ -156,14 +164,13 @@ class Button extends React.Component {
 }
 
 Button.propTypes = {
+    type: PropTypes.string,
     children: PropTypes.node,
     icon: PropTypes.string,
     buttonX: PropTypes.number,
     buttonY: PropTypes.number,
     buttonRadius: PropTypes.number,
-    buttonColor: PropTypes.string,
     buttonIconColor: PropTypes.string,
-    hideIconBackground: PropTypes.bool,
     showAlways: PropTypes.bool,
     onClick: PropTypes.func,
     tooltip: PropTypes.string,
@@ -172,6 +179,7 @@ Button.propTypes = {
 };
 
 Button.defaultProps = {
+    type: 'primary',
     icon: 'add',
     buttonX: 20,
     buttonY: 20,

--- a/composer/modules/web/src/plugins/ballerina/interactions/interaction.scss
+++ b/composer/modules/web/src/plugins/ballerina/interactions/interaction.scss
@@ -39,9 +39,24 @@
     cursor: pointer;
 }
 
-.button:hover, .button-show-always:hover .button-background{
+.button:hover, .button-show-always:hover .button-background {
     opacity: 1 !important;
 }
+
+.button:hover .button-background-secondary, .button-show-always:hover .button-background-secondary {
+    color:#f1772a;
+    opacity: 1 !important;
+}
+
+.button-background {
+    color:#f1772a;
+    text-shadow: 1px 1px 6px #acacac;
+}
+
+.button-background-secondary {
+    color:#dddddd;
+}
+
 
 @-webkit-keyframes appear-button {
     0% { opacity: 0;  font-size:0% }

--- a/composer/modules/web/src/plugins/ballerina/interactions/lifeline-button.jsx
+++ b/composer/modules/web/src/plugins/ballerina/interactions/lifeline-button.jsx
@@ -194,6 +194,7 @@ class LifelineButton extends React.Component {
                     buttonY={0}
                     showAlways
                     menuOverButton
+                    type='secondary'
                 >
                     <Menu>
                         <div className={connectorListCssClass}>

--- a/composer/modules/web/src/plugins/ballerina/interactions/worker-button.jsx
+++ b/composer/modules/web/src/plugins/ballerina/interactions/worker-button.jsx
@@ -241,6 +241,7 @@ class LifelineButton extends React.Component {
                     showAlways={this.props.showAlways}
                     buttonRadius={8}
                     menuOverButton
+                    type='secondary'
                 >
                     <Menu>
                         { !this.state.listConnectors && !this.state.listActions &&


### PR DESCRIPTION
## Purpose
Following improvements have been done

- Introduce button types as primary and secondary with different behaviors
- Include button colors in the css
- Include shadow for primary add buttons
- Include color change when secondary buttons being hovered

<img width="124" alt="screen shot 2018-02-07 at 9 04 56 pm" src="https://user-images.githubusercontent.com/2918812/35924753-ebba1e24-0c49-11e8-9c5f-e20db12329f2.png">

<img width="672" alt="screen shot 2018-02-07 at 9 06 00 pm" src="https://user-images.githubusercontent.com/2918812/35924781-04035efa-0c4a-11e8-9192-637f7b3d4f8b.png">
