### PR TITLE
Set custom diagnostic listener before initializing error strategy

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/TextDocumentServiceUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/TextDocumentServiceUtil.java
@@ -143,8 +143,8 @@ public class TextDocumentServiceUtil {
 
         List<org.ballerinalang.util.diagnostic.Diagnostic> balDiagnostics = new ArrayList<>();
         CollectDiagnosticListener diagnosticListener = new CollectDiagnosticListener(balDiagnostics);
-        BallerinaCustomErrorStrategy customErrorStrategy = new BallerinaCustomErrorStrategy(context);
         compilerContext.put(DiagnosticListener.class, diagnosticListener);
+        BallerinaCustomErrorStrategy customErrorStrategy = new BallerinaCustomErrorStrategy(context);
         compilerContext.put(DefaultErrorStrategy.class, customErrorStrategy);
 
         Compiler compiler = Compiler.getInstance(compilerContext);


### PR DESCRIPTION
This is needed to avoid DefaultDiagnosticListener being activated.
Default one prints to std.err and this will cause composer print
semantic errors to console.

