### PR TITLE
 Rename the WebSocket, Http Constants classes

### DIFF
--- a/composer/modules/server/services/ballerina-to-swagger/src/main/java/org/ballerinalang/composer/service/ballerina/swagger/service/SwaggerBallerinaConstants.java
+++ b/composer/modules/server/services/ballerina-to-swagger/src/main/java/org/ballerinalang/composer/service/ballerina/swagger/service/SwaggerBallerinaConstants.java
@@ -16,7 +16,7 @@
 
 package org.ballerinalang.composer.service.ballerina.swagger.service;
 
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 
 /**
  * This class will hold all constants related to swagger ballerina conversion.
@@ -25,11 +25,11 @@ public class SwaggerBallerinaConstants {
     public static final String RESOURCE_UUID_NAME = "x-UniqueResourceKey";
     public static final String VARIABLE_UUID_NAME = "x-UniqueVariableKey";
     public static final String HTTP_VERB_MATCHING_PATTERN = "(?i)|" +
-            Constants.ANNOTATION_METHOD_GET + "|" +
-            Constants.ANNOTATION_METHOD_PUT + "|" +
-            Constants.ANNOTATION_METHOD_POST + "|" +
-            Constants.ANNOTATION_METHOD_DELETE + "|" +
-            Constants.ANNOTATION_METHOD_OPTIONS + "|" +
-            Constants.ANNOTATION_METHOD_PATCH + "|" +
+            HttpConstants.ANNOTATION_METHOD_GET + "|" +
+            HttpConstants.ANNOTATION_METHOD_PUT + "|" +
+            HttpConstants.ANNOTATION_METHOD_POST + "|" +
+            HttpConstants.ANNOTATION_METHOD_DELETE + "|" +
+            HttpConstants.ANNOTATION_METHOD_OPTIONS + "|" +
+            HttpConstants.ANNOTATION_METHOD_PATCH + "|" +
             "HEAD";
 }

--- a/composer/modules/server/services/ballerina-to-swagger/src/main/java/org/ballerinalang/composer/service/ballerina/swagger/service/SwaggerResourceMapper.java
+++ b/composer/modules/server/services/ballerina-to-swagger/src/main/java/org/ballerinalang/composer/service/ballerina/swagger/service/SwaggerResourceMapper.java
@@ -40,7 +40,7 @@ import org.ballerinalang.model.tree.VariableNode;
 import org.ballerinalang.model.tree.expressions.AnnotationAttachmentAttributeNode;
 import org.ballerinalang.model.tree.expressions.AnnotationAttachmentAttributeValueNode;
 import org.ballerinalang.model.tree.expressions.LiteralNode;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -145,22 +145,22 @@ public class SwaggerResourceMapper {
         String httpOperation = operationAdaptor.getHttpOperation();
         Operation operation = operationAdaptor.getOperation();
         switch (httpOperation) {
-            case Constants.ANNOTATION_METHOD_GET:
+            case HttpConstants.ANNOTATION_METHOD_GET:
                 path.get(operation);
                 break;
-            case Constants.ANNOTATION_METHOD_PUT:
+            case HttpConstants.ANNOTATION_METHOD_PUT:
                 path.put(operation);
                 break;
-            case Constants.ANNOTATION_METHOD_POST:
+            case HttpConstants.ANNOTATION_METHOD_POST:
                 path.post(operation);
                 break;
-            case Constants.ANNOTATION_METHOD_DELETE:
+            case HttpConstants.ANNOTATION_METHOD_DELETE:
                 path.delete(operation);
                 break;
-            case Constants.ANNOTATION_METHOD_OPTIONS:
+            case HttpConstants.ANNOTATION_METHOD_OPTIONS:
                 path.options(operation);
                 break;
-            case Constants.ANNOTATION_METHOD_PATCH:
+            case HttpConstants.ANNOTATION_METHOD_PATCH:
                 path.patch(operation);
                 break;
             case "HEAD":
@@ -182,7 +182,7 @@ public class SwaggerResourceMapper {
         OperationAdaptor op = new OperationAdaptor();
         if (resource != null) {
             // Setting default values.
-            op.setHttpOperation(Constants.HTTP_METHOD_GET);
+            op.setHttpOperation(HttpConstants.HTTP_METHOD_GET);
             op.setPath('/' + resource.getName().getValue());
             Response response = new Response()
                     .description("Successful")

--- a/misc/swagger-ballerina/modules/ballerina-to-swagger-generator/src/main/java/org/ballerinalang/swagger/code/generator/BallerinaToSwaggerGenerator.java
+++ b/misc/swagger-ballerina/modules/ballerina-to-swagger-generator/src/main/java/org/ballerinalang/swagger/code/generator/BallerinaToSwaggerGenerator.java
@@ -17,7 +17,7 @@
 package org.ballerinalang.swagger.code.generator;
 
 import io.swagger.models.Swagger;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.swagger.code.generator.exception.SwaggerGenException;
 import org.ballerinalang.swagger.code.generator.util.SwaggerUtils;
 import org.ballerinalang.util.codegen.ServiceInfo;
@@ -38,7 +38,7 @@ public class BallerinaToSwaggerGenerator {
      */
     public static String generateSwagger(ServiceInfo serviceInfo) throws SwaggerGenException {
         if (null != serviceInfo.getProtocolPkgPath() &&
-                                                Constants.HTTP_PACKAGE_PATH.equals(serviceInfo.getProtocolPkgPath())) {
+                HttpConstants.HTTP_PACKAGE_PATH.equals(serviceInfo.getProtocolPkgPath())) {
             if (serviceInfo.getResourceInfoEntries().length > 0) {
                 SwaggerServiceMapper swaggerServiceMapper = new SwaggerServiceMapper();
                 Swagger swaggerDefinition = swaggerServiceMapper.convertServiceToSwagger(serviceInfo);

--- a/misc/swagger-ballerina/modules/ballerina-to-swagger-generator/src/main/java/org/ballerinalang/swagger/code/generator/SwaggerResourceMapper.java
+++ b/misc/swagger-ballerina/modules/ballerina-to-swagger-generator/src/main/java/org/ballerinalang/swagger/code/generator/SwaggerResourceMapper.java
@@ -34,7 +34,7 @@ import io.swagger.models.properties.BooleanProperty;
 import io.swagger.models.properties.IntegerProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.StringProperty;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.swagger.code.generator.util.SwaggerConstants;
 import org.ballerinalang.swagger.code.generator.util.SwaggerUtils;
 import org.ballerinalang.util.codegen.AnnAttachmentInfo;
@@ -78,22 +78,22 @@ class SwaggerResourceMapper {
             String httpOperation = operationAdaptor.getHttpOperation();
             Operation operation = operationAdaptor.getOperation();
             switch (httpOperation) {
-                case Constants.ANNOTATION_METHOD_GET:
+                case HttpConstants.ANNOTATION_METHOD_GET:
                     path.get(operation);
                     break;
-                case Constants.ANNOTATION_METHOD_PUT:
+                case HttpConstants.ANNOTATION_METHOD_PUT:
                     path.put(operation);
                     break;
-                case Constants.ANNOTATION_METHOD_POST:
+                case HttpConstants.ANNOTATION_METHOD_POST:
                     path.post(operation);
                     break;
-                case Constants.ANNOTATION_METHOD_DELETE:
+                case HttpConstants.ANNOTATION_METHOD_DELETE:
                     path.delete(operation);
                     break;
-                case Constants.ANNOTATION_METHOD_OPTIONS:
+                case HttpConstants.ANNOTATION_METHOD_OPTIONS:
                     path.options(operation);
                     break;
-                case Constants.ANNOTATION_METHOD_PATCH:
+                case HttpConstants.ANNOTATION_METHOD_PATCH:
                     path.patch(operation);
                     break;
                 case "HEAD":
@@ -117,7 +117,7 @@ class SwaggerResourceMapper {
         OperationAdaptor op = new OperationAdaptor();
         if (resource != null) {
             // Setting default values.
-            op.setHttpOperation(Constants.HTTP_METHOD_GET);
+            op.setHttpOperation(HttpConstants.HTTP_METHOD_GET);
             op.setPath('/' + resource.getName());
             Response response = new Response()
                     .description("Successful")
@@ -427,13 +427,13 @@ class SwaggerResourceMapper {
      * @param operation The swagger operation.
      */
     private void parseProducesAnnotationAttachment(ResourceInfo resource, Operation operation) {
-        AnnAttachmentInfo rConfigAnnAtchmnt = resource.getAnnotationAttachmentInfo(Constants.HTTP_PACKAGE_PATH,
-                Constants.ANN_NAME_RESOURCE_CONFIG);
+        AnnAttachmentInfo rConfigAnnAtchmnt = resource.getAnnotationAttachmentInfo(
+                HttpConstants.HTTP_PACKAGE_PATH, HttpConstants.ANN_NAME_RESOURCE_CONFIG);
         if (rConfigAnnAtchmnt == null) {
             return;
         }
         AnnAttributeValue producesAttrVal = rConfigAnnAtchmnt
-                .getAttributeValue(Constants.ANN_RESOURCE_ATTR_PRODUCES);
+                .getAttributeValue(HttpConstants.ANN_RESOURCE_ATTR_PRODUCES);
         if (producesAttrVal == null) {
             return;
         }
@@ -456,13 +456,13 @@ class SwaggerResourceMapper {
      * @param operation The swagger operation.
      */
     private void parseConsumesAnnotationAttachment(ResourceInfo resource, Operation operation) {
-        AnnAttachmentInfo rConfigAnnAtchmnt = resource.getAnnotationAttachmentInfo(Constants.HTTP_PACKAGE_PATH,
-                Constants.ANN_NAME_RESOURCE_CONFIG);
+        AnnAttachmentInfo rConfigAnnAtchmnt = resource.getAnnotationAttachmentInfo(
+                HttpConstants.HTTP_PACKAGE_PATH, HttpConstants.ANN_NAME_RESOURCE_CONFIG);
         if (rConfigAnnAtchmnt == null) {
             return;
         }
         AnnAttributeValue consumesAttrVal = rConfigAnnAtchmnt
-                .getAttributeValue(Constants.ANN_RESOURCE_ATTR_CONSUMES);
+                .getAttributeValue(HttpConstants.ANN_RESOURCE_ATTR_CONSUMES);
         if (consumesAttrVal == null) {
             return;
         }
@@ -477,13 +477,13 @@ class SwaggerResourceMapper {
      * @param operationAdaptor The operation adaptor.
      */
     private void parsePathAnnotationAttachment(ResourceInfo resource, OperationAdaptor operationAdaptor) {
-        AnnAttachmentInfo rConfigAnnAtchmnt = resource.getAnnotationAttachmentInfo(Constants.HTTP_PACKAGE_PATH,
-                Constants.ANN_NAME_RESOURCE_CONFIG);
+        AnnAttachmentInfo rConfigAnnAtchmnt = resource.getAnnotationAttachmentInfo(
+                HttpConstants.HTTP_PACKAGE_PATH, HttpConstants.ANN_NAME_RESOURCE_CONFIG);
         if (rConfigAnnAtchmnt == null) {
             return;
         }
         AnnAttributeValue pathAttrVal = rConfigAnnAtchmnt
-                .getAttributeValue(Constants.ANN_RESOURCE_ATTR_PATH);
+                .getAttributeValue(HttpConstants.ANN_RESOURCE_ATTR_PATH);
 
         if (null != pathAttrVal && pathAttrVal.getStringValue() != null) {
             operationAdaptor.setPath(pathAttrVal.getStringValue());
@@ -497,20 +497,21 @@ class SwaggerResourceMapper {
      * @param operationAdaptor The operation adaptor which stored the http method.
      */
     private void parseHttpMethodAnnotationAttachment(ResourceInfo resource, OperationAdaptor operationAdaptor) {
-        if (null != resource.getAnnotationAttachmentInfo(Constants.HTTP_PACKAGE_PATH, Constants.HTTP_METHOD_GET)) {
-            operationAdaptor.setHttpOperation(Constants.HTTP_METHOD_GET);
-        } else if (null != resource.getAnnotationAttachmentInfo(Constants.HTTP_PACKAGE_PATH,
-                Constants.HTTP_METHOD_POST)) {
-            operationAdaptor.setHttpOperation(Constants.HTTP_METHOD_POST);
-        } else if (null != resource.getAnnotationAttachmentInfo(Constants.HTTP_PACKAGE_PATH,
-                Constants.HTTP_METHOD_PUT)) {
-            operationAdaptor.setHttpOperation(Constants.HTTP_METHOD_PUT);
-        } else if (null != resource.getAnnotationAttachmentInfo(Constants.HTTP_PACKAGE_PATH,
-                Constants.HTTP_METHOD_DELETE)) {
-            operationAdaptor.setHttpOperation(Constants.HTTP_METHOD_DELETE);
-        } else if (null != resource.getAnnotationAttachmentInfo(Constants.HTTP_PACKAGE_PATH,
-                Constants.HTTP_METHOD_HEAD)) {
-            operationAdaptor.setHttpOperation(Constants.HTTP_METHOD_HEAD);
+        if (null != resource.getAnnotationAttachmentInfo(HttpConstants.HTTP_PACKAGE_PATH,
+                                                         HttpConstants.HTTP_METHOD_GET)) {
+            operationAdaptor.setHttpOperation(HttpConstants.HTTP_METHOD_GET);
+        } else if (null != resource.getAnnotationAttachmentInfo(HttpConstants.HTTP_PACKAGE_PATH,
+                                                                HttpConstants.HTTP_METHOD_POST)) {
+            operationAdaptor.setHttpOperation(HttpConstants.HTTP_METHOD_POST);
+        } else if (null != resource.getAnnotationAttachmentInfo(HttpConstants.HTTP_PACKAGE_PATH,
+                                                                HttpConstants.HTTP_METHOD_PUT)) {
+            operationAdaptor.setHttpOperation(HttpConstants.HTTP_METHOD_PUT);
+        } else if (null != resource.getAnnotationAttachmentInfo(HttpConstants.HTTP_PACKAGE_PATH,
+                                                                HttpConstants.HTTP_METHOD_DELETE)) {
+            operationAdaptor.setHttpOperation(HttpConstants.HTTP_METHOD_DELETE);
+        } else if (null != resource.getAnnotationAttachmentInfo(HttpConstants.HTTP_PACKAGE_PATH,
+                                                                HttpConstants.HTTP_METHOD_HEAD)) {
+            operationAdaptor.setHttpOperation(HttpConstants.HTTP_METHOD_HEAD);
         }
     }
 

--- a/misc/swagger-ballerina/modules/ballerina-to-swagger-generator/src/main/java/org/ballerinalang/swagger/code/generator/SwaggerServiceMapper.java
+++ b/misc/swagger-ballerina/modules/ballerina-to-swagger-generator/src/main/java/org/ballerinalang/swagger/code/generator/SwaggerServiceMapper.java
@@ -28,7 +28,7 @@ import io.swagger.models.auth.BasicAuthDefinition;
 import io.swagger.models.auth.In;
 import io.swagger.models.auth.OAuth2Definition;
 import io.swagger.models.auth.SecuritySchemeDefinition;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.swagger.code.generator.model.Developer;
 import org.ballerinalang.swagger.code.generator.model.Organization;
 import org.ballerinalang.swagger.code.generator.util.SwaggerConstants;
@@ -364,19 +364,19 @@ class SwaggerServiceMapper {
      */
     private void parseConfigAnnotationAttachment(ServiceInfo service, Swagger swagger) {
         AnnAttachmentInfo httpConfigAnnotationAttachment = service.getAnnotationAttachmentInfo(
-                Constants.HTTP_PACKAGE_PATH, Constants.ANN_NAME_CONFIG);
+                HttpConstants.HTTP_PACKAGE_PATH, HttpConstants.ANN_NAME_CONFIG);
         if (null != httpConfigAnnotationAttachment) {
             Map<String, AnnAttributeValue> httpConfigAnnAttributeValueMap = SwaggerUtils.convertToAttributeMap
                     (httpConfigAnnotationAttachment);
-            if (null != httpConfigAnnAttributeValueMap.get(Constants.ANN_CONFIG_ATTR_BASE_PATH)) {
-                swagger.setBasePath(httpConfigAnnAttributeValueMap.get(Constants.ANN_CONFIG_ATTR_BASE_PATH)
+            if (null != httpConfigAnnAttributeValueMap.get(HttpConstants.ANN_CONFIG_ATTR_BASE_PATH)) {
+                swagger.setBasePath(httpConfigAnnAttributeValueMap.get(HttpConstants.ANN_CONFIG_ATTR_BASE_PATH)
                         .getStringValue());
             }
-            if (null != httpConfigAnnAttributeValueMap.get(Constants.ANN_CONFIG_ATTR_HOST) &&
-                null != httpConfigAnnAttributeValueMap.get(Constants.ANN_CONFIG_ATTR_PORT)) {
-                swagger.setHost(httpConfigAnnAttributeValueMap.get(Constants.ANN_CONFIG_ATTR_HOST)
+            if (null != httpConfigAnnAttributeValueMap.get(HttpConstants.ANN_CONFIG_ATTR_HOST) &&
+                null != httpConfigAnnAttributeValueMap.get(HttpConstants.ANN_CONFIG_ATTR_PORT)) {
+                swagger.setHost(httpConfigAnnAttributeValueMap.get(HttpConstants.ANN_CONFIG_ATTR_HOST)
                                         .getStringValue() + ":" +
-                                httpConfigAnnAttributeValueMap.get(Constants.ANN_CONFIG_ATTR_PORT).getIntValue());
+                                httpConfigAnnAttributeValueMap.get(HttpConstants.ANN_CONFIG_ATTR_PORT).getIntValue());
             }
         }
     }

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/test/StartService.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/test/StartService.java
@@ -30,8 +30,9 @@ import org.ballerinalang.natives.annotations.Attribute;
 import org.ballerinalang.natives.annotations.BallerinaAnnotation;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
 import org.ballerinalang.net.http.HttpConnectionManager;
+import org.ballerinalang.net.http.HttpConstants;
+import org.ballerinalang.net.ws.WebSocketConstants;
 import org.ballerinalang.testerina.core.TesterinaRegistry;
 import org.ballerinalang.util.codegen.AnnAttachmentInfo;
 import org.ballerinalang.util.codegen.AnnAttributeValue;
@@ -161,8 +162,8 @@ public class StartService extends AbstractNativeFunction {
 
     private String getServiceURL(ServiceInfo service) {
         try {
-            AnnAttachmentInfo annotationInfo = service.getAnnotationAttachmentInfo(Constants
-                    .HTTP_PACKAGE_PATH, Constants.ANN_NAME_CONFIG);
+            AnnAttachmentInfo annotationInfo = service.getAnnotationAttachmentInfo(HttpConstants
+                    .HTTP_PACKAGE_PATH, HttpConstants.ANN_NAME_CONFIG);
 
             String basePath = discoverBasePathFrom(service, annotationInfo);
             Set<ListenerConfiguration> listenerConfigurationSet = getListenerConfig(annotationInfo);
@@ -212,21 +213,22 @@ public class StartService extends AbstractNativeFunction {
     }
     
     private void extractBasicConfig(AnnAttachmentInfo configInfo, Set<ListenerConfiguration> listenerConfSet) {
-        AnnAttributeValue hostAttrVal = configInfo.getAttributeValue(Constants.ANN_CONFIG_ATTR_HOST);
-        AnnAttributeValue portAttrVal = configInfo.getAttributeValue(Constants.ANN_CONFIG_ATTR_PORT);
-        AnnAttributeValue keepAliveAttrVal = configInfo.getAttributeValue(Constants.ANN_CONFIG_ATTR_KEEP_ALIVE);
-        AnnAttributeValue transferEncoding = configInfo.getAttributeValue(Constants.ANN_CONFIG_ATTR_TRANSFER_ENCODING);
-        AnnAttributeValue chunking = configInfo.getAttributeValue(Constants.ANN_CONFIG_ATTR_CHUNKING);
+        AnnAttributeValue hostAttrVal = configInfo.getAttributeValue(HttpConstants.ANN_CONFIG_ATTR_HOST);
+        AnnAttributeValue portAttrVal = configInfo.getAttributeValue(HttpConstants.ANN_CONFIG_ATTR_PORT);
+        AnnAttributeValue keepAliveAttrVal = configInfo.getAttributeValue(HttpConstants.ANN_CONFIG_ATTR_KEEP_ALIVE);
+        AnnAttributeValue transferEncoding = configInfo.getAttributeValue(
+                HttpConstants.ANN_CONFIG_ATTR_TRANSFER_ENCODING);
+        AnnAttributeValue chunking = configInfo.getAttributeValue(HttpConstants.ANN_CONFIG_ATTR_CHUNKING);
         
         ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
         if (portAttrVal != null && portAttrVal.getIntValue() > 0) {
             listenerConfiguration.setPort(Math.toIntExact(portAttrVal.getIntValue()));
             
-            listenerConfiguration.setScheme(Constants.PROTOCOL_HTTP);
+            listenerConfiguration.setScheme(HttpConstants.PROTOCOL_HTTP);
             if (hostAttrVal != null && hostAttrVal.getStringValue() != null) {
                 listenerConfiguration.setHost(hostAttrVal.getStringValue());
             } else {
-                listenerConfiguration.setHost(Constants.HTTP_DEFAULT_HOST);
+                listenerConfiguration.setHost(HttpConstants.HTTP_DEFAULT_HOST);
             }
             
             if (keepAliveAttrVal != null) {
@@ -237,7 +239,7 @@ public class StartService extends AbstractNativeFunction {
             
             // For the moment we don't have to pass it down to transport as we only support
             // chunking. Once we start supporting gzip, deflate, etc, we need to parse down the config.
-            if (transferEncoding != null && !Constants.ANN_CONFIG_ATTR_CHUNKING
+            if (transferEncoding != null && !HttpConstants.ANN_CONFIG_ATTR_CHUNKING
                     .equalsIgnoreCase(transferEncoding.getStringValue())) {
                 throw new BallerinaConnectorException("Unsupported configuration found for Transfer-Encoding : "
                                                       + transferEncoding.getStringValue());
@@ -258,11 +260,11 @@ public class StartService extends AbstractNativeFunction {
     
     public ChunkConfig getChunkConfig(String chunking) {
         ChunkConfig chunkConfig;
-        if (Constants.CHUNKING_AUTO.equalsIgnoreCase(chunking)) {
+        if (HttpConstants.CHUNKING_AUTO.equalsIgnoreCase(chunking)) {
             chunkConfig = ChunkConfig.AUTO;
-        } else if (Constants.CHUNKING_ALWAYS.equalsIgnoreCase(chunking)) {
+        } else if (HttpConstants.CHUNKING_ALWAYS.equalsIgnoreCase(chunking)) {
             chunkConfig = ChunkConfig.ALWAYS;
-        } else if (Constants.CHUNKING_NEVER.equalsIgnoreCase(chunking)) {
+        } else if (HttpConstants.CHUNKING_NEVER.equalsIgnoreCase(chunking)) {
             chunkConfig = ChunkConfig.NEVER;
         } else {
             throw new BallerinaConnectorException("Invalid configuration found for Transfer-Encoding : " + chunking);
@@ -273,38 +275,39 @@ public class StartService extends AbstractNativeFunction {
     private void extractHttpsConfig(AnnAttachmentInfo configInfo, Set<ListenerConfiguration> listenerConfSet) {
         // Retrieve secure port from either http of ws configuration annotation.
         AnnAttributeValue httpsPortAttrVal;
-        if (configInfo.getAttributeValue(Constants.ANN_CONFIG_ATTR_HTTPS_PORT) == null) {
+        if (configInfo.getAttributeValue(HttpConstants.ANN_CONFIG_ATTR_HTTPS_PORT) == null) {
             httpsPortAttrVal =
-                    configInfo.getAttributeValue(org.ballerinalang.net.ws.Constants.ANN_CONFIG_ATTR_WSS_PORT);
+                    configInfo.getAttributeValue(WebSocketConstants.ANN_CONFIG_ATTR_WSS_PORT);
         } else {
-            httpsPortAttrVal = configInfo.getAttributeValue(Constants.ANN_CONFIG_ATTR_HTTPS_PORT);
+            httpsPortAttrVal = configInfo.getAttributeValue(HttpConstants.ANN_CONFIG_ATTR_HTTPS_PORT);
         }
-        
-        AnnAttributeValue keyStoreFileAttrVal = configInfo.getAttributeValue(Constants.ANN_CONFIG_ATTR_KEY_STORE_FILE);
-        AnnAttributeValue keyStorePasswordAttrVal =
-                                                configInfo.getAttributeValue(Constants.ANN_CONFIG_ATTR_KEY_STORE_PASS);
-        AnnAttributeValue certPasswordAttrVal = configInfo.getAttributeValue(Constants.ANN_CONFIG_ATTR_CERT_PASS);
-        AnnAttributeValue trustStoreFileAttrVal =
-                                            configInfo.getAttributeValue(Constants.ANN_CONFIG_ATTR_TRUST_STORE_FILE);
-        AnnAttributeValue trustStorePasswordAttrVal =
-                                            configInfo.getAttributeValue(Constants.ANN_CONFIG_ATTR_TRUST_STORE_PASS);
-        AnnAttributeValue sslVerifyClientAttrVal =
-                                            configInfo.getAttributeValue(Constants.ANN_CONFIG_ATTR_SSL_VERIFY_CLIENT);
+
+        AnnAttributeValue keyStoreFileAttrVal = configInfo.getAttributeValue(
+                HttpConstants.ANN_CONFIG_ATTR_KEY_STORE_FILE);
+        AnnAttributeValue keyStorePasswordAttrVal = configInfo.getAttributeValue(
+                HttpConstants.ANN_CONFIG_ATTR_KEY_STORE_PASS);
+        AnnAttributeValue certPasswordAttrVal = configInfo.getAttributeValue(HttpConstants.ANN_CONFIG_ATTR_CERT_PASS);
+        AnnAttributeValue trustStoreFileAttrVal = configInfo.getAttributeValue(
+                HttpConstants.ANN_CONFIG_ATTR_TRUST_STORE_FILE);
+        AnnAttributeValue trustStorePasswordAttrVal = configInfo.getAttributeValue(
+                HttpConstants.ANN_CONFIG_ATTR_TRUST_STORE_PASS);
+        AnnAttributeValue sslVerifyClientAttrVal = configInfo.getAttributeValue(
+                HttpConstants.ANN_CONFIG_ATTR_SSL_VERIFY_CLIENT);
         AnnAttributeValue sslEnabledProtocolsAttrVal = configInfo
-                .getAttributeValue(Constants.ANN_CONFIG_ATTR_SSL_ENABLED_PROTOCOLS);
-        AnnAttributeValue ciphersAttrVal = configInfo.getAttributeValue(Constants.ANN_CONFIG_ATTR_CIPHERS);
-        AnnAttributeValue sslProtocolAttrVal = configInfo.getAttributeValue(Constants.ANN_CONFIG_ATTR_SSL_PROTOCOL);
-        AnnAttributeValue hostAttrVal = configInfo.getAttributeValue(Constants.ANN_CONFIG_ATTR_HOST);
+                .getAttributeValue(HttpConstants.ANN_CONFIG_ATTR_SSL_ENABLED_PROTOCOLS);
+        AnnAttributeValue ciphersAttrVal = configInfo.getAttributeValue(HttpConstants.ANN_CONFIG_ATTR_CIPHERS);
+        AnnAttributeValue sslProtocolAttrVal = configInfo.getAttributeValue(HttpConstants.ANN_CONFIG_ATTR_SSL_PROTOCOL);
+        AnnAttributeValue hostAttrVal = configInfo.getAttributeValue(HttpConstants.ANN_CONFIG_ATTR_HOST);
         
         ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
         if (httpsPortAttrVal != null && httpsPortAttrVal.getIntValue() > 0) {
             listenerConfiguration.setPort(Math.toIntExact(httpsPortAttrVal.getIntValue()));
-            listenerConfiguration.setScheme(Constants.PROTOCOL_HTTPS);
+            listenerConfiguration.setScheme(HttpConstants.PROTOCOL_HTTPS);
             
             if (hostAttrVal != null && hostAttrVal.getStringValue() != null) {
                 listenerConfiguration.setHost(hostAttrVal.getStringValue());
             } else {
-                listenerConfiguration.setHost(Constants.HTTP_DEFAULT_HOST);
+                listenerConfiguration.setHost(HttpConstants.HTTP_DEFAULT_HOST);
             }
             
             if (keyStoreFileAttrVal == null || keyStoreFileAttrVal.getStringValue() == null) {
@@ -331,7 +334,7 @@ public class StartService extends AbstractNativeFunction {
                 throw new BallerinaException("Truststore password value must be provided to enable Mutual SSL");
             }
             
-            listenerConfiguration.setTLSStoreType(Constants.PKCS_STORE_TYPE);
+            listenerConfiguration.setTLSStoreType(HttpConstants.PKCS_STORE_TYPE);
             listenerConfiguration.setKeyStoreFile(keyStoreFileAttrVal.getStringValue());
             listenerConfiguration.setKeyStorePass(keyStorePasswordAttrVal.getStringValue());
             listenerConfiguration.setCertPass(certPasswordAttrVal.getStringValue());
@@ -349,13 +352,13 @@ public class StartService extends AbstractNativeFunction {
             List<Parameter> serverParams = new ArrayList<>();
             Parameter serverCiphers;
             if (sslEnabledProtocolsAttrVal != null && sslEnabledProtocolsAttrVal.getStringValue() != null) {
-                serverCiphers = new Parameter(Constants.ANN_CONFIG_ATTR_SSL_ENABLED_PROTOCOLS,
-                        sslEnabledProtocolsAttrVal.getStringValue());
+                serverCiphers = new Parameter(HttpConstants.ANN_CONFIG_ATTR_SSL_ENABLED_PROTOCOLS,
+                                              sslEnabledProtocolsAttrVal.getStringValue());
                 serverParams.add(serverCiphers);
             }
             
             if (ciphersAttrVal != null && ciphersAttrVal.getStringValue() != null) {
-                serverCiphers = new Parameter(Constants.ANN_CONFIG_ATTR_CIPHERS, ciphersAttrVal.getStringValue());
+                serverCiphers = new Parameter(HttpConstants.ANN_CONFIG_ATTR_CIPHERS, ciphersAttrVal.getStringValue());
                 serverParams.add(serverCiphers);
             }
             
@@ -378,17 +381,17 @@ public class StartService extends AbstractNativeFunction {
         String basePath = service.getName();
         if (annotationInfo != null) {
             AnnAttributeValue annAttributeValue = annotationInfo.getAttributeValue
-                    (Constants.ANN_CONFIG_ATTR_BASE_PATH);
+                    (HttpConstants.ANN_CONFIG_ATTR_BASE_PATH);
             if (annAttributeValue != null && annAttributeValue.getStringValue() != null) {
                 if (annAttributeValue.getStringValue().trim().isEmpty()) {
-                    basePath = Constants.DEFAULT_BASE_PATH;
+                    basePath = HttpConstants.DEFAULT_BASE_PATH;
                 } else {
                     basePath = annAttributeValue.getStringValue();
                 }
             }
         }
-        if (!basePath.startsWith(Constants.DEFAULT_BASE_PATH)) {
-            basePath = Constants.DEFAULT_BASE_PATH.concat(basePath);
+        if (!basePath.startsWith(HttpConstants.DEFAULT_BASE_PATH)) {
+            basePath = HttpConstants.DEFAULT_BASE_PATH.concat(basePath);
         }
         return basePath;
     }

--- a/stdlib/ballerina-http/findbugs-exclude.xml
+++ b/stdlib/ballerina-http/findbugs-exclude.xml
@@ -33,9 +33,6 @@
         <Class name="org.ballerinalang.net.uri.parser.SimpleSplitStringExpression"/>
     </Match>
     <Match>
-        <Class name="org.ballerinalang.net.ws.Constants"/>
-    </Match>
-    <Match>
         <Class name="org.ballerinalang.net.ws.WebSocketService"/>
     </Match>
     <Match>

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/BallerinaHTTPConnectorListener.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/BallerinaHTTPConnectorListener.java
@@ -48,9 +48,9 @@ public class BallerinaHTTPConnectorListener implements HttpConnectorListener {
         //TODO below should be fixed properly
         //basically need to find a way to pass information from server connector side to client connector side
         Map<String, Object> properties = null;
-        if (httpCarbonMessage.getProperty(Constants.SRC_HANDLER) != null) {
-            Object srcHandler = httpCarbonMessage.getProperty(Constants.SRC_HANDLER);
-            properties = Collections.singletonMap(Constants.SRC_HANDLER, srcHandler);
+        if (httpCarbonMessage.getProperty(HttpConstants.SRC_HANDLER) != null) {
+            Object srcHandler = httpCarbonMessage.getProperty(HttpConstants.SRC_HANDLER);
+            properties = Collections.singletonMap(HttpConstants.SRC_HANDLER, srcHandler);
         }
         BValue[] signatureParams = HttpDispatcher.getSignatureParameters(httpResource, httpCarbonMessage);
         ConnectorFuture future = Executor.submit(httpResource.getBalResource(), properties, signatureParams);

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/BallerinaHttpServerConnector.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/BallerinaHttpServerConnector.java
@@ -27,8 +27,8 @@ import org.ballerinalang.net.ws.WebSocketServicesRegistry;
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.ballerinalang.net.ws.Constants.PROTOCOL_PACKAGE_HTTP;
-import static org.ballerinalang.net.ws.Constants.PROTOCOL_PACKAGE_WS;
+import static org.ballerinalang.net.http.HttpConstants.PROTOCOL_PACKAGE_HTTP;
+import static org.ballerinalang.net.ws.WebSocketConstants.PROTOCOL_PACKAGE_WS;
 
 /**
  * {@code HttpServerConnector} This is the http implementation for the {@code BallerinaServerConnector} API.

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/CorsHeaderGenerator.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/CorsHeaderGenerator.java
@@ -50,8 +50,8 @@ public class CorsHeaderGenerator {
         Map<String, String> responseHeaders = null;
         CorsHeaders resourceCors;
         if (isSimpleRequest) {
-            resourceCors = (CorsHeaders) requestMsg.getProperty(Constants.RESOURCES_CORS);
-            String origin = requestMsg.getHeader(Constants.ORIGIN);
+            resourceCors = (CorsHeaders) requestMsg.getProperty(HttpConstants.RESOURCES_CORS);
+            String origin = requestMsg.getHeader(HttpConstants.ORIGIN);
             //resourceCors cannot be null here
             if (origin == null || !resourceCors.isAvailable()) {
                 return;
@@ -60,7 +60,7 @@ public class CorsHeaderGenerator {
                 isCorsResponseHeadersAvailable = true;
             }
         } else {
-            String origin = requestMsg.getHeader(Constants.ORIGIN);
+            String origin = requestMsg.getHeader(HttpConstants.ORIGIN);
             if (origin == null) {
                 return;
             }
@@ -72,7 +72,7 @@ public class CorsHeaderGenerator {
             responseHeaders.entrySet().stream().forEach(header -> {
                 responseMsg.setHeader(header.getKey(), header.getValue());
             });
-            responseMsg.removeHeader(Constants.ALLOW);
+            responseMsg.removeHeader(HttpConstants.ALLOW);
         }
     }
 
@@ -106,7 +106,7 @@ public class CorsHeaderGenerator {
         }
         String origin = requestOrigins.get(0);
         //6.2.3 - request must have access-control-request-method, must be single-valued
-        List<String> requestMethods = getHeaderValues(Constants.AC_REQUEST_METHOD, cMsg);
+        List<String> requestMethods = getHeaderValues(HttpConstants.AC_REQUEST_METHOD, cMsg);
         if (requestMethods == null || requestMethods.size() != 1) {
             String error = requestMethods == null ? "Access-Control-Request-Method header is unavailable" :
                     "Access-Control-Request-Method header value must be single-valued";
@@ -131,7 +131,7 @@ public class CorsHeaderGenerator {
             return null;
         }
         //6.2.4 - get list of request headers.
-        List<String> requestHeaders = getHeaderValues(Constants.AC_REQUEST_HEADERS, cMsg);
+        List<String> requestHeaders = getHeaderValues(HttpConstants.AC_REQUEST_HEADERS, cMsg);
         if (!isEffectiveHeader(requestHeaders, resourceCors.getAllowHeaders())) {
             bLog.info(action + "header field parsing failed");
             return null;
@@ -139,13 +139,13 @@ public class CorsHeaderGenerator {
         //6.2.7 - set origin and credentials
         setAllowOriginAndCredentials(Arrays.asList(origin), resourceCors, responseHeaders);
         //6.2.9 - set allow-methods
-        responseHeaders.put(Constants.AC_ALLOW_METHODS, requestMethod);
+        responseHeaders.put(HttpConstants.AC_ALLOW_METHODS, requestMethod);
         //6.2.10 - set allow-headers
         if (requestHeaders != null) {
-            responseHeaders.put(Constants.AC_ALLOW_HEADERS, DispatcherUtil.concatValues(requestHeaders, false));
+            responseHeaders.put(HttpConstants.AC_ALLOW_HEADERS, DispatcherUtil.concatValues(requestHeaders, false));
         }
         //6.2.8 - set max-age
-        responseHeaders.put(Constants.AC_MAX_AGE, String.valueOf(resourceCors.getMaxAge()));
+        responseHeaders.put(HttpConstants.AC_MAX_AGE, String.valueOf(resourceCors.getMaxAge()));
         return responseHeaders;
     }
 
@@ -179,7 +179,7 @@ public class CorsHeaderGenerator {
     }
 
     private static CorsHeaders getResourceCors(HTTPCarbonMessage cMsg, String requestMethod) {
-        List<HttpResource> resources = (List<HttpResource>) cMsg.getProperty(Constants.PREFLIGHT_RESOURCES);
+        List<HttpResource> resources = (List<HttpResource>) cMsg.getProperty(HttpConstants.PREFLIGHT_RESOURCES);
         if (resources == null) {
             return null;
         }
@@ -188,11 +188,11 @@ public class CorsHeaderGenerator {
                 return resource.getCorsHeaders();
             }
         }
-        if (!requestMethod.equals(Constants.HTTP_METHOD_HEAD)) {
+        if (!requestMethod.equals(HttpConstants.HTTP_METHOD_HEAD)) {
             return null;
         }
         for (HttpResource resource : resources) {
-            if (resource.getMethods() != null && resource.getMethods().contains(Constants.HTTP_METHOD_GET)) {
+            if (resource.getMethods() != null && resource.getMethods().contains(HttpConstants.HTTP_METHOD_GET)) {
                 return resource.getCorsHeaders();
             }
         }
@@ -216,7 +216,7 @@ public class CorsHeaderGenerator {
         }
         String exposeHeaderResponse = DispatcherUtil.concatValues(exposeHeaders, false);
         if (!exposeHeaderResponse.isEmpty()) {
-            respHeaders.put(Constants.AC_EXPOSE_HEADERS, exposeHeaderResponse);
+            respHeaders.put(HttpConstants.AC_EXPOSE_HEADERS, exposeHeaderResponse);
         }
     }
 
@@ -224,9 +224,9 @@ public class CorsHeaderGenerator {
             , Map<String, String> responseHeaders) {
         int allowCreds = resCors.getAllowCredentials();
         if (allowCreds == 1) {
-            responseHeaders.put(Constants.AC_ALLOW_CREDENTIALS, String.valueOf(true));
+            responseHeaders.put(HttpConstants.AC_ALLOW_CREDENTIALS, String.valueOf(true));
         }
-        responseHeaders.put(Constants.AC_ALLOW_ORIGIN, DispatcherUtil.concatValues(effectiveOrigins, true));
+        responseHeaders.put(HttpConstants.AC_ALLOW_ORIGIN, DispatcherUtil.concatValues(effectiveOrigins, true));
     }
 
     private static List<String> getOriginValues(String originValue) {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/CorsPopulator.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/CorsPopulator.java
@@ -34,7 +34,7 @@ public class CorsPopulator {
 
     public static void populateServiceCors(HttpService service) {
         CorsHeaders corsHeaders = populateAndGetCorsHeaders(
-                HttpUtil.getServiceConfigAnnotation(service.getBalService(), Constants.HTTP_PACKAGE_PATH));
+                HttpUtil.getServiceConfigAnnotation(service.getBalService(), HttpConstants.HTTP_PACKAGE_PATH));
         service.setCorsHeaders(corsHeaders);
         if (!corsHeaders.isAvailable()) {
             return;
@@ -49,7 +49,7 @@ public class CorsPopulator {
 
     public static void processResourceCors(HttpResource resource, HttpService service) {
         CorsHeaders corsHeaders = populateAndGetCorsHeaders(
-                HttpUtil.getResourceConfigAnnotation(resource.getBalResource(), Constants.HTTP_PACKAGE_PATH));
+                HttpUtil.getResourceConfigAnnotation(resource.getBalResource(), HttpConstants.HTTP_PACKAGE_PATH));
         if (!corsHeaders.isAvailable()) {
             //resource doesn't have cors headers, hence use service cors
             resource.setCorsHeaders(service.getCorsHeaders());
@@ -74,27 +74,27 @@ public class CorsPopulator {
         if (configAnnotInfo == null) {
             return corsHeaders;
         }
-        AnnAttrValue allowOriginAttr = configAnnotInfo.getAnnAttrValue(Constants.ALLOW_ORIGIN);
+        AnnAttrValue allowOriginAttr = configAnnotInfo.getAnnAttrValue(HttpConstants.ALLOW_ORIGIN);
         if (allowOriginAttr != null) {
             corsHeaders.setAllowOrigins(DispatcherUtil.getValueList(allowOriginAttr, null));
         }
-        AnnAttrValue allowCredentials = configAnnotInfo.getAnnAttrValue(Constants.ALLOW_CREDENTIALS);
+        AnnAttrValue allowCredentials = configAnnotInfo.getAnnAttrValue(HttpConstants.ALLOW_CREDENTIALS);
         if (allowCredentials != null) {
             corsHeaders.setAllowCredentials(allowCredentials.getBooleanValue() ? 1 : 0);
         }
-        AnnAttrValue allowMethodsAttr = configAnnotInfo.getAnnAttrValue(Constants.ALLOW_METHODS);
+        AnnAttrValue allowMethodsAttr = configAnnotInfo.getAnnAttrValue(HttpConstants.ALLOW_METHODS);
         if (allowMethodsAttr != null) {
             corsHeaders.setAllowMethods(DispatcherUtil.getValueList(allowMethodsAttr, null));
         }
-        AnnAttrValue allowHeadersAttr = configAnnotInfo.getAnnAttrValue(Constants.ALLOW_HEADERS);
+        AnnAttrValue allowHeadersAttr = configAnnotInfo.getAnnAttrValue(HttpConstants.ALLOW_HEADERS);
         if (allowHeadersAttr != null) {
             corsHeaders.setAllowHeaders(DispatcherUtil.getValueList(allowHeadersAttr, null));
         }
-        AnnAttrValue maxAgeAttr = configAnnotInfo.getAnnAttrValue(Constants.MAX_AGE);
+        AnnAttrValue maxAgeAttr = configAnnotInfo.getAnnAttrValue(HttpConstants.MAX_AGE);
         if (maxAgeAttr != null) {
             corsHeaders.setMaxAge(maxAgeAttr.getIntValue());
         }
-        AnnAttrValue exposeHeadersAttr = configAnnotInfo.getAnnAttrValue(Constants.EXPOSE_HEADERS);
+        AnnAttrValue exposeHeadersAttr = configAnnotInfo.getAnnAttrValue(HttpConstants.EXPOSE_HEADERS);
         if (exposeHeadersAttr != null) {
             corsHeaders.setExposeHeaders(DispatcherUtil.getValueList(exposeHeadersAttr, null));
         }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HTTPResourceDispatcher.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HTTPResourceDispatcher.java
@@ -34,23 +34,23 @@ public class HTTPResourceDispatcher {
     public static HttpResource findResource(HttpService service, HTTPCarbonMessage inboundRequest)
             throws BallerinaConnectorException {
 
-        String method = (String) inboundRequest.getProperty(Constants.HTTP_METHOD);
-        String subPath = (String) inboundRequest.getProperty(Constants.SUB_PATH);
+        String method = (String) inboundRequest.getProperty(HttpConstants.HTTP_METHOD);
+        String subPath = (String) inboundRequest.getProperty(HttpConstants.SUB_PATH);
         subPath = sanitizeSubPath(subPath);
         Map<String, String> resourceArgumentValues = new HashMap<>();
         try {
             HttpResource resource = service.getUriTemplate().matches(subPath, resourceArgumentValues, inboundRequest);
             if (resource != null) {
-                inboundRequest.setProperty(Constants.RESOURCE_ARGS, resourceArgumentValues);
-                inboundRequest.setProperty(Constants.RESOURCES_CORS, resource.getCorsHeaders());
+                inboundRequest.setProperty(HttpConstants.RESOURCE_ARGS, resourceArgumentValues);
+                inboundRequest.setProperty(HttpConstants.RESOURCES_CORS, resource.getCorsHeaders());
                 return resource;
             } else {
-                if (method.equals(Constants.HTTP_METHOD_OPTIONS)) {
+                if (method.equals(HttpConstants.HTTP_METHOD_OPTIONS)) {
                     handleOptionsRequest(inboundRequest, service);
                 } else {
-                    inboundRequest.setProperty(Constants.HTTP_STATUS_CODE, 404);
+                    inboundRequest.setProperty(HttpConstants.HTTP_STATUS_CODE, 404);
                     throw new BallerinaConnectorException("no matching resource found for path : "
-                            + inboundRequest.getProperty(Constants.TO) + " , method : " + method);
+                            + inboundRequest.getProperty(HttpConstants.TO) + " , method : " + method);
                 }
                 return null;
             }
@@ -64,7 +64,7 @@ public class HTTPResourceDispatcher {
             return subPath;
         }
         if (!subPath.startsWith("/")) {
-            subPath = Constants.DEFAULT_BASE_PATH + subPath;
+            subPath = HttpConstants.DEFAULT_BASE_PATH + subPath;
         }
         subPath = subPath.endsWith("/") ? subPath.substring(0, subPath.length() - 1) : subPath;
         return subPath;
@@ -73,18 +73,18 @@ public class HTTPResourceDispatcher {
     private static void handleOptionsRequest(HTTPCarbonMessage cMsg, HttpService service)
             throws URITemplateException {
         HTTPCarbonMessage response = HttpUtil.createHttpCarbonMessage(false);
-        if (cMsg.getHeader(Constants.ALLOW) != null) {
-            response.setHeader(Constants.ALLOW, cMsg.getHeader(Constants.ALLOW));
-        } else if (service.getBasePath().equals(cMsg.getProperty(Constants.TO))
+        if (cMsg.getHeader(HttpConstants.ALLOW) != null) {
+            response.setHeader(HttpConstants.ALLOW, cMsg.getHeader(HttpConstants.ALLOW));
+        } else if (service.getBasePath().equals(cMsg.getProperty(HttpConstants.TO))
                 && !service.getAllAllowMethods().isEmpty()) {
-            response.setHeader(Constants.ALLOW, DispatcherUtil.concatValues(service.getAllAllowMethods(), false));
+            response.setHeader(HttpConstants.ALLOW, DispatcherUtil.concatValues(service.getAllAllowMethods(), false));
         } else {
-            cMsg.setProperty(Constants.HTTP_STATUS_CODE, 404);
+            cMsg.setProperty(HttpConstants.HTTP_STATUS_CODE, 404);
             throw new BallerinaConnectorException("no matching resource found for path : "
-                    + cMsg.getProperty(Constants.TO) + " , method : " + "OPTIONS");
+                    + cMsg.getProperty(HttpConstants.TO) + " , method : " + "OPTIONS");
         }
         CorsHeaderGenerator.process(cMsg, response, false);
-        response.setProperty(Constants.HTTP_STATUS_CODE, 200);
+        response.setProperty(HttpConstants.HTTP_STATUS_CODE, 200);
         response.setEndOfMsgAdded(true);
         HttpUtil.sendOutboundResponse(cMsg, response);
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HTTPServicesRegistry.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HTTPServicesRegistry.java
@@ -90,7 +90,7 @@ public class HTTPServicesRegistry {
      */
     public void registerService(HttpService service) {
         Annotation annotation = HttpUtil.getServiceConfigAnnotation(service.getBalService(),
-                                                                    Constants.HTTP_PACKAGE_PATH);
+                                                                    HttpConstants.HTTP_PACKAGE_PATH);
 
         String basePath = discoverBasePathFrom(service, annotation);
         basePath = urlDecode(basePath);
@@ -113,7 +113,7 @@ public class HTTPServicesRegistry {
 
             // If WebSocket upgrade path is available, then register the name of the WebSocket service.
             if (annotation != null) {
-                AnnAttrValue webSocketAttr = annotation.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_WEBSOCKET);
+                AnnAttrValue webSocketAttr = annotation.getAnnAttrValue(HttpConstants.ANN_CONFIG_ATTR_WEBSOCKET);
                 if (webSocketAttr != null) {
                     Annotation webSocketAnn = webSocketAttr.getAnnotation();
                     registerWebSocketUpgradePath(webSocketAnn, basePath, entryListenerInterface);
@@ -128,26 +128,26 @@ public class HTTPServicesRegistry {
         String basePath = service.getName();
         if (annotation == null) {
             //service name cannot start with / hence concat
-            return Constants.DEFAULT_BASE_PATH.concat(basePath);
+            return HttpConstants.DEFAULT_BASE_PATH.concat(basePath);
         }
-        AnnAttrValue annotationValue = annotation.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_BASE_PATH);
+        AnnAttrValue annotationValue = annotation.getAnnAttrValue(HttpConstants.ANN_CONFIG_ATTR_BASE_PATH);
         if (annotationValue == null || annotationValue.getStringValue() == null) {
-            return Constants.DEFAULT_BASE_PATH.concat(basePath);
+            return HttpConstants.DEFAULT_BASE_PATH.concat(basePath);
         }
         if (!annotationValue.getStringValue().trim().isEmpty()) {
             basePath = annotationValue.getStringValue();
         } else {
-            basePath = Constants.DEFAULT_BASE_PATH;
+            basePath = HttpConstants.DEFAULT_BASE_PATH;
         }
         return sanitizeBasePath(basePath);
     }
 
     private String sanitizeBasePath(String basePath) {
         basePath = basePath.trim();
-        if (!basePath.startsWith(Constants.DEFAULT_BASE_PATH)) {
-            basePath = Constants.DEFAULT_BASE_PATH.concat(basePath);
+        if (!basePath.startsWith(HttpConstants.DEFAULT_BASE_PATH)) {
+            basePath = HttpConstants.DEFAULT_BASE_PATH.concat(basePath);
         }
-        if (basePath.endsWith(Constants.DEFAULT_BASE_PATH) && basePath.length() != 1) {
+        if (basePath.endsWith(HttpConstants.DEFAULT_BASE_PATH) && basePath.length() != 1) {
             basePath = basePath.substring(0, basePath.length() - 1);
         }
         return basePath;
@@ -155,9 +155,9 @@ public class HTTPServicesRegistry {
 
     private void registerWebSocketUpgradePath(Annotation webSocketAnn, String basePath, String serviceInterface) {
         String upgradePath = sanitizeBasePath(
-                webSocketAnn.getAnnAttrValue(Constants.ANN_WEBSOCKET_ATTR_UPGRADE_PATH).getStringValue());
+                webSocketAnn.getAnnAttrValue(HttpConstants.ANN_WEBSOCKET_ATTR_UPGRADE_PATH).getStringValue());
         String serviceName =
-                webSocketAnn.getAnnAttrValue(Constants.ANN_WEBSOCKET_ATTR_SERVICE_NAME).getStringValue().trim();
+                webSocketAnn.getAnnAttrValue(HttpConstants.ANN_WEBSOCKET_ATTR_SERVICE_NAME).getStringValue().trim();
         String uri = basePath.concat(upgradePath);
         webSocketServicesRegistry.addUpgradableServiceByName(serviceInterface, uri, serviceName);
     }
@@ -196,7 +196,7 @@ public class HTTPServicesRegistry {
     private HttpResource buildHttpResource(Resource resource) {
         HttpResource httpResource = new HttpResource(resource);
         Annotation resourceConfigAnnotation = HttpUtil.getResourceConfigAnnotation(resource,
-                                                                                   Constants.HTTP_PACKAGE_PATH);
+                                                                                   HttpConstants.HTTP_PACKAGE_PATH);
         if (resourceConfigAnnotation == null) {
             if (logger.isDebugEnabled()) {
                 logger.debug("resourceConfig not specified in the Resource, using default sub path");
@@ -205,7 +205,7 @@ public class HTTPServicesRegistry {
             return httpResource;
         }
         String subPath;
-        AnnAttrValue pathAttrVal = resourceConfigAnnotation.getAnnAttrValue(Constants.ANN_RESOURCE_ATTR_PATH);
+        AnnAttrValue pathAttrVal = resourceConfigAnnotation.getAnnAttrValue(HttpConstants.ANN_RESOURCE_ATTR_PATH);
         if (pathAttrVal == null) {
             if (logger.isDebugEnabled()) {
                 logger.debug("Path not specified in the Resource, using default sub path");
@@ -215,19 +215,21 @@ public class HTTPServicesRegistry {
             subPath = pathAttrVal.getStringValue().trim();
         }
         if (subPath.isEmpty()) {
-            subPath = Constants.DEFAULT_BASE_PATH;
+            subPath = HttpConstants.DEFAULT_BASE_PATH;
         }
         httpResource.setPath(subPath);
 
-        AnnAttrValue methodsAttrVal = resourceConfigAnnotation.getAnnAttrValue(Constants.ANN_RESOURCE_ATTR_METHODS);
+        AnnAttrValue methodsAttrVal = resourceConfigAnnotation.getAnnAttrValue(HttpConstants.ANN_RESOURCE_ATTR_METHODS);
         if (methodsAttrVal != null) {
             httpResource.setMethods(DispatcherUtil.getValueList(methodsAttrVal, null));
         }
-        AnnAttrValue consumesAttrVal = resourceConfigAnnotation.getAnnAttrValue(Constants.ANN_RESOURCE_ATTR_CONSUMES);
+        AnnAttrValue consumesAttrVal = resourceConfigAnnotation.getAnnAttrValue(
+                HttpConstants.ANN_RESOURCE_ATTR_CONSUMES);
         if (consumesAttrVal != null) {
             httpResource.setConsumes(DispatcherUtil.getValueList(consumesAttrVal, null));
         }
-        AnnAttrValue producesAttrVal = resourceConfigAnnotation.getAnnAttrValue(Constants.ANN_RESOURCE_ATTR_PRODUCES);
+        AnnAttrValue producesAttrVal = resourceConfigAnnotation.getAnnAttrValue(
+                HttpConstants.ANN_RESOURCE_ATTR_PRODUCES);
         if (producesAttrVal != null) {
             httpResource.setProduces(DispatcherUtil.getValueList(producesAttrVal, null));
         }
@@ -248,19 +250,19 @@ public class HTTPServicesRegistry {
             throw new BallerinaConnectorException("resource signature parameter count should be more than two");
         }
 
-        if (!isValidResourceParam(paramDetails.get(0), Constants.CONNECTION)) {
+        if (!isValidResourceParam(paramDetails.get(0), HttpConstants.CONNECTION)) {
             throw new BallerinaConnectorException("first parameter should be of type - "
-                    + Constants.PROTOCOL_PACKAGE_HTTP + ":" + Constants.CONNECTION);
+                    + HttpConstants.PROTOCOL_PACKAGE_HTTP + ":" + HttpConstants.CONNECTION);
         }
 
-        if (!isValidResourceParam(paramDetails.get(1), Constants.IN_REQUEST)) {
+        if (!isValidResourceParam(paramDetails.get(1), HttpConstants.IN_REQUEST)) {
             throw new BallerinaConnectorException("second parameter should be of type - "
-                    + Constants.PROTOCOL_PACKAGE_HTTP + ":" + Constants.IN_REQUEST);
+                    + HttpConstants.PROTOCOL_PACKAGE_HTTP + ":" + HttpConstants.IN_REQUEST);
         }
 
         for (int i = 2; i < paramDetails.size(); i++) {
             ParamDetail paramDetail = paramDetails.get(i);
-            if (!paramDetail.getVarType().getName().equals(Constants.TYPE_STRING)) {
+            if (!paramDetail.getVarType().getName().equals(HttpConstants.TYPE_STRING)) {
                 throw new BallerinaConnectorException("incompatible resource signature parameter type");
             }
         }
@@ -268,7 +270,7 @@ public class HTTPServicesRegistry {
 
     private boolean isValidResourceParam(ParamDetail paramDetail, String varTypeName) {
         return paramDetail.getVarType().getPackagePath() != null
-                && paramDetail.getVarType().getPackagePath().equals(Constants.PROTOCOL_PACKAGE_HTTP)
+                && paramDetail.getVarType().getPackagePath().equals(HttpConstants.PROTOCOL_PACKAGE_HTTP)
                 && paramDetail.getVarType().getName().equals(varTypeName);
     }
 
@@ -284,8 +286,8 @@ public class HTTPServicesRegistry {
                 return key.toString();
             }
         }
-        if (services.containsKey(Constants.DEFAULT_BASE_PATH)) {
-            return Constants.DEFAULT_BASE_PATH;
+        if (services.containsKey(HttpConstants.DEFAULT_BASE_PATH)) {
+            return HttpConstants.DEFAULT_BASE_PATH;
         }
         return null;
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConnectionManager.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConnectionManager.java
@@ -60,8 +60,8 @@ public class HttpConnectionManager {
     private HttpWsConnectorFactory httpConnectorFactory = new HttpWsConnectorFactoryImpl();
 
     private HttpConnectionManager() {
-        String nettyConfigFile = System.getProperty(Constants.HTTP_TRANSPORT_CONF,
-                "conf" + File.separator + "transports" +
+        String nettyConfigFile = System.getProperty(HttpConstants.HTTP_TRANSPORT_CONF,
+                                                    "conf" + File.separator + "transports" +
                         File.separator + "netty-transports.yml");
         trpConfig = ConfigurationBuilder.getInstance().getConfiguration(nettyConfigFile);
         serverBootstrapConfiguration = HTTPConnectorUtil

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -23,7 +23,7 @@ package org.ballerinalang.net.http;
  *
  * @since 0.8.0
  */
-public class Constants {
+public class HttpConstants {
 
     public static final String BASE_PATH = "BASE_PATH";
     public static final String SUB_PATH = "SUB_PATH";

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpDispatcher.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpDispatcher.java
@@ -48,13 +48,13 @@ public class HttpDispatcher {
         try {
             Map<String, HttpService> servicesOnInterface = getServicesOnInterface(servicesRegistry, inboundReqMsg);
 
-            String rawUri = (String) inboundReqMsg.getProperty(Constants.TO);
-            inboundReqMsg.setProperty(Constants.RAW_URI, rawUri);
+            String rawUri = (String) inboundReqMsg.getProperty(HttpConstants.TO);
+            inboundReqMsg.setProperty(HttpConstants.RAW_URI, rawUri);
             Map<String, Map<String, String>> matrixParams = new HashMap<>();
             String uriWithoutMatrixParams = URIUtil.extractMatrixParams(rawUri, matrixParams);
 
-            inboundReqMsg.setProperty(Constants.TO, uriWithoutMatrixParams);
-            inboundReqMsg.setProperty(Constants.MATRIX_PARAMS, matrixParams);
+            inboundReqMsg.setProperty(HttpConstants.TO, uriWithoutMatrixParams);
+            inboundReqMsg.setProperty(HttpConstants.MATRIX_PARAMS, matrixParams);
 
             URI validatedUri = getValidatedURI(uriWithoutMatrixParams);
 
@@ -63,7 +63,7 @@ public class HttpDispatcher {
                     servicesRegistry.findTheMostSpecificBasePath(validatedUri.getPath(), servicesOnInterface);
             HttpService service = servicesOnInterface.get(basePath);
             if (service == null) {
-                inboundReqMsg.setProperty(Constants.HTTP_STATUS_CODE, 404);
+                inboundReqMsg.setProperty(HttpConstants.HTTP_STATUS_CODE, 404);
                 throw new BallerinaConnectorException("no matching service found for path : " +
                         validatedUri.getRawPath());
             }
@@ -88,11 +88,11 @@ public class HttpDispatcher {
 
     private static void setInboundReqProperties(HTTPCarbonMessage inboundReqMsg, URI requestUri, String basePath) {
         String subPath = URIUtil.getSubPath(requestUri.getPath(), basePath);
-        inboundReqMsg.setProperty(Constants.BASE_PATH, basePath);
-        inboundReqMsg.setProperty(Constants.SUB_PATH, subPath);
-        inboundReqMsg.setProperty(Constants.QUERY_STR, requestUri.getQuery());
+        inboundReqMsg.setProperty(HttpConstants.BASE_PATH, basePath);
+        inboundReqMsg.setProperty(HttpConstants.SUB_PATH, subPath);
+        inboundReqMsg.setProperty(HttpConstants.QUERY_STR, requestUri.getQuery());
         //store query params comes with request as it is
-        inboundReqMsg.setProperty(Constants.RAW_QUERY_STR, requestUri.getRawQuery());
+        inboundReqMsg.setProperty(HttpConstants.RAW_QUERY_STR, requestUri.getRawQuery());
     }
 
     private static URI getValidatedURI(String uriStr) {
@@ -106,12 +106,12 @@ public class HttpDispatcher {
     }
 
     private static String getInterface(HTTPCarbonMessage inboundRequest) {
-        String interfaceId = (String) inboundRequest.getProperty(Constants.LISTENER_INTERFACE_ID);
+        String interfaceId = (String) inboundRequest.getProperty(HttpConstants.LISTENER_INTERFACE_ID);
         if (interfaceId == null) {
             if (breLog.isDebugEnabled()) {
                 breLog.debug("Interface id not found on the message, hence using the default interface");
             }
-            interfaceId = Constants.DEFAULT_INTERFACE;
+            interfaceId = HttpConstants.DEFAULT_INTERFACE;
         }
 
         return interfaceId;
@@ -138,7 +138,7 @@ public class HttpDispatcher {
     public static HttpResource findResource(HTTPServicesRegistry servicesRegistry,
                                             HTTPCarbonMessage httpCarbonMessage) {
         HttpResource resource = null;
-        String protocol = (String) httpCarbonMessage.getProperty(Constants.PROTOCOL);
+        String protocol = (String) httpCarbonMessage.getProperty(HttpConstants.PROTOCOL);
         if (protocol == null) {
             throw new BallerinaConnectorException("protocol not defined in the incoming request");
         }
@@ -162,9 +162,9 @@ public class HttpDispatcher {
     public static BValue[] getSignatureParameters(HttpResource httpResource, HTTPCarbonMessage httpCarbonMessage) {
         //TODO Think of keeping struct type globally rather than creating for each request
         BStruct connection = ConnectorUtils.createStruct(httpResource.getBalResource(),
-                Constants.PROTOCOL_PACKAGE_HTTP, Constants.CONNECTION);
+                                                         HttpConstants.PROTOCOL_PACKAGE_HTTP, HttpConstants.CONNECTION);
         BStruct inRequest = ConnectorUtils.createStruct(httpResource.getBalResource(),
-                Constants.PROTOCOL_PACKAGE_HTTP, Constants.IN_REQUEST);
+                                                        HttpConstants.PROTOCOL_PACKAGE_HTTP, HttpConstants.IN_REQUEST);
 
         BStruct entityForRequest = ConnectorUtils.createStruct(httpResource.getBalResource(),
                 org.ballerinalang.mime.util.Constants.PROTOCOL_PACKAGE_MIME,
@@ -186,7 +186,7 @@ public class HttpDispatcher {
         }
 
         Map<String, String> resourceArgumentValues =
-                (Map<String, String>) httpCarbonMessage.getProperty(Constants.RESOURCE_ARGS);
+                (Map<String, String>) httpCarbonMessage.getProperty(HttpConstants.RESOURCE_ARGS);
         for (int i = 2; i < paramDetails.size(); i++) {
             //No need for validation as validation already happened at deployment time,
             //only string parameters can be found here.

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpResourceDataElement.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpResourceDataElement.java
@@ -84,7 +84,7 @@ public class HttpResourceDataElement implements DataElement<HttpResource, HTTPCa
     private HttpResource validateHTTPMethod(List<HttpResource> resources, HTTPCarbonMessage carbonMessage) {
         HttpResource resource = null;
         boolean isOptionsRequest = false;
-        String httpMethod = (String) carbonMessage.getProperty(Constants.HTTP_METHOD);
+        String httpMethod = (String) carbonMessage.getProperty(HttpConstants.HTTP_METHOD);
         for (HttpResource resourceInfo : resources) {
             if (DispatcherUtil.isMatchingMethodExist(resourceInfo, httpMethod)) {
                 resource = resourceInfo;
@@ -101,7 +101,7 @@ public class HttpResourceDataElement implements DataElement<HttpResource, HTTPCa
             return resource;
         }
         if (!isOptionsRequest) {
-            carbonMessage.setProperty(Constants.HTTP_STATUS_CODE, 405);
+            carbonMessage.setProperty(HttpConstants.HTTP_STATUS_CODE, 405);
             throw new BallerinaException("Method not allowed");
         }
         return null;
@@ -118,8 +118,8 @@ public class HttpResourceDataElement implements DataElement<HttpResource, HTTPCa
     }
 
     private boolean setAllowHeadersIfOPTIONS(String httpMethod, HTTPCarbonMessage cMsg) {
-        if (httpMethod.equals(Constants.HTTP_METHOD_OPTIONS)) {
-            cMsg.setHeader(Constants.ALLOW, getAllowHeaderValues(cMsg));
+        if (httpMethod.equals(HttpConstants.HTTP_METHOD_OPTIONS)) {
+            cMsg.setHeader(HttpConstants.ALLOW, getAllowHeaderValues(cMsg));
             return true;
         }
         return false;
@@ -134,26 +134,26 @@ public class HttpResourceDataElement implements DataElement<HttpResource, HTTPCa
             }
             resourceInfos.add(resourceInfo);
         }
-        cMsg.setProperty(Constants.PREFLIGHT_RESOURCES, resourceInfos);
+        cMsg.setProperty(HttpConstants.PREFLIGHT_RESOURCES, resourceInfos);
         methods = DispatcherUtil.validateAllowMethods(methods);
         return DispatcherUtil.concatValues(methods, false);
     }
 
     public HttpResource validateConsumes(HttpResource resource, HTTPCarbonMessage cMsg) {
-        String contentMediaType = extractContentMediaType(cMsg.getHeader(Constants.CONTENT_TYPE_HEADER));
+        String contentMediaType = extractContentMediaType(cMsg.getHeader(HttpConstants.CONTENT_TYPE_HEADER));
         List<String> consumesList = resource.getConsumes();
 
         if (consumesList == null) {
             return resource;
         }
         //when Content-Type header is not set, treat it as "application/octet-stream"
-        contentMediaType = (contentMediaType != null ? contentMediaType : Constants.VALUE_ATTRIBUTE);
+        contentMediaType = (contentMediaType != null ? contentMediaType : HttpConstants.VALUE_ATTRIBUTE);
         for (String consumeType : consumesList) {
             if (contentMediaType.equals(consumeType.trim())) {
                 return resource;
             }
         }
-        cMsg.setProperty(Constants.HTTP_STATUS_CODE, 415);
+        cMsg.setProperty(HttpConstants.HTTP_STATUS_CODE, 415);
         throw new BallerinaException();
     }
 
@@ -168,7 +168,7 @@ public class HttpResourceDataElement implements DataElement<HttpResource, HTTPCa
     }
 
     public HttpResource validateProduces(HttpResource resource, HTTPCarbonMessage cMsg) {
-        List<String> acceptMediaTypes = extractAcceptMediaTypes(cMsg.getHeader(Constants.ACCEPT_HEADER));
+        List<String> acceptMediaTypes = extractAcceptMediaTypes(cMsg.getHeader(HttpConstants.ACCEPT_HEADER));
         List<String> producesList = resource.getProduces();
 
         if (producesList == null || acceptMediaTypes == null) {
@@ -196,7 +196,7 @@ public class HttpResourceDataElement implements DataElement<HttpResource, HTTPCa
                 return resource;
             }
         }
-        cMsg.setProperty(Constants.HTTP_STATUS_CODE, 406);
+        cMsg.setProperty(HttpConstants.HTTP_STATUS_CODE, 406);
         throw new BallerinaException();
     }
 

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -49,6 +49,7 @@ import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.model.values.BXML;
 import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.net.http.session.Session;
+import org.ballerinalang.net.ws.WebSocketConstants;
 import org.ballerinalang.runtime.message.BlobDataSource;
 import org.ballerinalang.runtime.message.MessageDataSource;
 import org.ballerinalang.runtime.message.StringDataSource;
@@ -94,8 +95,8 @@ import static org.ballerinalang.mime.util.Constants.MULTIPART_ENCODER;
 import static org.ballerinalang.mime.util.Constants.NO_CONTENT_LENGTH_FOUND;
 import static org.ballerinalang.mime.util.Constants.OCTET_STREAM;
 import static org.ballerinalang.mime.util.Constants.TEXT_PLAIN;
-import static org.ballerinalang.net.http.Constants.ENTITY_INDEX;
-import static org.ballerinalang.net.http.Constants.HTTP_MESSAGE_INDEX;
+import static org.ballerinalang.net.http.HttpConstants.ENTITY_INDEX;
+import static org.ballerinalang.net.http.HttpConstants.HTTP_MESSAGE_INDEX;
 
 /**
  * Utility class providing utility methods.
@@ -267,7 +268,7 @@ public class HttpUtil {
             }
         } else {
             int contentLength = NO_CONTENT_LENGTH_FOUND;
-            String lengthStr = httpCarbonMessage.getHeader(Constants.HTTP_CONTENT_LENGTH);
+            String lengthStr = httpCarbonMessage.getHeader(HttpConstants.HTTP_CONTENT_LENGTH);
             try {
                 contentLength = lengthStr != null ? Integer.parseInt(lengthStr) : contentLength;
                 if (contentLength == NO_CONTENT_LENGTH_FOUND) {
@@ -365,25 +366,25 @@ public class HttpUtil {
 
     public static BStruct createSessionStruct(Context context, Session session) {
         BStruct sessionStruct = ConnectorUtils
-                .createAndGetStruct(context, Constants.PROTOCOL_PACKAGE_HTTP, Constants.SESSION);
+                .createAndGetStruct(context, HttpConstants.PROTOCOL_PACKAGE_HTTP, HttpConstants.SESSION);
         //Add session to the struct as a native data
-        sessionStruct.addNativeData(Constants.HTTP_SESSION, session);
+        sessionStruct.addNativeData(HttpConstants.HTTP_SESSION, session);
         return sessionStruct;
     }
 
     public static String getSessionID(String cookieHeader) {
         return Arrays.stream(cookieHeader.split(";"))
-                .filter(cookie -> cookie.trim().startsWith(Constants.SESSION_ID))
-                .findFirst().get().trim().substring(Constants.SESSION_ID.length());
+                .filter(cookie -> cookie.trim().startsWith(HttpConstants.SESSION_ID))
+                .findFirst().get().trim().substring(HttpConstants.SESSION_ID.length());
     }
 
     public static void addHTTPSessionAndCorsHeaders(HTTPCarbonMessage requestMsg, HTTPCarbonMessage responseMsg) {
-        Session session = (Session) requestMsg.getProperty(Constants.HTTP_SESSION);
+        Session session = (Session) requestMsg.getProperty(HttpConstants.HTTP_SESSION);
         if (session != null) {
             session.generateSessionHeader(responseMsg);
         }
         //Process CORS if exists.
-        if (requestMsg.getHeader(Constants.ORIGIN) != null) {
+        if (requestMsg.getHeader(HttpConstants.ORIGIN) != null) {
             CorsHeaderGenerator.process(requestMsg, responseMsg, true);
         }
     }
@@ -400,7 +401,7 @@ public class HttpUtil {
     }
 
     public static void handleFailure(HTTPCarbonMessage requestMessage, BallerinaConnectorException ex) {
-        Object carbonStatusCode = requestMessage.getProperty(Constants.HTTP_STATUS_CODE);
+        Object carbonStatusCode = requestMessage.getProperty(HttpConstants.HTTP_STATUS_CODE);
         int statusCode = (carbonStatusCode == null) ? 500 : Integer.parseInt(carbonStatusCode.toString());
         String errorMsg = ex.getMessage();
         log.error(errorMsg);
@@ -439,8 +440,8 @@ public class HttpUtil {
 
     public static BStruct getServerConnectorError(Context context, Throwable throwable) {
         PackageInfo httpPackageInfo = context.getProgramFile()
-                .getPackageInfo(Constants.PROTOCOL_PACKAGE_HTTP);
-        StructInfo errorStructInfo = httpPackageInfo.getStructInfo(Constants.HTTP_CONNECTOR_ERROR);
+                .getPackageInfo(HttpConstants.PROTOCOL_PACKAGE_HTTP);
+        StructInfo errorStructInfo = httpPackageInfo.getStructInfo(HttpConstants.HTTP_CONNECTOR_ERROR);
         BStruct httpConnectorError = new BStruct(errorStructInfo.getType());
         if (throwable.getMessage() == null) {
             httpConnectorError.setStringField(0, IO_EXCEPTION_OCCURED);
@@ -452,7 +453,7 @@ public class HttpUtil {
 
     public static HTTPCarbonMessage getCarbonMsg(BStruct struct, HTTPCarbonMessage defaultMsg) {
         HTTPCarbonMessage httpCarbonMessage = (HTTPCarbonMessage) struct
-                .getNativeData(Constants.TRANSPORT_MESSAGE);
+                .getNativeData(HttpConstants.TRANSPORT_MESSAGE);
         if (httpCarbonMessage != null) {
             return httpCarbonMessage;
         }
@@ -461,13 +462,13 @@ public class HttpUtil {
     }
 
     public static void addCarbonMsg(BStruct struct, HTTPCarbonMessage httpCarbonMessage) {
-        struct.addNativeData(Constants.TRANSPORT_MESSAGE, httpCarbonMessage);
+        struct.addNativeData(HttpConstants.TRANSPORT_MESSAGE, httpCarbonMessage);
     }
 
     public static void populateInboundRequest(BStruct inboundRequestStruct, BStruct entity, BStruct mediaType,
                                               HTTPCarbonMessage inboundRequestMsg) {
-        inboundRequestStruct.addNativeData(Constants.TRANSPORT_MESSAGE, inboundRequestMsg);
-        inboundRequestStruct.addNativeData(Constants.IN_REQUEST, true);
+        inboundRequestStruct.addNativeData(HttpConstants.TRANSPORT_MESSAGE, inboundRequestMsg);
+        inboundRequestStruct.addNativeData(HttpConstants.IN_REQUEST, true);
 
         enrichWithInboundRequestInfo(inboundRequestStruct, inboundRequestMsg);
         enrichWithInboundRequestHeaders(inboundRequestStruct, inboundRequestMsg);
@@ -479,32 +480,33 @@ public class HttpUtil {
 
     private static void enrichWithInboundRequestHeaders(BStruct inboundRequestStruct,
                                                         HTTPCarbonMessage inboundRequestMsg) {
-        if (inboundRequestMsg.getHeader(Constants.USER_AGENT_HEADER) != null) {
-            inboundRequestStruct.setStringField(Constants.IN_REQUEST_USER_AGENT_INDEX,
-                    inboundRequestMsg.getHeader(Constants.USER_AGENT_HEADER));
-            inboundRequestMsg.removeHeader(Constants.USER_AGENT_HEADER);
+        if (inboundRequestMsg.getHeader(HttpConstants.USER_AGENT_HEADER) != null) {
+            inboundRequestStruct.setStringField(HttpConstants.IN_REQUEST_USER_AGENT_INDEX,
+                                                inboundRequestMsg.getHeader(HttpConstants.USER_AGENT_HEADER));
+            inboundRequestMsg.removeHeader(HttpConstants.USER_AGENT_HEADER);
         }
     }
 
     private static void enrichWithInboundRequestInfo(BStruct inboundRequestStruct,
                                                      HTTPCarbonMessage inboundRequestMsg) {
-        inboundRequestStruct.setStringField(Constants.IN_REQUEST_RAW_PATH_INDEX,
-                (String) inboundRequestMsg.getProperty(Constants.REQUEST_URL));
-        inboundRequestStruct.setStringField(Constants.IN_REQUEST_METHOD_INDEX,
-                (String) inboundRequestMsg.getProperty(Constants.HTTP_METHOD));
-        inboundRequestStruct.setStringField(Constants.IN_REQUEST_VERSION_INDEX,
-                (String) inboundRequestMsg.getProperty(Constants.HTTP_VERSION));
+        inboundRequestStruct.setStringField(HttpConstants.IN_REQUEST_RAW_PATH_INDEX,
+                                            (String) inboundRequestMsg.getProperty(HttpConstants.REQUEST_URL));
+        inboundRequestStruct.setStringField(HttpConstants.IN_REQUEST_METHOD_INDEX,
+                                            (String) inboundRequestMsg.getProperty(HttpConstants.HTTP_METHOD));
+        inboundRequestStruct.setStringField(HttpConstants.IN_REQUEST_VERSION_INDEX,
+                                            (String) inboundRequestMsg.getProperty(HttpConstants.HTTP_VERSION));
         Map<String, String> resourceArgValues =
-                (Map<String, String>) inboundRequestMsg.getProperty(Constants.RESOURCE_ARGS);
-        inboundRequestStruct.setStringField(Constants.IN_REQUEST_EXTRA_PATH_INFO_INDEX,
-                resourceArgValues.get(Constants.EXTRA_PATH_INFO));
+                (Map<String, String>) inboundRequestMsg.getProperty(HttpConstants.RESOURCE_ARGS);
+        inboundRequestStruct.setStringField(HttpConstants.IN_REQUEST_EXTRA_PATH_INFO_INDEX,
+                                            resourceArgValues.get(HttpConstants.EXTRA_PATH_INFO));
     }
 
     public static void enrichConnectionInfo(BStruct connection, HTTPCarbonMessage cMsg) {
-        connection.addNativeData(Constants.TRANSPORT_MESSAGE, cMsg);
-        connection.setStringField(Constants.CONNECTION_HOST_INDEX,
-                ((InetSocketAddress) cMsg.getProperty(Constants.LOCAL_ADDRESS)).getHostName());
-        connection.setIntField(Constants.CONNECTION_PORT_INDEX, (Integer) cMsg.getProperty(Constants.LISTENER_PORT));
+        connection.addNativeData(HttpConstants.TRANSPORT_MESSAGE, cMsg);
+        connection.setStringField(HttpConstants.CONNECTION_HOST_INDEX,
+                                  ((InetSocketAddress) cMsg.getProperty(HttpConstants.LOCAL_ADDRESS)).getHostName());
+        connection.setIntField(HttpConstants.CONNECTION_PORT_INDEX,
+                               (Integer) cMsg.getProperty(HttpConstants.LISTENER_PORT));
     }
 
     /**
@@ -517,16 +519,16 @@ public class HttpUtil {
      */
     public static void populateInboundResponse(BStruct inboundResponse, BStruct entity, BStruct mediaType,
                                                HTTPCarbonMessage inboundResponseMsg) {
-        inboundResponse.addNativeData(Constants.TRANSPORT_MESSAGE, inboundResponseMsg);
-        int statusCode = (Integer) inboundResponseMsg.getProperty(Constants.HTTP_STATUS_CODE);
-        inboundResponse.setIntField(Constants.IN_RESPONSE_STATUS_CODE_INDEX, statusCode);
-        inboundResponse.setStringField(Constants.IN_RESPONSE_REASON_PHRASE_INDEX,
-                HttpResponseStatus.valueOf(statusCode).reasonPhrase());
+        inboundResponse.addNativeData(HttpConstants.TRANSPORT_MESSAGE, inboundResponseMsg);
+        int statusCode = (Integer) inboundResponseMsg.getProperty(HttpConstants.HTTP_STATUS_CODE);
+        inboundResponse.setIntField(HttpConstants.IN_RESPONSE_STATUS_CODE_INDEX, statusCode);
+        inboundResponse.setStringField(HttpConstants.IN_RESPONSE_REASON_PHRASE_INDEX,
+                                       HttpResponseStatus.valueOf(statusCode).reasonPhrase());
 
-        if (inboundResponseMsg.getHeader(Constants.SERVER_HEADER) != null) {
-            inboundResponse.setStringField(Constants.IN_RESPONSE_SERVER_INDEX,
-                    inboundResponseMsg.getHeader(Constants.SERVER_HEADER));
-            inboundResponseMsg.removeHeader(Constants.SERVER_HEADER);
+        if (inboundResponseMsg.getHeader(HttpConstants.SERVER_HEADER) != null) {
+            inboundResponse.setStringField(HttpConstants.IN_RESPONSE_SERVER_INDEX,
+                                           inboundResponseMsg.getHeader(HttpConstants.SERVER_HEADER));
+            inboundResponseMsg.removeHeader(HttpConstants.SERVER_HEADER);
         }
         populateEntity(entity, mediaType, inboundResponseMsg);
         inboundResponse.addNativeData(MESSAGE_ENTITY, entity);
@@ -544,7 +546,7 @@ public class HttpUtil {
         String contentType = cMsg.getHeader(CONTENT_TYPE);
         MimeUtil.setContentType(mediaType, entity, contentType);
         int contentLength = -1;
-        String lengthStr = cMsg.getHeader(Constants.HTTP_CONTENT_LENGTH);
+        String lengthStr = cMsg.getHeader(HttpConstants.HTTP_CONTENT_LENGTH);
         try {
             contentLength = lengthStr != null ? Integer.parseInt(lengthStr) : contentLength;
             MimeUtil.setContentLength(entity, contentLength);
@@ -617,40 +619,40 @@ public class HttpUtil {
     }
 
     private static boolean isInboundRequestStruct(BStruct struct) {
-        return struct.getType().getName().equals(Constants.IN_REQUEST);
+        return struct.getType().getName().equals(HttpConstants.IN_REQUEST);
     }
 
     private static boolean isInboundResponseStruct(BStruct struct) {
-        return struct.getType().getName().equals(Constants.IN_RESPONSE);
+        return struct.getType().getName().equals(HttpConstants.IN_RESPONSE);
     }
 
     private static boolean isOutboundResponseStruct(BStruct struct) {
-        return struct.getType().getName().equals(Constants.OUT_RESPONSE);
+        return struct.getType().getName().equals(HttpConstants.OUT_RESPONSE);
     }
 
     private static void addRemovedPropertiesBackToHeadersMap(BStruct struct, HttpHeaders transportHeaders) {
         if (isInboundRequestStruct(struct)) {
-            if (!struct.getStringField(Constants.IN_REQUEST_USER_AGENT_INDEX).isEmpty()) {
-                transportHeaders.add(Constants.USER_AGENT_HEADER,
-                        struct.getStringField(Constants.IN_REQUEST_USER_AGENT_INDEX));
+            if (!struct.getStringField(HttpConstants.IN_REQUEST_USER_AGENT_INDEX).isEmpty()) {
+                transportHeaders.add(HttpConstants.USER_AGENT_HEADER,
+                                     struct.getStringField(HttpConstants.IN_REQUEST_USER_AGENT_INDEX));
             }
         } else {
-            if (!struct.getStringField(Constants.IN_RESPONSE_SERVER_INDEX).isEmpty()) {
-                transportHeaders.add(Constants.SERVER_HEADER,
-                        struct.getStringField(Constants.IN_RESPONSE_SERVER_INDEX));
+            if (!struct.getStringField(HttpConstants.IN_RESPONSE_SERVER_INDEX).isEmpty()) {
+                transportHeaders.add(HttpConstants.SERVER_HEADER,
+                                     struct.getStringField(HttpConstants.IN_RESPONSE_SERVER_INDEX));
             }
         }
     }
 
     private static void setPropertiesToTransportMessage(HTTPCarbonMessage outboundResponseMsg, BStruct struct) {
         if (isOutboundResponseStruct(struct)) {
-            if (struct.getIntField(Constants.OUT_RESPONSE_STATUS_CODE_INDEX) != 0) {
-                outboundResponseMsg.setProperty(Constants.HTTP_STATUS_CODE,
-                        getIntValue(struct.getIntField(Constants.OUT_RESPONSE_STATUS_CODE_INDEX)));
+            if (struct.getIntField(HttpConstants.OUT_RESPONSE_STATUS_CODE_INDEX) != 0) {
+                outboundResponseMsg.setProperty(HttpConstants.HTTP_STATUS_CODE, getIntValue(
+                        struct.getIntField(HttpConstants.OUT_RESPONSE_STATUS_CODE_INDEX)));
             }
-            if (!struct.getStringField(Constants.OUT_RESPONSE_REASON_PHRASE_INDEX).isEmpty()) {
-                outboundResponseMsg.setProperty(Constants.HTTP_REASON_PHRASE,
-                        struct.getStringField(Constants.OUT_RESPONSE_REASON_PHRASE_INDEX));
+            if (!struct.getStringField(HttpConstants.OUT_RESPONSE_REASON_PHRASE_INDEX).isEmpty()) {
+                outboundResponseMsg.setProperty(HttpConstants.HTTP_REASON_PHRASE,
+                                                struct.getStringField(HttpConstants.OUT_RESPONSE_REASON_PHRASE_INDEX));
             }
         }
     }
@@ -699,19 +701,20 @@ public class HttpUtil {
      */
     public static void setKeepAliveHeader(Context context, HTTPCarbonMessage outboundMessage) {
         AnnAttachmentInfo configAnn = context.getServiceInfo().getAnnotationAttachmentInfo(
-                Constants.PROTOCOL_PACKAGE_HTTP, Constants.ANN_NAME_CONFIG);
+                HttpConstants.PROTOCOL_PACKAGE_HTTP, HttpConstants.ANN_NAME_CONFIG);
         if (configAnn != null) {
-            AnnAttributeValue keepAliveAttrVal = configAnn.getAttributeValue(Constants.ANN_CONFIG_ATTR_KEEP_ALIVE);
+            AnnAttributeValue keepAliveAttrVal = configAnn.getAttributeValue(HttpConstants.ANN_CONFIG_ATTR_KEEP_ALIVE);
 
             if (keepAliveAttrVal != null && !keepAliveAttrVal.getBooleanValue()) {
-                outboundMessage.setHeader(Constants.CONNECTION_HEADER, Constants.HEADER_VAL_CONNECTION_CLOSE);
+                outboundMessage.setHeader(HttpConstants.CONNECTION_HEADER, HttpConstants.HEADER_VAL_CONNECTION_CLOSE);
             } else {
                 // default behaviour: keepAlive = true
-                outboundMessage.setHeader(Constants.CONNECTION_HEADER, Constants.HEADER_VAL_CONNECTION_KEEP_ALIVE);
+                outboundMessage.setHeader(HttpConstants.CONNECTION_HEADER,
+                                          HttpConstants.HEADER_VAL_CONNECTION_KEEP_ALIVE);
             }
         } else {
             // default behaviour: keepAlive = true
-            outboundMessage.setHeader(Constants.CONNECTION_HEADER, Constants.HEADER_VAL_CONNECTION_KEEP_ALIVE);
+            outboundMessage.setHeader(HttpConstants.CONNECTION_HEADER, HttpConstants.HEADER_VAL_CONNECTION_KEEP_ALIVE);
         }
     }
 
@@ -746,24 +749,25 @@ public class HttpUtil {
     }
 
     private static void extractBasicConfig(Annotation configInfo, Set<ListenerConfiguration> listenerConfSet) {
-        AnnAttrValue hostAttrVal = configInfo.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_HOST);
-        AnnAttrValue portAttrVal = configInfo.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_PORT);
-        AnnAttrValue keepAliveAttrVal = configInfo.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_KEEP_ALIVE);
-        AnnAttrValue transferEncoding = configInfo.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_TRANSFER_ENCODING);
-        AnnAttrValue chunking = configInfo.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_CHUNKING);
-        AnnAttrValue maxUriLength = configInfo.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_MAXIMUM_URL_LENGTH);
-        AnnAttrValue maxHeaderSize = configInfo.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_MAXIMUM_HEADER_SIZE);
-        AnnAttrValue maxEntityBodySize = configInfo.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_MAXIMUM_ENTITY_BODY_SIZE);
+        AnnAttrValue hostAttrVal = configInfo.getAnnAttrValue(HttpConstants.ANN_CONFIG_ATTR_HOST);
+        AnnAttrValue portAttrVal = configInfo.getAnnAttrValue(HttpConstants.ANN_CONFIG_ATTR_PORT);
+        AnnAttrValue keepAliveAttrVal = configInfo.getAnnAttrValue(HttpConstants.ANN_CONFIG_ATTR_KEEP_ALIVE);
+        AnnAttrValue transferEncoding = configInfo.getAnnAttrValue(HttpConstants.ANN_CONFIG_ATTR_TRANSFER_ENCODING);
+        AnnAttrValue chunking = configInfo.getAnnAttrValue(HttpConstants.ANN_CONFIG_ATTR_CHUNKING);
+        AnnAttrValue maxUriLength = configInfo.getAnnAttrValue(HttpConstants.ANN_CONFIG_ATTR_MAXIMUM_URL_LENGTH);
+        AnnAttrValue maxHeaderSize = configInfo.getAnnAttrValue(HttpConstants.ANN_CONFIG_ATTR_MAXIMUM_HEADER_SIZE);
+        AnnAttrValue maxEntityBodySize = configInfo.getAnnAttrValue(
+                HttpConstants.ANN_CONFIG_ATTR_MAXIMUM_ENTITY_BODY_SIZE);
 
         ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
         if (portAttrVal != null && portAttrVal.getIntValue() > 0) {
             listenerConfiguration.setPort(Math.toIntExact(portAttrVal.getIntValue()));
 
-            listenerConfiguration.setScheme(Constants.PROTOCOL_HTTP);
+            listenerConfiguration.setScheme(HttpConstants.PROTOCOL_HTTP);
             if (hostAttrVal != null && hostAttrVal.getStringValue() != null) {
                 listenerConfiguration.setHost(hostAttrVal.getStringValue());
             } else {
-                listenerConfiguration.setHost(Constants.HTTP_DEFAULT_HOST);
+                listenerConfiguration.setHost(HttpConstants.HTTP_DEFAULT_HOST);
             }
 
             if (keepAliveAttrVal != null) {
@@ -774,7 +778,7 @@ public class HttpUtil {
 
             // For the moment we don't have to pass it down to transport as we only support
             // chunking. Once we start supporting gzip, deflate, etc, we need to parse down the config.
-            if (transferEncoding != null && !Constants.ANN_CONFIG_ATTR_CHUNKING
+            if (transferEncoding != null && !HttpConstants.ANN_CONFIG_ATTR_CHUNKING
                     .equalsIgnoreCase(transferEncoding.getStringValue())) {
                 throw new BallerinaConnectorException("Unsupported configuration found for Transfer-Encoding : "
                         + transferEncoding.getStringValue());
@@ -822,11 +826,11 @@ public class HttpUtil {
 
     public static ChunkConfig getChunkConfig(String chunking) {
         ChunkConfig chunkConfig;
-        if (Constants.CHUNKING_AUTO.equalsIgnoreCase(chunking)) {
+        if (HttpConstants.CHUNKING_AUTO.equalsIgnoreCase(chunking)) {
             chunkConfig = ChunkConfig.AUTO;
-        } else if (Constants.CHUNKING_ALWAYS.equalsIgnoreCase(chunking)) {
+        } else if (HttpConstants.CHUNKING_ALWAYS.equalsIgnoreCase(chunking)) {
             chunkConfig = ChunkConfig.ALWAYS;
-        } else if (Constants.CHUNKING_NEVER.equalsIgnoreCase(chunking)) {
+        } else if (HttpConstants.CHUNKING_NEVER.equalsIgnoreCase(chunking)) {
             chunkConfig = ChunkConfig.NEVER;
         } else {
             throw new BallerinaConnectorException("Invalid configuration found for Transfer-Encoding : " + chunking);
@@ -837,34 +841,36 @@ public class HttpUtil {
     private static void extractHttpsConfig(Annotation configInfo, Set<ListenerConfiguration> listenerConfSet) {
         // Retrieve secure port from either http of ws configuration annotation.
         AnnAttrValue httpsPortAttrVal;
-        if (configInfo.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_HTTPS_PORT) == null) {
+        if (configInfo.getAnnAttrValue(HttpConstants.ANN_CONFIG_ATTR_HTTPS_PORT) == null) {
             httpsPortAttrVal =
-                    configInfo.getAnnAttrValue(org.ballerinalang.net.ws.Constants.ANN_CONFIG_ATTR_WSS_PORT);
+                    configInfo.getAnnAttrValue(WebSocketConstants.ANN_CONFIG_ATTR_WSS_PORT);
         } else {
-            httpsPortAttrVal = configInfo.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_HTTPS_PORT);
+            httpsPortAttrVal = configInfo.getAnnAttrValue(HttpConstants.ANN_CONFIG_ATTR_HTTPS_PORT);
         }
 
-        AnnAttrValue keyStoreFileAttrVal = configInfo.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_KEY_STORE_FILE);
-        AnnAttrValue keyStorePasswordAttrVal = configInfo.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_KEY_STORE_PASS);
-        AnnAttrValue certPasswordAttrVal = configInfo.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_CERT_PASS);
-        AnnAttrValue trustStoreFileAttrVal = configInfo.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_TRUST_STORE_FILE);
-        AnnAttrValue trustStorePasswordAttrVal = configInfo.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_TRUST_STORE_PASS);
-        AnnAttrValue sslVerifyClientAttrVal = configInfo.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_SSL_VERIFY_CLIENT);
+        AnnAttrValue keyStoreFileAttrVal = configInfo.getAnnAttrValue(HttpConstants.ANN_CONFIG_ATTR_KEY_STORE_FILE);
+        AnnAttrValue keyStorePasswordAttrVal = configInfo.getAnnAttrValue(HttpConstants.ANN_CONFIG_ATTR_KEY_STORE_PASS);
+        AnnAttrValue certPasswordAttrVal = configInfo.getAnnAttrValue(HttpConstants.ANN_CONFIG_ATTR_CERT_PASS);
+        AnnAttrValue trustStoreFileAttrVal = configInfo.getAnnAttrValue(HttpConstants.ANN_CONFIG_ATTR_TRUST_STORE_FILE);
+        AnnAttrValue trustStorePasswordAttrVal = configInfo.getAnnAttrValue(
+                HttpConstants.ANN_CONFIG_ATTR_TRUST_STORE_PASS);
+        AnnAttrValue sslVerifyClientAttrVal = configInfo.getAnnAttrValue(
+                HttpConstants.ANN_CONFIG_ATTR_SSL_VERIFY_CLIENT);
         AnnAttrValue sslEnabledProtocolsAttrVal = configInfo
-                .getAnnAttrValue(Constants.ANN_CONFIG_ATTR_SSL_ENABLED_PROTOCOLS);
-        AnnAttrValue ciphersAttrVal = configInfo.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_CIPHERS);
-        AnnAttrValue sslProtocolAttrVal = configInfo.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_SSL_PROTOCOL);
-        AnnAttrValue hostAttrVal = configInfo.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_HOST);
+                .getAnnAttrValue(HttpConstants.ANN_CONFIG_ATTR_SSL_ENABLED_PROTOCOLS);
+        AnnAttrValue ciphersAttrVal = configInfo.getAnnAttrValue(HttpConstants.ANN_CONFIG_ATTR_CIPHERS);
+        AnnAttrValue sslProtocolAttrVal = configInfo.getAnnAttrValue(HttpConstants.ANN_CONFIG_ATTR_SSL_PROTOCOL);
+        AnnAttrValue hostAttrVal = configInfo.getAnnAttrValue(HttpConstants.ANN_CONFIG_ATTR_HOST);
 
         ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
         if (httpsPortAttrVal != null && httpsPortAttrVal.getIntValue() > 0) {
             listenerConfiguration.setPort(Math.toIntExact(httpsPortAttrVal.getIntValue()));
-            listenerConfiguration.setScheme(Constants.PROTOCOL_HTTPS);
+            listenerConfiguration.setScheme(HttpConstants.PROTOCOL_HTTPS);
 
             if (hostAttrVal != null && hostAttrVal.getStringValue() != null) {
                 listenerConfiguration.setHost(hostAttrVal.getStringValue());
             } else {
-                listenerConfiguration.setHost(Constants.HTTP_DEFAULT_HOST);
+                listenerConfiguration.setHost(HttpConstants.HTTP_DEFAULT_HOST);
             }
 
             if (keyStoreFileAttrVal == null || keyStoreFileAttrVal.getStringValue() == null) {
@@ -891,7 +897,7 @@ public class HttpUtil {
                 throw new BallerinaException("Truststore password value must be provided to enable Mutual SSL");
             }
 
-            listenerConfiguration.setTLSStoreType(Constants.PKCS_STORE_TYPE);
+            listenerConfiguration.setTLSStoreType(HttpConstants.PKCS_STORE_TYPE);
             listenerConfiguration.setKeyStoreFile(keyStoreFileAttrVal.getStringValue());
             listenerConfiguration.setKeyStorePass(keyStorePasswordAttrVal.getStringValue());
             listenerConfiguration.setCertPass(certPasswordAttrVal.getStringValue());
@@ -909,13 +915,13 @@ public class HttpUtil {
             List<Parameter> serverParams = new ArrayList<>();
             Parameter serverCiphers;
             if (sslEnabledProtocolsAttrVal != null && sslEnabledProtocolsAttrVal.getStringValue() != null) {
-                serverCiphers = new Parameter(Constants.ANN_CONFIG_ATTR_SSL_ENABLED_PROTOCOLS,
-                        sslEnabledProtocolsAttrVal.getStringValue());
+                serverCiphers = new Parameter(HttpConstants.ANN_CONFIG_ATTR_SSL_ENABLED_PROTOCOLS,
+                                              sslEnabledProtocolsAttrVal.getStringValue());
                 serverParams.add(serverCiphers);
             }
 
             if (ciphersAttrVal != null && ciphersAttrVal.getStringValue() != null) {
-                serverCiphers = new Parameter(Constants.ANN_CONFIG_ATTR_CIPHERS, ciphersAttrVal.getStringValue());
+                serverCiphers = new Parameter(HttpConstants.ANN_CONFIG_ATTR_CIPHERS, ciphersAttrVal.getStringValue());
                 serverParams.add(serverCiphers);
             }
 
@@ -969,11 +975,11 @@ public class HttpUtil {
     }
 
     private static boolean is100ContinueRequest(HTTPCarbonMessage reqMsg) {
-        return Constants.HEADER_VAL_100_CONTINUE.equalsIgnoreCase(reqMsg.getHeader(Constants.EXPECT_HEADER));
+        return HttpConstants.HEADER_VAL_100_CONTINUE.equalsIgnoreCase(reqMsg.getHeader(HttpConstants.EXPECT_HEADER));
     }
 
     public static Annotation getServiceConfigAnnotation(Service service, String pkgPath) {
-        List<Annotation> annotationList = service.getAnnotationList(pkgPath, Constants.ANN_NAME_CONFIG);
+        List<Annotation> annotationList = service.getAnnotationList(pkgPath, HttpConstants.ANN_NAME_CONFIG);
 
         if (annotationList == null) {
             return null;
@@ -988,7 +994,7 @@ public class HttpUtil {
     }
 
     public static Annotation getResourceConfigAnnotation(Resource resource, String pkgPath) {
-        List<Annotation> annotationList = resource.getAnnotationList(pkgPath, Constants.ANN_NAME_RESOURCE_CONFIG);
+        List<Annotation> annotationList = resource.getAnnotationList(pkgPath, HttpConstants.ANN_NAME_RESOURCE_CONFIG);
 
         if (annotationList == null) {
             return null;

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/AbstractHTTPAction.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/AbstractHTTPAction.java
@@ -27,7 +27,7 @@ import org.ballerinalang.model.types.BStructType;
 import org.ballerinalang.model.values.BConnector;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.nativeimpl.actions.ClientConnectorFuture;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.net.http.RetryConfig;
 import org.ballerinalang.runtime.message.MessageDataSource;
@@ -124,12 +124,12 @@ public abstract class AbstractHTTPAction extends AbstractNativeAction {
 
     private void setOutboundReqProperties(HTTPCarbonMessage outboundRequest, URL url, int port, String host) {
         outboundRequest.setProperty(org.wso2.transport.http.netty.common.Constants.HOST, host);
-        outboundRequest.setProperty(Constants.PORT, port);
+        outboundRequest.setProperty(HttpConstants.PORT, port);
 
         String outboundReqPath = getOutboundReqPath(url);
-        outboundRequest.setProperty(Constants.TO, outboundReqPath);
+        outboundRequest.setProperty(HttpConstants.TO, outboundReqPath);
 
-        outboundRequest.setProperty(Constants.PROTOCOL, url.getProtocol());
+        outboundRequest.setProperty(HttpConstants.PROTOCOL, url.getProtocol());
     }
 
     private void setHostHeader(String host, int port, HttpHeaders headers) {
@@ -142,8 +142,8 @@ public abstract class AbstractHTTPAction extends AbstractNativeAction {
 
     private void removeConnectionHeader(HttpHeaders headers) {
         // Remove existing Connection header
-        if (headers.contains(Constants.CONNECTION_HEADER)) {
-            headers.remove(Constants.CONNECTION_HEADER);
+        if (headers.contains(HttpConstants.CONNECTION_HEADER)) {
+            headers.remove(HttpConstants.CONNECTION_HEADER);
         }
     }
 
@@ -155,8 +155,8 @@ public abstract class AbstractHTTPAction extends AbstractNativeAction {
             userAgent = "ballerina";
         }
 
-        if (!headers.contains(Constants.USER_AGENT_HEADER)) { // If User-Agent is not already set from program
-            headers.set(Constants.USER_AGENT_HEADER, userAgent);
+        if (!headers.contains(HttpConstants.USER_AGENT_HEADER)) { // If User-Agent is not already set from program
+            headers.set(HttpConstants.USER_AGENT_HEADER, userAgent);
         }
     }
 
@@ -173,7 +173,7 @@ public abstract class AbstractHTTPAction extends AbstractNativeAction {
         int port = 80;
         if (url.getPort() != -1) {
             port = url.getPort();
-        } else if (url.getProtocol().equalsIgnoreCase(Constants.PROTOCOL_HTTPS)) {
+        } else if (url.getProtocol().equalsIgnoreCase(HttpConstants.PROTOCOL_HTTPS)) {
             port = 443;
         }
         return port;
@@ -193,10 +193,10 @@ public abstract class AbstractHTTPAction extends AbstractNativeAction {
         HTTPClientConnectorListener httpClientConnectorLister =
                 new HTTPClientConnectorListener(context, ballerinaFuture, retryConfig, outboundRequestMsg);
 
-        Object sourceHandler = outboundRequestMsg.getProperty(Constants.SRC_HANDLER);
+        Object sourceHandler = outboundRequestMsg.getProperty(HttpConstants.SRC_HANDLER);
         if (sourceHandler == null) {
-            outboundRequestMsg.setProperty(Constants.SRC_HANDLER,
-                    context.getProperty(Constants.SRC_HANDLER));
+            outboundRequestMsg.setProperty(HttpConstants.SRC_HANDLER,
+                                           context.getProperty(HttpConstants.SRC_HANDLER));
         }
         sendOutboundRequest(context, outboundRequestMsg, httpClientConnectorLister);
         return ballerinaFuture;
@@ -217,7 +217,7 @@ public abstract class AbstractHTTPAction extends AbstractNativeAction {
                       HTTPClientConnectorListener httpClientConnectorLister) throws Exception {
         BConnector bConnector = (BConnector) getRefArgument(context, 0);
         HttpClientConnector clientConnector =
-                (HttpClientConnector) bConnector.getnativeData(Constants.CONNECTOR_NAME);
+                (HttpClientConnector) bConnector.getnativeData(HttpConstants.CONNECTOR_NAME);
 
         HttpResponseFuture future = clientConnector.send(outboundRequestMsg);
         future.setHttpConnectorListener(httpClientConnectorLister);
@@ -250,17 +250,17 @@ public abstract class AbstractHTTPAction extends AbstractNativeAction {
 
     private RetryConfig getRetryConfiguration(Context context) {
         BConnector bConnector = (BConnector) getRefArgument(context, 0);
-        BStruct options = (BStruct) bConnector.getRefField(Constants.OPTIONS_STRUCT_INDEX);
+        BStruct options = (BStruct) bConnector.getRefField(HttpConstants.OPTIONS_STRUCT_INDEX);
         if (options == null) {
             return new RetryConfig();
         }
 
-        BStruct retryConfig = (BStruct) options.getRefField(Constants.RETRY_STRUCT_INDEX);
+        BStruct retryConfig = (BStruct) options.getRefField(HttpConstants.RETRY_STRUCT_INDEX);
         if (retryConfig == null) {
             return new RetryConfig();
         }
-        long retryCount = retryConfig.getIntField(Constants.RETRY_COUNT_INDEX);
-        long interval = retryConfig.getIntField(Constants.RETRY_INTERVAL_INDEX);
+        long retryCount = retryConfig.getIntField(HttpConstants.RETRY_COUNT_INDEX);
+        long interval = retryConfig.getIntField(HttpConstants.RETRY_INTERVAL_INDEX);
         return new RetryConfig(retryCount, interval);
     }
 
@@ -288,9 +288,9 @@ public abstract class AbstractHTTPAction extends AbstractNativeAction {
 
         @Override
         public void onMessage(HTTPCarbonMessage httpCarbonMessage) {
-            BStruct inboundResponse = createStruct(this.context, Constants.IN_RESPONSE,
-                    Constants.PROTOCOL_PACKAGE_HTTP);
-            BStruct entity = createStruct(this.context, Constants.ENTITY, PROTOCOL_PACKAGE_MIME);
+            BStruct inboundResponse = createStruct(this.context, HttpConstants.IN_RESPONSE,
+                                                   HttpConstants.PROTOCOL_PACKAGE_HTTP);
+            BStruct entity = createStruct(this.context, HttpConstants.ENTITY, PROTOCOL_PACKAGE_MIME);
             BStruct mediaType = createStruct(this.context, MEDIA_TYPE, PROTOCOL_PACKAGE_MIME);
             HttpUtil.populateInboundResponse(inboundResponse, entity, mediaType, httpCarbonMessage);
             ballerinaFuture.notifyReply(inboundResponse);
@@ -322,7 +322,7 @@ public abstract class AbstractHTTPAction extends AbstractNativeAction {
         }
 
         private void notifyError(Throwable throwable) {
-            BStruct httpConnectorError = createStruct(context, Constants.HTTP_CONNECTOR_ERROR,  Constants
+            BStruct httpConnectorError = createStruct(context, HttpConstants.HTTP_CONNECTOR_ERROR, HttpConstants
                     .PROTOCOL_PACKAGE_HTTP);
             httpConnectorError.setStringField(0, throwable.getMessage());
             if (throwable instanceof ClientConnectorException) {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Delete.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Delete.java
@@ -22,7 +22,7 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaAction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +35,7 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 @BallerinaAction(
         packageName = "ballerina.net.http",
         actionName = "delete",
-        connectorName = Constants.CONNECTOR_NAME,
+        connectorName = HttpConstants.CONNECTOR_NAME,
         args = {
                 @Argument(name = "c", type = TypeKind.CONNECTOR),
                 @Argument(name = "path", type = TypeKind.STRING),
@@ -67,7 +67,7 @@ public class Delete extends AbstractHTTPAction {
             // Execute the operation
             return executeNonBlockingAction(context, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
-            throw new BallerinaException("Failed to invoke 'delete' action in " + Constants.CONNECTOR_NAME
+            throw new BallerinaException("Failed to invoke 'delete' action in " + HttpConstants.CONNECTOR_NAME
                     + ". " + clientConnectorException.getMessage(), context);
         }
     }
@@ -76,7 +76,7 @@ public class Delete extends AbstractHTTPAction {
     protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {
         // Extract Argument values
         HTTPCarbonMessage cMsg = super.createOutboundRequestMsg(context);
-        cMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_METHOD_DELETE);
+        cMsg.setProperty(HttpConstants.HTTP_METHOD, HttpConstants.HTTP_METHOD_DELETE);
         return cMsg;
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Execute.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Execute.java
@@ -24,7 +24,7 @@ import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaAction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.slf4j.Logger;
@@ -40,7 +40,7 @@ import java.util.Locale;
 @BallerinaAction(
         packageName = "ballerina.net.http",
         actionName = "execute",
-        connectorName = Constants.CONNECTOR_NAME,
+        connectorName = HttpConstants.CONNECTOR_NAME,
         args = {
                 @Argument(name = "c", type = TypeKind.CONNECTOR),
                 @Argument(name = "httpVerb", type = TypeKind.STRING),
@@ -73,7 +73,7 @@ public class Execute extends AbstractHTTPAction {
             // Execute the operation
             return executeNonBlockingAction(context, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
-            throw new BallerinaException("Failed to invoke 'execute' action in " + Constants.CONNECTOR_NAME
+            throw new BallerinaException("Failed to invoke 'execute' action in " + HttpConstants.CONNECTOR_NAME
                     + ". " + clientConnectorException.getMessage(), context);
         }
     }
@@ -91,9 +91,9 @@ public class Execute extends AbstractHTTPAction {
 
         // If the verb is not specified, use the verb in incoming message
         if (httpVerb == null || "".equals(httpVerb)) {
-            httpVerb = (String) outboundRequestMsg.getProperty(Constants.HTTP_METHOD);
+            httpVerb = (String) outboundRequestMsg.getProperty(HttpConstants.HTTP_METHOD);
         }
-        outboundRequestMsg.setProperty(Constants.HTTP_METHOD, httpVerb.trim().toUpperCase(Locale.getDefault()));
+        outboundRequestMsg.setProperty(HttpConstants.HTTP_METHOD, httpVerb.trim().toUpperCase(Locale.getDefault()));
         return outboundRequestMsg;
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Forward.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Forward.java
@@ -26,7 +26,7 @@ import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaAction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.slf4j.Logger;
@@ -41,7 +41,7 @@ import java.util.Locale;
 @BallerinaAction(
         packageName = "ballerina.net.http",
         actionName = "forward",
-        connectorName = Constants.CONNECTOR_NAME,
+        connectorName = HttpConstants.CONNECTOR_NAME,
         args = {
                 @Argument(name = "c", type = TypeKind.CONNECTOR),
                 @Argument(name = "path", type = TypeKind.STRING),
@@ -73,7 +73,7 @@ public class Forward extends AbstractHTTPAction {
             // Execute the operation
             return executeNonBlockingAction(context, createOutboundRequestMsg(context));
         } catch (Throwable t) {
-            throw new BallerinaException("Failed to invoke 'forward' action in " + Constants.CONNECTOR_NAME
+            throw new BallerinaException("Failed to invoke 'forward' action in " + HttpConstants.CONNECTOR_NAME
                     + ". " + t.getMessage(), context);
         }
     }
@@ -83,7 +83,7 @@ public class Forward extends AbstractHTTPAction {
         String path = getStringArgument(context, 0);
         BStruct requestStruct = ((BStruct) getRefArgument(context, 1));
 
-        if (requestStruct.getNativeData(Constants.IN_REQUEST) == null) {
+        if (requestStruct.getNativeData(HttpConstants.IN_REQUEST) == null) {
             throw new BallerinaException("invalid inbound request parameter");
         }
 
@@ -91,8 +91,8 @@ public class Forward extends AbstractHTTPAction {
                 .getCarbonMsg(requestStruct, HttpUtil.createHttpCarbonMessage(true));
         prepareOutboundRequest(bConnector, path, outboundRequestMsg);
 
-        String httpVerb = (String) outboundRequestMsg.getProperty(Constants.HTTP_METHOD);
-        outboundRequestMsg.setProperty(Constants.HTTP_METHOD, httpVerb.trim().toUpperCase(Locale.getDefault()));
+        String httpVerb = (String) outboundRequestMsg.getProperty(HttpConstants.HTTP_METHOD);
+        outboundRequestMsg.setProperty(HttpConstants.HTTP_METHOD, httpVerb.trim().toUpperCase(Locale.getDefault()));
 
         return outboundRequestMsg;
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Get.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Get.java
@@ -22,7 +22,7 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaAction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +35,7 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 @BallerinaAction(
         packageName = "ballerina.net.http",
         actionName = "get",
-        connectorName = Constants.CONNECTOR_NAME,
+        connectorName = HttpConstants.CONNECTOR_NAME,
         args = {
                 @Argument(name = "c", type = TypeKind.CONNECTOR),
                 @Argument(name = "path", type = TypeKind.STRING),
@@ -66,14 +66,14 @@ public class Get extends AbstractHTTPAction {
             return executeNonBlockingAction(context, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
             // This is should be a JavaError. Need to handle this properly.
-            throw new BallerinaException("Failed to invoke 'get' action in " + Constants.CONNECTOR_NAME
+            throw new BallerinaException("Failed to invoke 'get' action in " + HttpConstants.CONNECTOR_NAME
                     + ". " + clientConnectorException.getMessage(), context);
         }
     }
 
     protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {
         HTTPCarbonMessage outboundReqMsg = super.createOutboundRequestMsg(context);
-        outboundReqMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_METHOD_GET);
+        outboundReqMsg.setProperty(HttpConstants.HTTP_METHOD, HttpConstants.HTTP_METHOD_GET);
         return outboundReqMsg;
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Head.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Head.java
@@ -24,7 +24,7 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaAction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +37,7 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 @BallerinaAction(
         packageName = "ballerina.net.http",
         actionName = "head",
-        connectorName = Constants.CONNECTOR_NAME,
+        connectorName = HttpConstants.CONNECTOR_NAME,
         args = {
                 @Argument(name = "c", type = TypeKind.CONNECTOR),
                 @Argument(name = "path", type = TypeKind.STRING),
@@ -68,14 +68,14 @@ public class Head extends AbstractHTTPAction {
             // Execute the operation
             return executeNonBlockingAction(context, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
-            throw new BallerinaException("Failed to invoke 'head' action in " + Constants.CONNECTOR_NAME
+            throw new BallerinaException("Failed to invoke 'head' action in " + HttpConstants.CONNECTOR_NAME
                     + ". " + clientConnectorException.getMessage(), context);
         }
     }
 
     protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {
         HTTPCarbonMessage outboundReqMsg = super.createOutboundRequestMsg(context);
-        outboundReqMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_METHOD_HEAD);
+        outboundReqMsg.setProperty(HttpConstants.HTTP_METHOD, HttpConstants.HTTP_METHOD_HEAD);
         return outboundReqMsg;
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Init.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Init.java
@@ -28,8 +28,8 @@ import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.nativeimpl.actions.ClientConnectorFuture;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaAction;
-import org.ballerinalang.net.http.Constants;
 import org.ballerinalang.net.http.HttpConnectionManager;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.wso2.transport.http.netty.common.ProxyServerConfiguration;
@@ -53,7 +53,7 @@ import java.util.Map;
 @BallerinaAction(
         packageName = "ballerina.net.http",
         actionName = "<init>",
-        connectorName = Constants.CONNECTOR_NAME,
+        connectorName = HttpConstants.CONNECTOR_NAME,
         args = {@Argument(name = "c", type = TypeKind.CONNECTOR)
         },
         connectorArgs = {
@@ -82,9 +82,9 @@ public class Init extends AbstractHTTPAction {
 
         String scheme;
         if (url.startsWith("http://")) {
-            scheme = Constants.PROTOCOL_HTTP;
+            scheme = HttpConstants.PROTOCOL_HTTP;
         } else if (url.startsWith("https://")) {
-            scheme = Constants.PROTOCOL_HTTPS;
+            scheme = HttpConstants.PROTOCOL_HTTPS;
         } else {
             throw new BallerinaException("malformed URL: " + url);
         }
@@ -97,21 +97,21 @@ public class Init extends AbstractHTTPAction {
         if (connectionManager.isHTTPTraceLoggerEnabled()) {
             senderConfiguration.setHttpTraceLogEnabled(true);
         }
-        senderConfiguration.setTLSStoreType(Constants.PKCS_STORE_TYPE);
+        senderConfiguration.setTLSStoreType(HttpConstants.PKCS_STORE_TYPE);
 
-        BStruct options = (BStruct) connector.getRefField(Constants.OPTIONS_STRUCT_INDEX);
+        BStruct options = (BStruct) connector.getRefField(HttpConstants.OPTIONS_STRUCT_INDEX);
         if (options != null) {
             populateSenderConfigurationOptions(senderConfiguration, options);
-            long maxActiveConnections = options.getIntField(Constants.MAX_ACTIVE_CONNECTIONS_INDEX);
+            long maxActiveConnections = options.getIntField(HttpConstants.MAX_ACTIVE_CONNECTIONS_INDEX);
             if (!isInteger(maxActiveConnections)) {
                 throw new BallerinaConnectorException("invalid maxActiveConnections value: " + maxActiveConnections);
             }
-            properties.put(Constants.MAX_ACTIVE_CONNECTIONS_PER_POOL, (int) maxActiveConnections);
+            properties.put(HttpConstants.MAX_ACTIVE_CONNECTIONS_PER_POOL, (int) maxActiveConnections);
         }
 
         HttpClientConnector httpClientConnector =
                 httpConnectorFactory.createHttpClientConnector(properties, senderConfiguration);
-        connector.setNativeData(Constants.CONNECTOR_NAME, httpClientConnector);
+        connector.setNativeData(HttpConstants.CONNECTOR_NAME, httpClientConnector);
 
         ClientConnectorFuture ballerinaFuture = new ClientConnectorFuture();
         ballerinaFuture.notifySuccess();
@@ -124,20 +124,20 @@ public class Init extends AbstractHTTPAction {
         ProxyServerConfiguration proxyServerConfiguration = null;
         int followRedirect = FALSE;
         int maxRedirectCount = DEFAULT_MAX_REDIRECT_COUNT;
-        if (options.getRefField(Constants.FOLLOW_REDIRECT_STRUCT_INDEX) != null) {
-            BStruct followRedirects = (BStruct) options.getRefField(Constants.FOLLOW_REDIRECT_STRUCT_INDEX);
-            followRedirect = followRedirects.getBooleanField(Constants.FOLLOW_REDIRECT_INDEX);
-            maxRedirectCount = (int) followRedirects.getIntField(Constants.MAX_REDIRECT_COUNT);
+        if (options.getRefField(HttpConstants.FOLLOW_REDIRECT_STRUCT_INDEX) != null) {
+            BStruct followRedirects = (BStruct) options.getRefField(HttpConstants.FOLLOW_REDIRECT_STRUCT_INDEX);
+            followRedirect = followRedirects.getBooleanField(HttpConstants.FOLLOW_REDIRECT_INDEX);
+            maxRedirectCount = (int) followRedirects.getIntField(HttpConstants.MAX_REDIRECT_COUNT);
         }
-        if (options.getRefField(Constants.SSL_STRUCT_INDEX) != null) {
-            BStruct ssl = (BStruct) options.getRefField(Constants.SSL_STRUCT_INDEX);
-            String trustStoreFile = ssl.getStringField(Constants.TRUST_STORE_FILE_INDEX);
-            String trustStorePassword = ssl.getStringField(Constants.TRUST_STORE_PASSWORD_INDEX);
-            String keyStoreFile = ssl.getStringField(Constants.KEY_STORE_FILE_INDEX);
-            String keyStorePassword = ssl.getStringField(Constants.KEY_STORE_PASSWORD_INDEX);
-            String sslEnabledProtocols = ssl.getStringField(Constants.SSL_ENABLED_PROTOCOLS_INDEX);
-            String ciphers = ssl.getStringField(Constants.CIPHERS_INDEX);
-            String sslProtocol = ssl.getStringField(Constants.SSL_PROTOCOL_INDEX);
+        if (options.getRefField(HttpConstants.SSL_STRUCT_INDEX) != null) {
+            BStruct ssl = (BStruct) options.getRefField(HttpConstants.SSL_STRUCT_INDEX);
+            String trustStoreFile = ssl.getStringField(HttpConstants.TRUST_STORE_FILE_INDEX);
+            String trustStorePassword = ssl.getStringField(HttpConstants.TRUST_STORE_PASSWORD_INDEX);
+            String keyStoreFile = ssl.getStringField(HttpConstants.KEY_STORE_FILE_INDEX);
+            String keyStorePassword = ssl.getStringField(HttpConstants.KEY_STORE_PASSWORD_INDEX);
+            String sslEnabledProtocols = ssl.getStringField(HttpConstants.SSL_ENABLED_PROTOCOLS_INDEX);
+            String ciphers = ssl.getStringField(HttpConstants.CIPHERS_INDEX);
+            String sslProtocol = ssl.getStringField(HttpConstants.SSL_PROTOCOL_INDEX);
 
             if (StringUtils.isNotBlank(trustStoreFile)) {
                 senderConfiguration.setTrustStoreFile(trustStoreFile);
@@ -154,11 +154,11 @@ public class Init extends AbstractHTTPAction {
 
             List<Parameter> clientParams = new ArrayList<>();
             if (StringUtils.isNotBlank(sslEnabledProtocols)) {
-                Parameter clientProtocols = new Parameter(Constants.SSL_ENABLED_PROTOCOLS, sslEnabledProtocols);
+                Parameter clientProtocols = new Parameter(HttpConstants.SSL_ENABLED_PROTOCOLS, sslEnabledProtocols);
                 clientParams.add(clientProtocols);
             }
             if (StringUtils.isNotBlank(ciphers)) {
-                Parameter clientCiphers = new Parameter(Constants.CIPHERS, ciphers);
+                Parameter clientCiphers = new Parameter(HttpConstants.CIPHERS, ciphers);
                 clientParams.add(clientCiphers);
             }
             if (StringUtils.isNotBlank(sslProtocol)) {
@@ -168,12 +168,12 @@ public class Init extends AbstractHTTPAction {
                 senderConfiguration.setParameters(clientParams);
             }
         }
-        if (options.getRefField(Constants.PROXY_STRUCT_INDEX) != null) {
-            BStruct proxy = (BStruct) options.getRefField(Constants.PROXY_STRUCT_INDEX);
-            String proxyHost = proxy.getStringField(Constants.PROXY_HOST_INDEX);
-            int proxyPort = (int) proxy.getIntField(Constants.PROXY_PORT_INDEX);
-            String proxyUserName = proxy.getStringField(Constants.PROXY_USER_NAME_INDEX);
-            String proxyPassword = proxy.getStringField(Constants.PROXY_PASSWORD_INDEX);
+        if (options.getRefField(HttpConstants.PROXY_STRUCT_INDEX) != null) {
+            BStruct proxy = (BStruct) options.getRefField(HttpConstants.PROXY_STRUCT_INDEX);
+            String proxyHost = proxy.getStringField(HttpConstants.PROXY_HOST_INDEX);
+            int proxyPort = (int) proxy.getIntField(HttpConstants.PROXY_PORT_INDEX);
+            String proxyUserName = proxy.getStringField(HttpConstants.PROXY_USER_NAME_INDEX);
+            String proxyPassword = proxy.getStringField(HttpConstants.PROXY_PASSWORD_INDEX);
             try {
                 proxyServerConfiguration = new ProxyServerConfiguration(proxyHost, proxyPort);
             } catch (UnknownHostException e) {
@@ -193,25 +193,25 @@ public class Init extends AbstractHTTPAction {
 
         // For the moment we don't have to pass it down to transport as we only support
         // chunking. Once we start supporting gzip, deflate, etc, we need to parse down the config.
-        String transferEncoding = options.getStringField(Constants.TRANSFER_ENCODING);
-        if (transferEncoding != null && !Constants.ANN_CONFIG_ATTR_CHUNKING.equalsIgnoreCase(transferEncoding)) {
+        String transferEncoding = options.getStringField(HttpConstants.TRANSFER_ENCODING);
+        if (transferEncoding != null && !HttpConstants.ANN_CONFIG_ATTR_CHUNKING.equalsIgnoreCase(transferEncoding)) {
             throw new BallerinaConnectorException("Unsupported configuration found for Transfer-Encoding : "
                                                           + transferEncoding);
         }
 
-        String chunking = options.getStringField(Constants.ENABLE_CHUNKING_INDEX);
+        String chunking = options.getStringField(HttpConstants.ENABLE_CHUNKING_INDEX);
         senderConfiguration.setChunkingConfig(HttpUtil.getChunkConfig(chunking));
 
-        long endpointTimeout = options.getIntField(Constants.ENDPOINT_TIMEOUT_STRUCT_INDEX);
+        long endpointTimeout = options.getIntField(HttpConstants.ENDPOINT_TIMEOUT_STRUCT_INDEX);
         if (endpointTimeout < 0 || !isInteger(endpointTimeout)) {
             throw new BallerinaConnectorException("invalid idle timeout: " + endpointTimeout);
         }
         senderConfiguration.setSocketIdleTimeout((int) endpointTimeout);
 
-        boolean isKeepAlive = options.getBooleanField(Constants.IS_KEEP_ALIVE_INDEX) == TRUE;
+        boolean isKeepAlive = options.getBooleanField(HttpConstants.IS_KEEP_ALIVE_INDEX) == TRUE;
         senderConfiguration.setKeepAlive(isKeepAlive);
 
-        String httpVersion = options.getStringField(Constants.HTTP_VERSION_STRUCT_INDEX);
+        String httpVersion = options.getStringField(HttpConstants.HTTP_VERSION_STRUCT_INDEX);
         senderConfiguration.setHttpVersion(httpVersion);
     }
 

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Options.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Options.java
@@ -24,7 +24,7 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaAction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +37,7 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 @BallerinaAction(
         packageName = "ballerina.net.http",
         actionName = "options",
-        connectorName = Constants.CONNECTOR_NAME,
+        connectorName = HttpConstants.CONNECTOR_NAME,
         args = {
                 @Argument(name = "c", type = TypeKind.CONNECTOR),
                 @Argument(name = "path", type = TypeKind.STRING),
@@ -67,14 +67,14 @@ public class Options extends AbstractHTTPAction {
         try {
             return executeNonBlockingAction(context, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
-            throw new BallerinaException("Failed to invoke 'options' action in " + Constants.CONNECTOR_NAME
+            throw new BallerinaException("Failed to invoke 'options' action in " + HttpConstants.CONNECTOR_NAME
                     + ". " + clientConnectorException.getMessage(), context);
         }
     }
 
     protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {
         HTTPCarbonMessage outboundRequestMsg = super.createOutboundRequestMsg(context);
-        outboundRequestMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_METHOD_OPTIONS);
+        outboundRequestMsg.setProperty(HttpConstants.HTTP_METHOD, HttpConstants.HTTP_METHOD_OPTIONS);
         return outboundRequestMsg;
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Patch.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Patch.java
@@ -22,7 +22,7 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaAction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +35,7 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 @BallerinaAction(
         packageName = "ballerina.net.http",
         actionName = "patch",
-        connectorName = Constants.CONNECTOR_NAME,
+        connectorName = HttpConstants.CONNECTOR_NAME,
         args = {
                 @Argument(name = "c", type = TypeKind.CONNECTOR),
                 @Argument(name = "path", type = TypeKind.STRING),
@@ -68,14 +68,14 @@ public class Patch extends AbstractHTTPAction {
             // Execute the operation
             return executeNonBlockingAction(context, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
-            throw new BallerinaException("Failed to invoke 'patch' action in " + Constants.CONNECTOR_NAME
+            throw new BallerinaException("Failed to invoke 'patch' action in " + HttpConstants.CONNECTOR_NAME
                     + ". " + clientConnectorException.getMessage(), context);
         }
     }
 
     protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {
         HTTPCarbonMessage outboundRequestMsg = super.createOutboundRequestMsg(context);
-        outboundRequestMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_METHOD_PATCH);
+        outboundRequestMsg.setProperty(HttpConstants.HTTP_METHOD, HttpConstants.HTTP_METHOD_PATCH);
         return outboundRequestMsg;
     }
 

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Post.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Post.java
@@ -22,7 +22,7 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaAction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +35,7 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 @BallerinaAction(
         packageName = "ballerina.net.http",
         actionName = "post",
-        connectorName = Constants.CONNECTOR_NAME,
+        connectorName = HttpConstants.CONNECTOR_NAME,
         args = {
                 @Argument(name = "c", type = TypeKind.CONNECTOR),
                 @Argument(name = "path", type = TypeKind.STRING),
@@ -67,14 +67,14 @@ public class Post extends AbstractHTTPAction {
             // Execute the operation
             return executeNonBlockingAction(context, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
-            throw new BallerinaException("Failed to invoke 'post' action in " + Constants.CONNECTOR_NAME
+            throw new BallerinaException("Failed to invoke 'post' action in " + HttpConstants.CONNECTOR_NAME
                     + ". " + clientConnectorException.getMessage(), context);
         }
     }
 
     protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {
         HTTPCarbonMessage outboundRequestMsg = super.createOutboundRequestMsg(context);
-        outboundRequestMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_METHOD_POST);
+        outboundRequestMsg.setProperty(HttpConstants.HTTP_METHOD, HttpConstants.HTTP_METHOD_POST);
         return outboundRequestMsg;
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Put.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Put.java
@@ -22,7 +22,7 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaAction;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +35,7 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 @BallerinaAction(
         packageName = "ballerina.net.http",
         actionName = "put",
-        connectorName = Constants.CONNECTOR_NAME,
+        connectorName = HttpConstants.CONNECTOR_NAME,
         args = {
                 @Argument(name = "c", type = TypeKind.CONNECTOR),
                 @Argument(name = "path", type = TypeKind.STRING),
@@ -68,14 +68,14 @@ public class Put extends AbstractHTTPAction {
             // Execute the operation
             return executeNonBlockingAction(context, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
-            throw new BallerinaException("Failed to invoke 'put' action in " + Constants.CONNECTOR_NAME
+            throw new BallerinaException("Failed to invoke 'put' action in " + HttpConstants.CONNECTOR_NAME
                     + ". " + clientConnectorException.getMessage(), context);
         }
     }
 
     protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {
         HTTPCarbonMessage outboundRequestMsg = super.createOutboundRequestMsg(context);
-        outboundRequestMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_METHOD_PUT);
+        outboundRequestMsg.setProperty(HttpConstants.HTTP_METHOD, HttpConstants.HTTP_METHOD_PUT);
         return outboundRequestMsg;
     }
 

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/inbound/request/GetQueryParams.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/inbound/request/GetQueryParams.java
@@ -28,7 +28,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.uri.URIUtil;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
@@ -52,10 +52,10 @@ public class GetQueryParams extends AbstractNativeFunction {
         try {
             BStruct requestStruct  = ((BStruct) getRefArgument(context, 0));
             HTTPCarbonMessage httpCarbonMessage = (HTTPCarbonMessage) requestStruct
-                    .getNativeData(Constants.TRANSPORT_MESSAGE);
+                    .getNativeData(HttpConstants.TRANSPORT_MESSAGE);
 
-            if (httpCarbonMessage.getProperty(Constants.QUERY_STR) != null) {
-                String queryString = (String) httpCarbonMessage.getProperty(Constants.QUERY_STR);
+            if (httpCarbonMessage.getProperty(HttpConstants.QUERY_STR) != null) {
+                String queryString = (String) httpCarbonMessage.getProperty(HttpConstants.QUERY_STR);
                 BMap<String, BString> params = new BMap<>();
                 URIUtil.populateQueryParamMap(queryString, params);
                 return getBValues(params);

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/CreateSessionIfAbsent.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/CreateSessionIfAbsent.java
@@ -26,7 +26,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.net.http.session.Session;
 import org.ballerinalang.net.http.session.SessionManager;
@@ -62,9 +62,9 @@ public class CreateSessionIfAbsent extends AbstractNativeFunction {
             //TODO check below line
             HTTPCarbonMessage httpCarbonMessage = HttpUtil
                     .getCarbonMsg(connectionStruct, HttpUtil.createHttpCarbonMessage(true));
-            String cookieHeader = httpCarbonMessage.getHeader(Constants.COOKIE_HEADER);
-            String path = (String) httpCarbonMessage.getProperty(Constants.BASE_PATH);
-            Session session = (Session) httpCarbonMessage.getProperty(Constants.HTTP_SESSION);
+            String cookieHeader = httpCarbonMessage.getHeader(HttpConstants.COOKIE_HEADER);
+            String path = (String) httpCarbonMessage.getProperty(HttpConstants.BASE_PATH);
+            Session session = (Session) httpCarbonMessage.getProperty(HttpConstants.HTTP_SESSION);
             if (cookieHeader != null) {
                 try {
                     String sessionId = HttpUtil.getSessionID(cookieHeader);
@@ -95,8 +95,8 @@ public class CreateSessionIfAbsent extends AbstractNativeFunction {
                 //create session since request doesn't have a cookie
                 session = SessionManager.getInstance().createHTTPSession(path);
             }
-            httpCarbonMessage.setProperty(Constants.HTTP_SESSION, session);
-            httpCarbonMessage.removeHeader(Constants.COOKIE_HEADER);
+            httpCarbonMessage.setProperty(HttpConstants.HTTP_SESSION, session);
+            httpCarbonMessage.removeHeader(HttpConstants.COOKIE_HEADER);
             return new BValue[]{HttpUtil.createSessionStruct(context, session)};
 
         } catch (IllegalStateException e) {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/GetAttribute.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/GetAttribute.java
@@ -27,7 +27,7 @@ import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.session.Session;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
@@ -51,7 +51,7 @@ public class GetAttribute extends AbstractNativeFunction {
         try {
             BStruct sessionStruct  = ((BStruct) getRefArgument(context, 0));
             String attributeKey = getStringArgument(context, 0);
-            Session session = (Session) sessionStruct.getNativeData(Constants.HTTP_SESSION);
+            Session session = (Session) sessionStruct.getNativeData(HttpConstants.HTTP_SESSION);
             if (session != null && session.isValid()) {
                 return getBValues(session.getAttributeValue(attributeKey));
             } else {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/GetAttributeNames.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/GetAttributeNames.java
@@ -27,7 +27,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.session.Session;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
@@ -50,7 +50,7 @@ public class GetAttributeNames extends AbstractNativeFunction {
     public BValue[] execute(Context context) {
         try {
             BStruct sessionStruct = ((BStruct) getRefArgument(context, 0));
-            Session session = (Session) sessionStruct.getNativeData(Constants.HTTP_SESSION);
+            Session session = (Session) sessionStruct.getNativeData(HttpConstants.HTTP_SESSION);
             if (session != null && session.isValid()) {
                 return getBValues(new BStringArray(session.getAttributeNames()));
             } else {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/GetAttributes.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/GetAttributes.java
@@ -26,7 +26,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.session.Session;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
@@ -48,7 +48,7 @@ public class GetAttributes extends AbstractNativeFunction {
     public BValue[] execute(Context context) {
         try {
             BStruct sessionStruct = ((BStruct) getRefArgument(context, 0));
-            Session session = (Session) sessionStruct.getNativeData(Constants.HTTP_SESSION);
+            Session session = (Session) sessionStruct.getNativeData(HttpConstants.HTTP_SESSION);
             if (session != null && session.isValid()) {
                 return getBValues(session.getAttributes());
             } else {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/GetCreationTime.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/GetCreationTime.java
@@ -27,7 +27,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.session.Session;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
@@ -49,7 +49,7 @@ public class GetCreationTime extends AbstractNativeFunction {
     public BValue[] execute(Context context) {
         try {
             BStruct sessionStruct  = ((BStruct) getRefArgument(context, 0));
-            Session session = (Session) sessionStruct.getNativeData(Constants.HTTP_SESSION);
+            Session session = (Session) sessionStruct.getNativeData(HttpConstants.HTTP_SESSION);
             if (session != null && session.isValid()) {
                 return getBValues(new BInteger(session.getCreationTime()));
             } else {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/GetId.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/GetId.java
@@ -27,7 +27,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.session.Session;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
@@ -49,7 +49,7 @@ public class GetId extends AbstractNativeFunction {
     public BValue[] execute(Context context) {
         try {
             BStruct sessionStruct  = ((BStruct) getRefArgument(context, 0));
-            Session session = (Session) sessionStruct.getNativeData(Constants.HTTP_SESSION);
+            Session session = (Session) sessionStruct.getNativeData(HttpConstants.HTTP_SESSION);
             if (session != null && session.isValid()) {
                 return getBValues(new BString(session.getId()));
             } else {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/GetLastAccessedTime.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/GetLastAccessedTime.java
@@ -27,7 +27,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.session.Session;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
@@ -49,7 +49,7 @@ public class GetLastAccessedTime extends AbstractNativeFunction {
     public BValue[] execute(Context context) {
         try {
             BStruct sessionStruct  = ((BStruct) getRefArgument(context, 0));
-            Session session = (Session) sessionStruct.getNativeData(Constants.HTTP_SESSION);
+            Session session = (Session) sessionStruct.getNativeData(HttpConstants.HTTP_SESSION);
             if (session != null  && session.isValid()) {
                 return getBValues(new BInteger(session.getLastAccessedTime()));
             } else {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/GetMaxInactiveInterval.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/GetMaxInactiveInterval.java
@@ -27,7 +27,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.session.Session;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
@@ -49,7 +49,7 @@ public class GetMaxInactiveInterval extends AbstractNativeFunction {
     public BValue[] execute(Context context) {
         try {
             BStruct sessionStruct  = ((BStruct) getRefArgument(context, 0));
-            Session session = (Session) sessionStruct.getNativeData(Constants.HTTP_SESSION);
+            Session session = (Session) sessionStruct.getNativeData(HttpConstants.HTTP_SESSION);
             if (session != null && session.isValid()) {
                 return getBValues(new BInteger(session.getMaxInactiveInterval()));
             } else {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/GetSession.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/GetSession.java
@@ -26,7 +26,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.net.http.session.Session;
 import org.ballerinalang.net.http.session.SessionManager;
@@ -61,9 +61,9 @@ public class GetSession extends AbstractNativeFunction {
             BStruct connectionStruct  = ((BStruct) getRefArgument(context, 0));
             //TODO check below line
             HTTPCarbonMessage httpCarbonMessage = HttpUtil.getCarbonMsg(connectionStruct, null);
-            String cookieHeader = httpCarbonMessage.getHeader(Constants.COOKIE_HEADER);
-            String path = (String) httpCarbonMessage.getProperty(Constants.BASE_PATH);
-            Session session = (Session) httpCarbonMessage.getProperty(Constants.HTTP_SESSION);
+            String cookieHeader = httpCarbonMessage.getHeader(HttpConstants.COOKIE_HEADER);
+            String path = (String) httpCarbonMessage.getProperty(HttpConstants.BASE_PATH);
+            Session session = (Session) httpCarbonMessage.getProperty(HttpConstants.HTTP_SESSION);
 
             if (cookieHeader != null) {
                 try {
@@ -95,8 +95,8 @@ public class GetSession extends AbstractNativeFunction {
                 logger.info("Failed to get session: session cookie is not available");
                 return new BValue[]{};
             }
-            httpCarbonMessage.setProperty(Constants.HTTP_SESSION, session);
-            httpCarbonMessage.removeHeader(Constants.COOKIE_HEADER);
+            httpCarbonMessage.setProperty(HttpConstants.HTTP_SESSION, session);
+            httpCarbonMessage.removeHeader(HttpConstants.COOKIE_HEADER);
             return new BValue[]{HttpUtil.createSessionStruct(context, session)};
         } catch (IllegalStateException e) {
             throw new BallerinaException(e.getMessage(), e);

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/Invalidate.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/Invalidate.java
@@ -25,7 +25,7 @@ import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.session.Session;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
@@ -46,7 +46,7 @@ public class Invalidate extends AbstractNativeFunction {
     public BValue[] execute(Context context) {
         try {
             BStruct sessionStruct  = ((BStruct) getRefArgument(context, 0));
-            Session session = (Session) sessionStruct.getNativeData(Constants.HTTP_SESSION);
+            Session session = (Session) sessionStruct.getNativeData(HttpConstants.HTTP_SESSION);
             if (session != null && session.isValid()) {
                 session.invalidate();
             } else {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/IsNew.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/IsNew.java
@@ -27,7 +27,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.session.Session;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
@@ -49,7 +49,7 @@ public class IsNew extends AbstractNativeFunction {
     public BValue[] execute(Context context) {
         try {
             BStruct sessionStruct = ((BStruct) getRefArgument(context, 0));
-            Session session = (Session) sessionStruct.getNativeData(Constants.HTTP_SESSION);
+            Session session = (Session) sessionStruct.getNativeData(HttpConstants.HTTP_SESSION);
             if (session != null && session.isValid()) {
                 return getBValues(new BBoolean(session.isNew()));
             } else {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/RemoveAttribute.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/RemoveAttribute.java
@@ -26,7 +26,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.session.Session;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
@@ -49,7 +49,7 @@ public class RemoveAttribute extends AbstractNativeFunction {
         try {
             BStruct sessionStruct  = ((BStruct) getRefArgument(context, 0));
             String attributeKey = getStringArgument(context, 0);
-            Session session = (Session) sessionStruct.getNativeData(Constants.HTTP_SESSION);
+            Session session = (Session) sessionStruct.getNativeData(HttpConstants.HTTP_SESSION);
             if (session != null && session.isValid()) {
                 session.removeAttribute(attributeKey);
             } else {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/SetAttribute.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/SetAttribute.java
@@ -26,7 +26,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.session.Session;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
@@ -54,7 +54,7 @@ public class SetAttribute extends AbstractNativeFunction {
             BStruct sessionStruct  = ((BStruct) getRefArgument(context, 0));
             String attributeKey = getStringArgument(context, 0);
             BValue attributeValue = getRefArgument(context, 1);
-            Session session = (Session) sessionStruct.getNativeData(Constants.HTTP_SESSION);
+            Session session = (Session) sessionStruct.getNativeData(HttpConstants.HTTP_SESSION);
 
             if (attributeKey == null || attributeValue == null) {
                 throw new NullPointerException("Failed to set attribute: Attribute key: "

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/SetMaxInactiveInterval.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/SetMaxInactiveInterval.java
@@ -26,7 +26,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.session.Session;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
@@ -52,7 +52,7 @@ public class SetMaxInactiveInterval extends AbstractNativeFunction {
         try {
             BStruct sessionStruct  = ((BStruct) getRefArgument(context, 0));
             int timeInterval = (int) getIntArgument(context, 0);
-            Session session = (Session) sessionStruct.getNativeData(Constants.HTTP_SESSION);
+            Session session = (Session) sessionStruct.getNativeData(HttpConstants.HTTP_SESSION);
 
             if (timeInterval == 0) {
                 throw new IllegalStateException("Failed to set max time interval: Time interval: " + timeInterval);

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/session/HTTPSession.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/session/HTTPSession.java
@@ -20,7 +20,7 @@ package org.ballerinalang.net.http.session;
 
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
 import java.io.Serializable;
@@ -137,8 +137,8 @@ public class HTTPSession implements Session, Serializable {
     public void generateSessionHeader(HTTPCarbonMessage message) {
         //Add set Cookie only for the first response after the creation
         if (this.isNew()) {
-            message.setHeader(Constants.RESPONSE_COOKIE_HEADER, Constants.SESSION_ID + this.getId() + "; "
-                    + Constants.PATH + this.getPath() + ";");
+            message.setHeader(HttpConstants.RESPONSE_COOKIE_HEADER, HttpConstants.SESSION_ID + this.getId() + "; "
+                    + HttpConstants.PATH + this.getPath() + ";");
         }
     }
 

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/uri/DispatcherUtil.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/uri/DispatcherUtil.java
@@ -22,7 +22,7 @@ package org.ballerinalang.net.uri;
 import org.ballerinalang.connector.api.AnnAttrValue;
 import org.ballerinalang.connector.api.Annotation;
 import org.ballerinalang.connector.api.Resource;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpResource;
 import org.ballerinalang.net.http.HttpService;
 import org.ballerinalang.net.http.HttpUtil;
@@ -37,9 +37,9 @@ import java.util.stream.Collectors;
  */
 public class DispatcherUtil {
 
-    private static String[] allMethods = new String[]{Constants.HTTP_METHOD_GET, Constants.HTTP_METHOD_HEAD
-            , Constants.HTTP_METHOD_POST, Constants.HTTP_METHOD_DELETE
-            , Constants.HTTP_METHOD_PUT, Constants.HTTP_METHOD_OPTIONS};
+    private static String[] allMethods = new String[]{HttpConstants.HTTP_METHOD_GET, HttpConstants.HTTP_METHOD_HEAD
+            , HttpConstants.HTTP_METHOD_POST, HttpConstants.HTTP_METHOD_DELETE
+            , HttpConstants.HTTP_METHOD_PUT, HttpConstants.HTTP_METHOD_OPTIONS};
 
     public static boolean isMatchingMethodExist(HttpResource resourceInfo, String method) {
         if (resourceInfo.getMethods() == null) {
@@ -50,12 +50,12 @@ public class DispatcherUtil {
 
     public static String[] getHttpMethods(Resource resource) {
         Annotation resourceConfigAnnotation = HttpUtil.getResourceConfigAnnotation(resource,
-                                                                                   Constants.HTTP_PACKAGE_PATH);
+                                                                                   HttpConstants.HTTP_PACKAGE_PATH);
         if (resourceConfigAnnotation == null) {
             return null;
         }
 
-        AnnAttrValue methodsAttrVal = resourceConfigAnnotation.getAnnAttrValue(Constants.ANN_RESOURCE_ATTR_METHODS);
+        AnnAttrValue methodsAttrVal = resourceConfigAnnotation.getAnnAttrValue(HttpConstants.ANN_RESOURCE_ATTR_METHODS);
         if (methodsAttrVal == null) {
             return null;
         }
@@ -87,10 +87,10 @@ public class DispatcherUtil {
         if (cachedMethods.isEmpty()) {
             return cachedMethods;
         }
-        if (cachedMethods.contains(Constants.HTTP_METHOD_GET)) {
-            cachedMethods.add(Constants.HTTP_METHOD_HEAD);
+        if (cachedMethods.contains(HttpConstants.HTTP_METHOD_GET)) {
+            cachedMethods.add(HttpConstants.HTTP_METHOD_HEAD);
         }
-        cachedMethods.add(Constants.HTTP_METHOD_OPTIONS);
+        cachedMethods.add(HttpConstants.HTTP_METHOD_OPTIONS);
         cachedMethods = cachedMethods.stream().distinct().collect(Collectors.toList());
         return cachedMethods;
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/uri/URIUtil.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/uri/URIUtil.java
@@ -22,7 +22,7 @@ import org.ballerinalang.connector.api.BallerinaConnectorException;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BValue;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
 import java.io.UnsupportedEncodingException;
@@ -72,7 +72,7 @@ public class URIUtil {
     public static BMap<String, BValue> getMatrixParamsMap(String path, HTTPCarbonMessage carbonMessage) {
         BMap<String, BValue> matrixParamsBMap = new BMap<>();
         Map<String, Map<String, String>> pathToMatrixParamMap =
-                (Map<String, Map<String, String>>) carbonMessage.getProperty(Constants.MATRIX_PARAMS);
+                (Map<String, Map<String, String>>) carbonMessage.getProperty(HttpConstants.MATRIX_PARAMS);
         Map<String, String> matrixParamsMap = pathToMatrixParamMap.get(path);
         if (matrixParamsMap != null) {
             for (Map.Entry<String, String> matrixParamEntry : matrixParamsMap.entrySet()) {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/uri/parser/Node.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/uri/parser/Node.java
@@ -18,7 +18,7 @@
 
 package org.ballerinalang.net.uri.parser;
 
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 
 import java.util.Collections;
 import java.util.LinkedList;
@@ -107,7 +107,7 @@ public abstract class Node<DataElementType extends DataElement> {
     }
 
     private void setUriPostFix(Map<String, String> variables, String subUriFragment) {
-        variables.putIfAbsent(Constants.EXTRA_PATH_INFO, "/" + subUriFragment);
+        variables.putIfAbsent(HttpConstants.EXTRA_PATH_INFO, "/" + subUriFragment);
     }
 
     abstract String expand(Map<String, String> variables);

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/BallerinaWsServerConnectorListener.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/BallerinaWsServerConnectorListener.java
@@ -69,14 +69,14 @@ public class BallerinaWsServerConnectorListener implements WebSocketConnectorLis
         BMap<String, BString> queryParams = new BMap<>();
         WebSocketService wsService = WebSocketDispatcher.findService(servicesRegistry, variables, webSocketInitMessage,
                                                                      queryParams);
-        Resource onHandshakeResource = wsService.getResourceByName(Constants.RESOURCE_NAME_ON_HANDSHAKE);
+        Resource onHandshakeResource = wsService.getResourceByName(WebSocketConstants.RESOURCE_NAME_ON_HANDSHAKE);
         if (onHandshakeResource != null) {
             Semaphore semaphore = new Semaphore(0);
             AtomicBoolean isResourceExeSuccessful = new AtomicBoolean(false);
             // TODO: Resource should be able to run without any parameter.
             BStruct handshakeStruct = wsService.createHandshakeConnectionStruct();
-            handshakeStruct.addNativeData(Constants.WEBSOCKET_MESSAGE, webSocketInitMessage);
-            handshakeStruct.addNativeData(Constants.NATIVE_DATA_QUERY_PARAMS, queryParams);
+            handshakeStruct.addNativeData(WebSocketConstants.WEBSOCKET_MESSAGE, webSocketInitMessage);
+            handshakeStruct.addNativeData(WebSocketConstants.NATIVE_DATA_QUERY_PARAMS, queryParams);
             handshakeStruct.setStringField(0, webSocketInitMessage.getSessionID());
             handshakeStruct.setBooleanField(0, webSocketInitMessage.isConnectionSecured() ? 1 : 0);
 
@@ -168,14 +168,14 @@ public class BallerinaWsServerConnectorListener implements WebSocketConnectorLis
             @Override
             public void onSuccess(Session session) {
                 BStruct wsConnection = wsService.createConnectionStruct();
-                wsConnection.addNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION, session);
-                wsConnection.addNativeData(Constants.WEBSOCKET_MESSAGE, initMessage);
-                wsConnection.addNativeData(Constants.NATIVE_DATA_UPGRADE_HEADERS, initMessage.getHeaders());
-                wsConnection.addNativeData(Constants.NATIVE_DATA_QUERY_PARAMS, queryParams);
+                wsConnection.addNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_SESSION, session);
+                wsConnection.addNativeData(WebSocketConstants.WEBSOCKET_MESSAGE, initMessage);
+                wsConnection.addNativeData(WebSocketConstants.NATIVE_DATA_UPGRADE_HEADERS, initMessage.getHeaders());
+                wsConnection.addNativeData(WebSocketConstants.NATIVE_DATA_QUERY_PARAMS, queryParams);
                 connectionManager.addConnection(session.getId(),
                                                 new WsOpenConnectionInfo(wsService, wsConnection, variables));
 
-                Resource onOpenResource = wsService.getResourceByName(Constants.RESOURCE_NAME_ON_OPEN);
+                Resource onOpenResource = wsService.getResourceByName(WebSocketConstants.RESOURCE_NAME_ON_OPEN);
                 if (onOpenResource == null) {
                     return;
                 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/WebSocketConstants.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/WebSocketConstants.java
@@ -21,7 +21,7 @@ package org.ballerinalang.net.ws;
 /**
  * Constants of WebSocket.
  */
-public class Constants extends org.ballerinalang.net.http.Constants {
+public class WebSocketConstants {
 
     // Common constants
     public static final String CONNECTOR_NAME = "WsClient";

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/WebSocketDispatcher.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/WebSocketDispatcher.java
@@ -93,7 +93,7 @@ public class WebSocketDispatcher {
 
     public static void dispatchTextMessage(WsOpenConnectionInfo connectionInfo, WebSocketTextMessage textMessage) {
         WebSocketService wsService = connectionInfo.getService();
-        Resource onTextMessageResource = wsService.getResourceByName(Constants.RESOURCE_NAME_ON_TEXT_MESSAGE);
+        Resource onTextMessageResource = wsService.getResourceByName(WebSocketConstants.RESOURCE_NAME_ON_TEXT_MESSAGE);
         if (onTextMessageResource == null) {
             return;
         }
@@ -117,7 +117,8 @@ public class WebSocketDispatcher {
     public static void dispatchBinaryMessage(WsOpenConnectionInfo connectionInfo,
                                              WebSocketBinaryMessage binaryMessage) {
         WebSocketService wsService = connectionInfo.getService();
-        Resource onBinaryMessageResource = wsService.getResourceByName(Constants.RESOURCE_NAME_ON_BINARY_MESSAGE);
+        Resource onBinaryMessageResource = wsService.getResourceByName(
+                WebSocketConstants.RESOURCE_NAME_ON_BINARY_MESSAGE);
         if (onBinaryMessageResource == null) {
             return;
         }
@@ -153,7 +154,7 @@ public class WebSocketDispatcher {
     private static void dispatchPingMessage(WsOpenConnectionInfo connectionInfo,
                                             WebSocketControlMessage controlMessage) {
         WebSocketService wsService = connectionInfo.getService();
-        Resource onPingMessageResource = wsService.getResourceByName(Constants.RESOURCE_NAME_ON_PING);
+        Resource onPingMessageResource = wsService.getResourceByName(WebSocketConstants.RESOURCE_NAME_ON_PING);
         if (onPingMessageResource == null) {
             pingAutomatically(controlMessage);
             return;
@@ -174,7 +175,7 @@ public class WebSocketDispatcher {
     private static void dispatchPongMessage(WsOpenConnectionInfo connectionInfo,
                                             WebSocketControlMessage controlMessage) {
         WebSocketService wsService = connectionInfo.getService();
-        Resource onPongMessageResource = wsService.getResourceByName(Constants.RESOURCE_NAME_ON_PONG);
+        Resource onPongMessageResource = wsService.getResourceByName(WebSocketConstants.RESOURCE_NAME_ON_PONG);
         if (onPongMessageResource == null) {
             return;
         }
@@ -193,7 +194,7 @@ public class WebSocketDispatcher {
 
     public static void dispatchCloseMessage(WsOpenConnectionInfo connectionInfo, WebSocketCloseMessage closeMessage) {
         WebSocketService wsService = connectionInfo.getService();
-        Resource onCloseResource = wsService.getResourceByName(Constants.RESOURCE_NAME_ON_CLOSE);
+        Resource onCloseResource = wsService.getResourceByName(WebSocketConstants.RESOURCE_NAME_ON_CLOSE);
         if (onCloseResource == null) {
             return;
         }
@@ -213,7 +214,7 @@ public class WebSocketDispatcher {
     public static void dispatchIdleTimeout(WsOpenConnectionInfo connectionInfo,
                                            WebSocketControlMessage controlMessage) {
         WebSocketService wsService = connectionInfo.getService();
-        Resource onIdleTimeoutResource = wsService.getResourceByName(Constants.RESOURCE_NAME_ON_IDLE_TIMEOUT);
+        Resource onIdleTimeoutResource = wsService.getResourceByName(WebSocketConstants.RESOURCE_NAME_ON_IDLE_TIMEOUT);
         if (onIdleTimeoutResource == null) {
             return;
         }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/WebSocketService.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/WebSocketService.java
@@ -49,7 +49,7 @@ public class WebSocketService implements Service {
         }
 
         Annotation configAnnotation =
-                HttpUtil.getServiceConfigAnnotation(service, Constants.PROTOCOL_PACKAGE_WS);
+                HttpUtil.getServiceConfigAnnotation(service, WebSocketConstants.PROTOCOL_PACKAGE_WS);
         negotiableSubProtocols = findNegotiableSubProtocols(configAnnotation);
         idleTimeoutInSeconds = findIdleTimeoutInSeconds(configAnnotation);
     }
@@ -92,48 +92,50 @@ public class WebSocketService implements Service {
     }
 
     public BStruct createHandshakeConnectionStruct() {
-        return ConnectorUtils.createStruct(service.getResources()[0], Constants.PROTOCOL_PACKAGE_WS,
-                                           Constants.STRUCT_WEBSOCKET_HANDSHAKE_CONNECTION);
+        return ConnectorUtils.createStruct(service.getResources()[0], WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                                           WebSocketConstants.STRUCT_WEBSOCKET_HANDSHAKE_CONNECTION);
     }
 
     public BStruct createConnectionStruct() {
-        BStruct wsConnection = ConnectorUtils.createStruct(service.getResources()[0], Constants.PROTOCOL_PACKAGE_WS,
-                                    Constants.STRUCT_WEBSOCKET_CONNECTION);
+        BStruct wsConnection = ConnectorUtils.createStruct(service.getResources()[0],
+                                                           WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                                                           WebSocketConstants.STRUCT_WEBSOCKET_CONNECTION);
         BMap<String, BValue> attributes = new BMap<>();
         wsConnection.setRefField(0, attributes);
         return wsConnection;
     }
 
     public BStruct createTextFrameStruct() {
-        return ConnectorUtils.createStruct(service.getResources()[0], Constants.PROTOCOL_PACKAGE_WS,
-                                           Constants.STRUCT_WEBSOCKET_TEXT_FRAME);
+        return ConnectorUtils.createStruct(service.getResources()[0], WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                                           WebSocketConstants.STRUCT_WEBSOCKET_TEXT_FRAME);
     }
 
     public BStruct createBinaryFrameStruct() {
-        return ConnectorUtils.createStruct(service.getResources()[0], Constants.PROTOCOL_PACKAGE_WS,
-                                           Constants.STRUCT_WEBSOCKET_BINARY_FRAME);
+        return ConnectorUtils.createStruct(service.getResources()[0], WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                                           WebSocketConstants.STRUCT_WEBSOCKET_BINARY_FRAME);
     }
 
     public BStruct createCloseFrameStruct() {
-        return ConnectorUtils.createStruct(service.getResources()[0], Constants.PROTOCOL_PACKAGE_WS,
-                                           Constants.STRUCT_WEBSOCKET_CLOSE_FRAME);
+        return ConnectorUtils.createStruct(service.getResources()[0], WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                                           WebSocketConstants.STRUCT_WEBSOCKET_CLOSE_FRAME);
     }
 
     public BStruct createPingFrameStruct() {
-        return ConnectorUtils.createStruct(service.getResources()[0], Constants.PROTOCOL_PACKAGE_WS,
-                                           Constants.STRUCT_WEBSOCKET_PING_FRAME);
+        return ConnectorUtils.createStruct(service.getResources()[0], WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                                           WebSocketConstants.STRUCT_WEBSOCKET_PING_FRAME);
     }
 
     public BStruct createPongFrameStruct() {
-        return ConnectorUtils.createStruct(service.getResources()[0], Constants.PROTOCOL_PACKAGE_WS,
-                                           Constants.STRUCT_WEBSOCKET_PONG_FRAME);
+        return ConnectorUtils.createStruct(service.getResources()[0], WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                                           WebSocketConstants.STRUCT_WEBSOCKET_PONG_FRAME);
     }
 
     private String[] findNegotiableSubProtocols(Annotation configAnnotation) {
         if (configAnnotation == null) {
             return null;
         }
-        AnnAttrValue annAttrSubProtocols = configAnnotation.getAnnAttrValue(Constants.ANNOTATION_ATTR_SUB_PROTOCOLS);
+        AnnAttrValue annAttrSubProtocols = configAnnotation.getAnnAttrValue(
+                WebSocketConstants.ANNOTATION_ATTR_SUB_PROTOCOLS);
         if (annAttrSubProtocols == null) {
             return null;
         }
@@ -150,7 +152,8 @@ public class WebSocketService implements Service {
         if (configAnnotation == null) {
             return 0;
         }
-        AnnAttrValue annAttrIdleTimeout = configAnnotation.getAnnAttrValue(Constants.ANNOTATION_ATTR_IDLE_TIMEOUT);
+        AnnAttrValue annAttrIdleTimeout = configAnnotation.getAnnAttrValue(
+                WebSocketConstants.ANNOTATION_ATTR_IDLE_TIMEOUT);
         if (annAttrIdleTimeout == null) {
             return 0;
         }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/WebSocketServiceValidator.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/WebSocketServiceValidator.java
@@ -24,6 +24,7 @@ import org.ballerinalang.connector.api.BallerinaConnectorException;
 import org.ballerinalang.connector.api.ParamDetail;
 import org.ballerinalang.connector.api.Resource;
 import org.ballerinalang.model.types.BStringType;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
@@ -35,20 +36,21 @@ import java.util.List;
 public class WebSocketServiceValidator {
 
     public static boolean validateClientService(WebSocketService wsService) {
-        if (HttpUtil.getServiceConfigAnnotation(wsService, Constants.PROTOCOL_PACKAGE_WS) != null) {
+        if (HttpUtil.getServiceConfigAnnotation(wsService, WebSocketConstants.PROTOCOL_PACKAGE_WS) != null) {
             throw new BallerinaException(
                     String.format("Cannot define %s:%s annotation for WebSocket client service",
-                                  Constants.PROTOCOL_PACKAGE_WS, Constants.ANNOTATION_CONFIGURATION));
+                                  WebSocketConstants.PROTOCOL_PACKAGE_WS, WebSocketConstants.ANNOTATION_CONFIGURATION));
         }
         return validateResources(wsService.getName(), wsService.getResources(), true);
     }
 
     public static boolean validateServiceEndpoint(WebSocketService wsService) {
-        if (wsService.getAnnotationList(Constants.PROTOCOL_PACKAGE_WS,
-                                        Constants.ANNOTATION_WEBSOCKET_CLIENT_SERVICE) != null) {
+        if (wsService.getAnnotationList(WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                                        WebSocketConstants.ANNOTATION_WEBSOCKET_CLIENT_SERVICE) != null) {
             throw new BallerinaException(
                     String.format("Cannot define %s:%s annotation for WebSocket client service",
-                                  Constants.PROTOCOL_PACKAGE_WS, Constants.ANNOTATION_WEBSOCKET_CLIENT_SERVICE));
+                                  WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                                  WebSocketConstants.ANNOTATION_WEBSOCKET_CLIENT_SERVICE));
         }
         validateConfigAnnotation(wsService);
         return validateResources(wsService.getName(), wsService.getResources(), false);
@@ -58,28 +60,28 @@ public class WebSocketServiceValidator {
         for (Resource resource : resources) {
             String resourceName = resource.getName();
             switch (resourceName) {
-                case Constants.RESOURCE_NAME_ON_HANDSHAKE:
+                case WebSocketConstants.RESOURCE_NAME_ON_HANDSHAKE:
                     validateOnHandshakeResource(serviceName, resource, isClientService);
                     break;
-                case Constants.RESOURCE_NAME_ON_OPEN:
+                case WebSocketConstants.RESOURCE_NAME_ON_OPEN:
                     validateOnOpenResource(serviceName, resource, isClientService);
                     break;
-                case Constants.RESOURCE_NAME_ON_TEXT_MESSAGE:
+                case WebSocketConstants.RESOURCE_NAME_ON_TEXT_MESSAGE:
                     validateOnTextMessageResource(serviceName, resource, isClientService);
                     break;
-                case Constants.RESOURCE_NAME_ON_BINARY_MESSAGE:
+                case WebSocketConstants.RESOURCE_NAME_ON_BINARY_MESSAGE:
                     validateOnBinaryMessageResource(serviceName, resource, isClientService);
                     break;
-                case Constants.RESOURCE_NAME_ON_PING:
+                case WebSocketConstants.RESOURCE_NAME_ON_PING:
                     validateOnPingResource(serviceName, resource, isClientService);
                     break;
-                case Constants.RESOURCE_NAME_ON_PONG:
+                case WebSocketConstants.RESOURCE_NAME_ON_PONG:
                     validateOnPongResource(serviceName, resource, isClientService);
                     break;
-                case Constants.RESOURCE_NAME_ON_IDLE_TIMEOUT:
+                case WebSocketConstants.RESOURCE_NAME_ON_IDLE_TIMEOUT:
                     validateOnIdleTimeoutResource(serviceName, resource, isClientService);
                     break;
-                case Constants.RESOURCE_NAME_ON_CLOSE:
+                case WebSocketConstants.RESOURCE_NAME_ON_CLOSE:
                     validateOnCloseResource(serviceName, resource, isClientService);
                     break;
                 default:
@@ -91,13 +93,13 @@ public class WebSocketServiceValidator {
 
     private static void validateConfigAnnotation(WebSocketService wsService) {
         Annotation configAnnotation =
-                HttpUtil.getServiceConfigAnnotation(wsService, Constants.PROTOCOL_PACKAGE_WS);
+                HttpUtil.getServiceConfigAnnotation(wsService, WebSocketConstants.PROTOCOL_PACKAGE_WS);
         if (configAnnotation == null) {
             return;
         }
-        AnnAttrValue basePath = configAnnotation.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_BASE_PATH);
-        AnnAttrValue host = configAnnotation.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_HOST);
-        AnnAttrValue port = configAnnotation.getAnnAttrValue(Constants.ANN_CONFIG_ATTR_PORT);
+        AnnAttrValue basePath = configAnnotation.getAnnAttrValue(HttpConstants.ANN_CONFIG_ATTR_BASE_PATH);
+        AnnAttrValue host = configAnnotation.getAnnAttrValue(HttpConstants.ANN_CONFIG_ATTR_HOST);
+        AnnAttrValue port = configAnnotation.getAnnAttrValue(HttpConstants.ANN_CONFIG_ATTR_PORT);
         if (basePath == null && (host != null || port != null)) {
             String msg = String.format("service %s: cannot define host, port configurations without base path",
                                        wsService.getName());
@@ -113,78 +115,78 @@ public class WebSocketServiceValidator {
      */
     public static boolean isWebSocketClientService(WebSocketService service) {
         List<Annotation> annotationList = service.getAnnotationList(
-                Constants.PROTOCOL_PACKAGE_WS, Constants.ANNOTATION_WEBSOCKET_CLIENT_SERVICE);
+                WebSocketConstants.PROTOCOL_PACKAGE_WS, WebSocketConstants.ANNOTATION_WEBSOCKET_CLIENT_SERVICE);
         return !(annotationList == null);
     }
 
     private static void validateOnHandshakeResource(String serviceName, Resource resource, boolean isClientService) {
         List<ParamDetail> paramDetails = resource.getParamDetails();
         validateParamDetailsSize(paramDetails, 1, serviceName, resource.getName(), isClientService);
-        validateStructType(resource.getName(), paramDetails.get(0), Constants.PROTOCOL_PACKAGE_WS,
-                           Constants.STRUCT_WEBSOCKET_HANDSHAKE_CONNECTION);
+        validateStructType(resource.getName(), paramDetails.get(0), WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                           WebSocketConstants.STRUCT_WEBSOCKET_HANDSHAKE_CONNECTION);
     }
 
     private static void validateOnOpenResource(String serviceName, Resource resource, boolean isClientService) {
         List<ParamDetail> paramDetails = resource.getParamDetails();
         validateParamDetailsSize(paramDetails, 1, serviceName, resource.getName(), isClientService);
-        validateStructType(resource.getName(), paramDetails.get(0), Constants.PROTOCOL_PACKAGE_WS,
-                           Constants.STRUCT_WEBSOCKET_CONNECTION);
+        validateStructType(resource.getName(), paramDetails.get(0), WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                           WebSocketConstants.STRUCT_WEBSOCKET_CONNECTION);
     }
 
     private static void validateOnTextMessageResource(String serviceName, Resource resource, boolean isClientService) {
         List<ParamDetail> paramDetails = resource.getParamDetails();
         validateParamDetailsSize(paramDetails, 2, serviceName, resource.getName(), isClientService);
-        validateStructType(resource.getName(), paramDetails.get(0), Constants.PROTOCOL_PACKAGE_WS,
-                           Constants.STRUCT_WEBSOCKET_CONNECTION);
-        validateStructType(resource.getName(), paramDetails.get(1), Constants.PROTOCOL_PACKAGE_WS,
-                           Constants.STRUCT_WEBSOCKET_TEXT_FRAME);
+        validateStructType(resource.getName(), paramDetails.get(0), WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                           WebSocketConstants.STRUCT_WEBSOCKET_CONNECTION);
+        validateStructType(resource.getName(), paramDetails.get(1), WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                           WebSocketConstants.STRUCT_WEBSOCKET_TEXT_FRAME);
     }
 
     private static void validateOnBinaryMessageResource(String serviceName, Resource resource,
                                                         boolean isClientService) {
         List<ParamDetail> paramDetails = resource.getParamDetails();
         validateParamDetailsSize(paramDetails, 2, serviceName, resource.getName(), isClientService);
-        validateStructType(resource.getName(), paramDetails.get(0), Constants.PROTOCOL_PACKAGE_WS,
-                           Constants.STRUCT_WEBSOCKET_CONNECTION);
-        validateStructType(resource.getName(), paramDetails.get(1), Constants.PROTOCOL_PACKAGE_WS,
-                           Constants.STRUCT_WEBSOCKET_BINARY_FRAME);
+        validateStructType(resource.getName(), paramDetails.get(0), WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                           WebSocketConstants.STRUCT_WEBSOCKET_CONNECTION);
+        validateStructType(resource.getName(), paramDetails.get(1), WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                           WebSocketConstants.STRUCT_WEBSOCKET_BINARY_FRAME);
 
     }
 
     private static void validateOnPingResource(String serviceName, Resource resource, boolean isClientService) {
         List<ParamDetail> paramDetails = resource.getParamDetails();
         validateParamDetailsSize(paramDetails, 2, serviceName, resource.getName(), isClientService);
-        validateStructType(resource.getName(), paramDetails.get(0), Constants.PROTOCOL_PACKAGE_WS,
-                           Constants.STRUCT_WEBSOCKET_CONNECTION);
-        validateStructType(resource.getName(), paramDetails.get(1), Constants.PROTOCOL_PACKAGE_WS,
-                           Constants.STRUCT_WEBSOCKET_PING_FRAME);
+        validateStructType(resource.getName(), paramDetails.get(0), WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                           WebSocketConstants.STRUCT_WEBSOCKET_CONNECTION);
+        validateStructType(resource.getName(), paramDetails.get(1), WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                           WebSocketConstants.STRUCT_WEBSOCKET_PING_FRAME);
 
     }
 
     private static void validateOnPongResource(String serviceName, Resource resource, boolean isClientService) {
         List<ParamDetail> paramDetails = resource.getParamDetails();
         validateParamDetailsSize(paramDetails, 2, serviceName, resource.getName(), isClientService);
-        validateStructType(resource.getName(), paramDetails.get(0), Constants.PROTOCOL_PACKAGE_WS,
-                           Constants.STRUCT_WEBSOCKET_CONNECTION);
-        validateStructType(resource.getName(), paramDetails.get(1), Constants.PROTOCOL_PACKAGE_WS,
-                           Constants.STRUCT_WEBSOCKET_PONG_FRAME);
+        validateStructType(resource.getName(), paramDetails.get(0), WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                           WebSocketConstants.STRUCT_WEBSOCKET_CONNECTION);
+        validateStructType(resource.getName(), paramDetails.get(1), WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                           WebSocketConstants.STRUCT_WEBSOCKET_PONG_FRAME);
 
     }
 
     private static void validateOnIdleTimeoutResource(String serviceName, Resource resource, boolean isClientService) {
         List<ParamDetail> paramDetails = resource.getParamDetails();
         validateParamDetailsSize(paramDetails, 1, serviceName, resource.getName(), isClientService);
-        validateStructType(resource.getName(), paramDetails.get(0), Constants.PROTOCOL_PACKAGE_WS,
-                           Constants.STRUCT_WEBSOCKET_CONNECTION);
+        validateStructType(resource.getName(), paramDetails.get(0), WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                           WebSocketConstants.STRUCT_WEBSOCKET_CONNECTION);
     }
 
     private static void validateOnCloseResource(String serviceName, Resource resource, boolean isClientService) {
         List<ParamDetail> paramDetails = resource.getParamDetails();
         validateParamDetailsSize(paramDetails, 2, serviceName, resource.getName(), isClientService);
-        validateStructType(resource.getName(), paramDetails.get(0), Constants.PROTOCOL_PACKAGE_WS,
-                           Constants.STRUCT_WEBSOCKET_CONNECTION);
-        validateStructType(resource.getName(), paramDetails.get(1), Constants.PROTOCOL_PACKAGE_WS,
-                           Constants.STRUCT_WEBSOCKET_CLOSE_FRAME);
+        validateStructType(resource.getName(), paramDetails.get(0), WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                           WebSocketConstants.STRUCT_WEBSOCKET_CONNECTION);
+        validateStructType(resource.getName(), paramDetails.get(1), WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                           WebSocketConstants.STRUCT_WEBSOCKET_CLOSE_FRAME);
     }
 
     private static void validateParamDetailsSize(List<ParamDetail> paramDetails, int expectedSize, String serviceName,

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/WebSocketServicesRegistry.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/WebSocketServicesRegistry.java
@@ -22,6 +22,7 @@ import org.ballerinalang.connector.api.AnnAttrValue;
 import org.ballerinalang.connector.api.Annotation;
 import org.ballerinalang.connector.api.BallerinaConnectorException;
 import org.ballerinalang.net.http.HttpConnectionManager;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.net.uri.URITemplate;
 import org.ballerinalang.net.uri.URITemplateException;
@@ -73,7 +74,7 @@ public class WebSocketServicesRegistry {
         } else {
             if (WebSocketServiceValidator.validateServiceEndpoint(service)) {
                 Annotation configAnnotation =
-                        HttpUtil.getServiceConfigAnnotation(service, Constants.PROTOCOL_PACKAGE_WS);
+                        HttpUtil.getServiceConfigAnnotation(service, WebSocketConstants.PROTOCOL_PACKAGE_WS);
                 if (configAnnotation == null) {
                     slaveServices.put(service.getName(), service);
                     return;
@@ -123,7 +124,7 @@ public class WebSocketServicesRegistry {
             StringBuilder errorMsg = new StringBuilder("Cannot register following services: \n");
             for (String serviceName : slaveServices.keySet()) {
                 WebSocketService service = slaveServices.remove(serviceName);
-                if (HttpUtil.getServiceConfigAnnotation(service, Constants.PROTOCOL_PACKAGE_WS) == null) {
+                if (HttpUtil.getServiceConfigAnnotation(service, WebSocketConstants.PROTOCOL_PACKAGE_WS) == null) {
                     String msg = "Cannot deploy WebSocket service without configuration annotation";
                     errorMsg.append(String.format("\t%s: %s\n", serviceName, msg));
                 } else {
@@ -221,11 +222,12 @@ public class WebSocketServicesRegistry {
      */
     private String findFullWebSocketUpgradePath(WebSocketService service) {
         // Find Base path for WebSocket
-        Annotation configAnnotation = HttpUtil.getServiceConfigAnnotation(service, Constants.PROTOCOL_PACKAGE_WS);
+        Annotation configAnnotation = HttpUtil.getServiceConfigAnnotation(service,
+                                                                          WebSocketConstants.PROTOCOL_PACKAGE_WS);
         String basePath = null;
         if (configAnnotation != null) {
             AnnAttrValue annotationAttributeBasePathValue = configAnnotation.getAnnAttrValue
-                    (Constants.ANN_CONFIG_ATTR_BASE_PATH);
+                    (HttpConstants.ANN_CONFIG_ATTR_BASE_PATH);
             if (annotationAttributeBasePathValue != null && annotationAttributeBasePathValue.getStringValue() != null
                     && !annotationAttributeBasePathValue.getStringValue().trim().isEmpty()) {
                 basePath = refactorUri(annotationAttributeBasePathValue.getStringValue());

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/WebSocketUtil.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/WebSocketUtil.java
@@ -30,10 +30,10 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 public abstract class WebSocketUtil {
     public static BValue[] getQueryParams(Context context, AbstractNativeFunction abstractNativeFunction) {
         BStruct wsConnection = (BStruct) abstractNativeFunction.getRefArgument(context, 0);
-        Object queryParams = wsConnection.getNativeData(Constants.NATIVE_DATA_QUERY_PARAMS);
+        Object queryParams = wsConnection.getNativeData(WebSocketConstants.NATIVE_DATA_QUERY_PARAMS);
         if (queryParams != null && queryParams instanceof BMap) {
             return abstractNativeFunction.getBValues(
-                    (BMap) wsConnection.getNativeData(Constants.NATIVE_DATA_QUERY_PARAMS));
+                    (BMap) wsConnection.getNativeData(WebSocketConstants.NATIVE_DATA_QUERY_PARAMS));
         }
         return abstractNativeFunction.getBValues(new BMap<>());
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/actions/AbstractNativeWsAction.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/actions/AbstractNativeWsAction.java
@@ -26,7 +26,7 @@ import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BRefType;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStruct;
-import org.ballerinalang.net.ws.Constants;
+import org.ballerinalang.net.ws.WebSocketConstants;
 import org.ballerinalang.net.ws.WebSocketService;
 import org.ballerinalang.util.codegen.PackageInfo;
 import org.ballerinalang.util.codegen.StructInfo;
@@ -43,17 +43,18 @@ public abstract class AbstractNativeWsAction extends AbstractNativeAction {
 
     public BStruct createWsConnectionStruct(WebSocketService wsService, Session session, String parentConnectionID) {
         BStruct wsConnection = wsService.createConnectionStruct();
-        wsConnection.addNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION, session);
-        wsConnection.addNativeData(Constants.NATIVE_DATA_PARENT_CONNECTION_ID, parentConnectionID);
+        wsConnection.addNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_SESSION, session);
+        wsConnection.addNativeData(WebSocketConstants.NATIVE_DATA_PARENT_CONNECTION_ID, parentConnectionID);
         return wsConnection;
     }
 
     public BStruct createWsErrorStruct(Context context, Throwable throwable) {
 
         //gather package details from natives
-        PackageInfo wsErrorPackageInfo = context.getProgramFile().getPackageInfo(Constants.PROTOCOL_PACKAGE_WS);
+        PackageInfo wsErrorPackageInfo = context.getProgramFile().getPackageInfo(
+                WebSocketConstants.PROTOCOL_PACKAGE_WS);
         StructInfo wsConnectionStructInfo =
-                wsErrorPackageInfo.getStructInfo(Constants.STRUCT_WEBSOCKET_ERROR);
+                wsErrorPackageInfo.getStructInfo(WebSocketConstants.STRUCT_WEBSOCKET_ERROR);
 
         //create error struct
         BStructType structType = wsConnectionStructInfo.getType();

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/actions/Connect.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/actions/Connect.java
@@ -33,8 +33,9 @@ import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaAction;
 import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.net.http.BallerinaHttpServerConnector;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.ws.BallerinaWsClientConnectorListener;
-import org.ballerinalang.net.ws.Constants;
+import org.ballerinalang.net.ws.WebSocketConstants;
 import org.ballerinalang.net.ws.WebSocketService;
 import org.ballerinalang.net.ws.WsOpenConnectionInfo;
 import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
@@ -55,11 +56,11 @@ import javax.websocket.Session;
 @BallerinaAction(
         packageName = "ballerina.net.ws",
         actionName = "connect",
-        connectorName = Constants.CONNECTOR_NAME,
+        connectorName = WebSocketConstants.CONNECTOR_NAME,
         args = {
                 @Argument(name = "c", type = TypeKind.CONNECTOR),
                 @Argument(name = "clientConnectorConfig", type = TypeKind.STRUCT, structType = "ClientConnectorConfig",
-                          structPackage = Constants.PROTOCOL_PACKAGE_WS)
+                          structPackage = WebSocketConstants.PROTOCOL_PACKAGE_WS)
         },
         returnType = {@ReturnType(type = TypeKind.STRUCT, structType = "Connection",
                                   structPackage = "ballerina.net.ws")}
@@ -73,7 +74,7 @@ public class Connect extends AbstractNativeWsAction {
         String remoteUrl = getUrlFromConnector(bconnector);
         String clientServiceName = getClientServiceNameFromConnector(bconnector);
         BallerinaHttpServerConnector httpServerConnector = (BallerinaHttpServerConnector) ConnectorUtils.
-                getBallerinaServerConnector(context, Constants.HTTP_PACKAGE_PATH);
+                getBallerinaServerConnector(context, HttpConstants.HTTP_PACKAGE_PATH);
         final WebSocketService wsService =
                 httpServerConnector.getWebSocketServicesRegistry().getClientService(clientServiceName);
         if (wsService == null) {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/actions/ConnectWithDefault.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/actions/ConnectWithDefault.java
@@ -30,8 +30,9 @@ import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaAction;
 import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.net.http.BallerinaHttpServerConnector;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.ws.BallerinaWsClientConnectorListener;
-import org.ballerinalang.net.ws.Constants;
+import org.ballerinalang.net.ws.WebSocketConstants;
 import org.ballerinalang.net.ws.WebSocketService;
 import org.ballerinalang.net.ws.WsOpenConnectionInfo;
 import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
@@ -52,7 +53,7 @@ import javax.websocket.Session;
 @BallerinaAction(
         packageName = "ballerina.net.ws",
         actionName = "connectWithDefault",
-        connectorName = Constants.CONNECTOR_NAME,
+        connectorName = WebSocketConstants.CONNECTOR_NAME,
         args = {
                 @Argument(name = "c", type = TypeKind.CONNECTOR)
         },
@@ -66,7 +67,7 @@ public class ConnectWithDefault extends AbstractNativeWsAction {
         String remoteUrl = getUrlFromConnector(bconnector);
         String clientServiceName = getClientServiceNameFromConnector(bconnector);
         BallerinaHttpServerConnector httpServerConnector = (BallerinaHttpServerConnector) ConnectorUtils.
-                getBallerinaServerConnector(context, Constants.HTTP_PACKAGE_PATH);
+                getBallerinaServerConnector(context, HttpConstants.HTTP_PACKAGE_PATH);
         final WebSocketService wsService =
                 httpServerConnector.getWebSocketServicesRegistry().getClientService(clientServiceName);
         if (wsService == null) {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/CloseConnection.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/CloseConnection.java
@@ -26,8 +26,8 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
-import org.ballerinalang.net.ws.Constants;
 import org.ballerinalang.net.ws.WebSocketConnectionManager;
+import org.ballerinalang.net.ws.WebSocketConstants;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
 import java.io.IOException;
@@ -56,7 +56,7 @@ public class CloseConnection extends AbstractNativeFunction {
         BStruct wsConnection = (BStruct) getRefArgument(context, 0);
         int statusCode = (int) getIntArgument(context, 0);
         String reason = getStringArgument(context, 0);
-        Session session = (Session) wsConnection.getNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION);
+        Session session = (Session) wsConnection.getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_SESSION);
         try {
             session.close(new CloseReason(() -> statusCode, reason));
         } catch (IOException e) {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/GetID.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/GetID.java
@@ -27,7 +27,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.ws.Constants;
+import org.ballerinalang.net.ws.WebSocketConstants;
 
 import javax.websocket.Session;
 
@@ -50,7 +50,7 @@ public class GetID extends AbstractNativeFunction {
     @Override
     public BValue[] execute(Context context) {
         BStruct wsConnection = (BStruct) getRefArgument(context, 0);
-        Session session = (Session) wsConnection.getNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION);
+        Session session = (Session) wsConnection.getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_SESSION);
         String id = session.getId();
         return getBValues(new BString(id));
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/GetNegotiatedSubProtocol.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/GetNegotiatedSubProtocol.java
@@ -27,7 +27,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.ws.Constants;
+import org.ballerinalang.net.ws.WebSocketConstants;
 
 import javax.websocket.Session;
 
@@ -50,7 +50,7 @@ public class GetNegotiatedSubProtocol extends AbstractNativeFunction {
     @Override
     public BValue[] execute(Context context) {
         BStruct wsConnection = (BStruct) getRefArgument(context, 0);
-        Session session = (Session) wsConnection.getNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION);
+        Session session = (Session) wsConnection.getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_SESSION);
         String negotiatedSubProtocol = session.getNegotiatedSubprotocol();
         return getBValues(new BString(negotiatedSubProtocol));
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/GetParentConnection.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/GetParentConnection.java
@@ -26,8 +26,8 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.ws.Constants;
 import org.ballerinalang.net.ws.WebSocketConnectionManager;
+import org.ballerinalang.net.ws.WebSocketConstants;
 import org.ballerinalang.net.ws.WsOpenConnectionInfo;
 
 /**
@@ -50,7 +50,8 @@ public class GetParentConnection extends AbstractNativeFunction {
     @Override
     public BValue[] execute(Context context) {
         BStruct wsConnection = (BStruct) getRefArgument(context, 0);
-        String parentConnectionID = (String) wsConnection.getNativeData(Constants.NATIVE_DATA_PARENT_CONNECTION_ID);
+        String parentConnectionID = (String) wsConnection.getNativeData(
+                WebSocketConstants.NATIVE_DATA_PARENT_CONNECTION_ID);
         WsOpenConnectionInfo connectionInfo =
                 WebSocketConnectionManager.getInstance().getConnectionInfo(parentConnectionID);
         return getBValues(connectionInfo.getWsConnection());

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/GetUpgradeHeader.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/GetUpgradeHeader.java
@@ -28,7 +28,7 @@ import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.ws.Constants;
+import org.ballerinalang.net.ws.WebSocketConstants;
 
 import java.util.Locale;
 import java.util.Map;
@@ -55,7 +55,7 @@ public class GetUpgradeHeader extends AbstractNativeFunction {
         BStruct wsConnection = (BStruct) getRefArgument(context, 0);
         String key = getStringArgument(context, 0).toLowerCase(Locale.ENGLISH);
         Map<String, String> upgradeHeaders =
-                (Map<String, String>) wsConnection.getNativeData(Constants.NATIVE_DATA_UPGRADE_HEADERS);
+                (Map<String, String>) wsConnection.getNativeData(WebSocketConstants.NATIVE_DATA_UPGRADE_HEADERS);
         return getBValues(new BString(upgradeHeaders.get(key)));
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/GetUpgradeHeaders.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/GetUpgradeHeaders.java
@@ -28,7 +28,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.ws.Constants;
+import org.ballerinalang.net.ws.WebSocketConstants;
 
 import java.util.Map;
 
@@ -52,7 +52,7 @@ public class GetUpgradeHeaders extends AbstractNativeFunction {
     public BValue[] execute(Context context) {
         BStruct wsConnection = (BStruct) getRefArgument(context, 0);
         Map<String, String> upgradeHeaders =
-                (Map<String, String>) wsConnection.getNativeData(Constants.NATIVE_DATA_UPGRADE_HEADERS);
+                (Map<String, String>) wsConnection.getNativeData(WebSocketConstants.NATIVE_DATA_UPGRADE_HEADERS);
         BMap<String, BString> bUpgradeHeaders = new BMap<>();
         upgradeHeaders.entrySet().forEach(
                 upgradeHeader -> bUpgradeHeaders.put(upgradeHeader.getKey(), new BString(upgradeHeader.getValue())));

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/IsOpen.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/IsOpen.java
@@ -27,7 +27,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.ws.Constants;
+import org.ballerinalang.net.ws.WebSocketConstants;
 
 import javax.websocket.Session;
 
@@ -50,7 +50,7 @@ public class IsOpen extends AbstractNativeFunction {
     @Override
     public BValue[] execute(Context context) {
         BStruct wsConnection = (BStruct) getRefArgument(context, 0);
-        Session session = (Session) wsConnection.getNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION);
+        Session session = (Session) wsConnection.getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_SESSION);
         boolean isOpen = session.isOpen();
         return getBValues(new BBoolean(isOpen));
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/IsSecure.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/IsSecure.java
@@ -27,7 +27,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.net.ws.Constants;
+import org.ballerinalang.net.ws.WebSocketConstants;
 
 import javax.websocket.Session;
 
@@ -50,7 +50,7 @@ public class IsSecure extends AbstractNativeFunction {
     @Override
     public BValue[] execute(Context context) {
         BStruct wsConnection = (BStruct) getRefArgument(context, 0);
-        Session session = (Session) wsConnection.getNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION);
+        Session session = (Session) wsConnection.getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_SESSION);
         boolean isSecuredConnection = session.isSecure();
         return getBValues(new BBoolean(isSecuredConnection));
     }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/Ping.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/Ping.java
@@ -26,7 +26,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
-import org.ballerinalang.net.ws.Constants;
+import org.ballerinalang.net.ws.WebSocketConstants;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
 import java.nio.ByteBuffer;
@@ -53,7 +53,7 @@ public class Ping extends AbstractNativeFunction {
     public BValue[] execute(Context context) {
         try {
             BStruct wsConnection = (BStruct) getRefArgument(context, 0);
-            Session session = (Session) wsConnection.getNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION);
+            Session session = (Session) wsConnection.getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_SESSION);
             byte[] binaryData = getBlobArgument(context, 0);
             session.getBasicRemote().sendPing(ByteBuffer.wrap(binaryData));
         } catch (Throwable e) {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/Pong.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/Pong.java
@@ -26,7 +26,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
-import org.ballerinalang.net.ws.Constants;
+import org.ballerinalang.net.ws.WebSocketConstants;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
 import java.nio.ByteBuffer;
@@ -52,7 +52,7 @@ public class Pong extends AbstractNativeFunction {
     public BValue[] execute(Context context) {
         try {
             BStruct wsConnection = (BStruct) getRefArgument(context, 0);
-            Session session = (Session) wsConnection.getNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION);
+            Session session = (Session) wsConnection.getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_SESSION);
             byte[] binaryData = getBlobArgument(context, 0);
             session.getBasicRemote().sendPong(ByteBuffer.wrap(binaryData));
         } catch (Throwable e) {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/PushBinary.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/PushBinary.java
@@ -26,7 +26,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
-import org.ballerinalang.net.ws.Constants;
+import org.ballerinalang.net.ws.WebSocketConstants;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
 import java.nio.ByteBuffer;
@@ -52,7 +52,7 @@ public class PushBinary extends AbstractNativeFunction {
     public BValue[] execute(Context context) {
         try {
             BStruct wsConnection = (BStruct) getRefArgument(context, 0);
-            Session session = (Session) wsConnection.getNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION);
+            Session session = (Session) wsConnection.getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_SESSION);
             byte[] binaryData = getBlobArgument(context, 0);
             session.getBasicRemote().sendBinary(ByteBuffer.wrap(binaryData));
         } catch (Throwable e) {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/PushText.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/connection/PushText.java
@@ -26,7 +26,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
-import org.ballerinalang.net.ws.Constants;
+import org.ballerinalang.net.ws.WebSocketConstants;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
 import javax.websocket.Session;
@@ -51,7 +51,7 @@ public class PushText extends AbstractNativeFunction {
     public BValue[] execute(Context context) {
         try {
             BStruct wsConnection = (BStruct) getRefArgument(context, 0);
-            Session session = (Session) wsConnection.getNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION);
+            Session session = (Session) wsConnection.getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_SESSION);
             String text = getStringArgument(context, 0);
             session.getBasicRemote().sendText(text);
         } catch (Throwable e) {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/handshakeconnection/CancelHandshake.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/ws/nativeimpl/handshakeconnection/CancelHandshake.java
@@ -26,7 +26,7 @@ import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
-import org.ballerinalang.net.ws.Constants;
+import org.ballerinalang.net.ws.WebSocketConstants;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketInitMessage;
 
 /**
@@ -52,7 +52,7 @@ public class CancelHandshake extends AbstractNativeFunction {
         int statusCode = (int) getIntArgument(context, 0);
         String reason = getStringArgument(context, 0);
         WebSocketInitMessage initMessage =
-                (WebSocketInitMessage) handshakeConnection.getNativeData(Constants.WEBSOCKET_MESSAGE);
+                (WebSocketInitMessage) handshakeConnection.getNativeData(WebSocketConstants.WEBSOCKET_MESSAGE);
         initMessage.cancelHandShake(statusCode, reason);
         return VOID_RETURN;
     }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/mime/MimeTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/mime/MimeTest.java
@@ -31,7 +31,7 @@ import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.model.values.BXMLItem;
 import org.ballerinalang.nativeimpl.io.channels.base.AbstractChannel;
 import org.ballerinalang.nativeimpl.io.channels.base.CharacterChannel;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.test.nativeimpl.functions.io.MockByteChannel;
 import org.ballerinalang.test.nativeimpl.functions.io.util.TestUtil;
 import org.ballerinalang.test.services.testutils.HTTPTestRequest;
@@ -72,7 +72,7 @@ public class MimeTest {
     private CompileResult compileResult, serviceResult;
     private final String protocolPackageMime = PROTOCOL_PACKAGE_MIME;
     private final String protocolPackageFile = PROTOCOL_PACKAGE_FILE;
-    private final String entityStruct = Constants.ENTITY;
+    private final String entityStruct = HttpConstants.ENTITY;
     private final String mediaTypeStruct = MEDIA_TYPE;
     private String sourceFilePath = "test-src/mime/mime-test.bal";
 
@@ -268,7 +268,8 @@ public class MimeTest {
             CharacterChannel characterChannel = new CharacterChannel(channel, StandardCharsets.UTF_8.name());
             String responseValue = characterChannel.readAll();
             characterChannel.close();
-            HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_POST, responseValue);
+            HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_POST,
+                                                                    responseValue);
             HTTPCarbonMessage response = Services.invokeNew(serviceResult, cMsg);
             Assert.assertNotNull(response, "Response message not found");
             String temporaryFilePath = ResponseReader.getReturnValue(response);

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/mime/MultipartRequestTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/mime/MultipartRequestTest.java
@@ -31,7 +31,7 @@ import org.ballerinalang.model.values.BStringArray;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.model.values.BXMLItem;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.test.services.testutils.HTTPTestRequest;
 import org.ballerinalang.test.services.testutils.MessageUtils;
@@ -83,11 +83,11 @@ public class MultipartRequestTest {
     private static final Logger LOG = LoggerFactory.getLogger(MultipartRequestTest.class);
 
     private CompileResult result, serviceResult;
-    private final String requestStruct = Constants.IN_REQUEST;
-    private final String protocolPackageHttp = Constants.PROTOCOL_PACKAGE_HTTP;
+    private final String requestStruct = HttpConstants.IN_REQUEST;
+    private final String protocolPackageHttp = HttpConstants.PROTOCOL_PACKAGE_HTTP;
     private final String protocolPackageMime = PROTOCOL_PACKAGE_MIME;
     private final String protocolPackageFile = PROTOCOL_PACKAGE_FILE;
-    private final String entityStruct = Constants.ENTITY;
+    private final String entityStruct = HttpConstants.ENTITY;
     private final String mediaTypeStruct = MEDIA_TYPE;
     private String sourceFilePath = "test-src/mime/multipart-request.bal";
     private final String carbonMessage = "CarbonMessage";
@@ -441,7 +441,7 @@ public class MultipartRequestTest {
     private Map<String, Object> createPrerequisiteMessages(String path) {
         Map<String, Object> messageMap = new HashMap<>();
         BStruct request = getRequestStruct();
-        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessageForMultiparts(path, Constants.HTTP_METHOD_POST);
+        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessageForMultiparts(path, HttpConstants.HTTP_METHOD_POST);
         HttpUtil.addCarbonMsg(request, cMsg);
         BStruct entity = getEntityStruct();
         MimeUtil.setContentType(getMediaTypeStruct(), entity, MULTIPART_FORM_DATA);

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/net/ws/HttpToWebSocketUpgradeTestCase.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/net/ws/HttpToWebSocketUpgradeTestCase.java
@@ -23,7 +23,7 @@ import org.ballerinalang.connector.api.ConnectorUtils;
 import org.ballerinalang.launcher.util.BServiceUtil;
 import org.ballerinalang.launcher.util.CompileResult;
 import org.ballerinalang.net.http.BallerinaHttpServerConnector;
-import org.ballerinalang.net.ws.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.testng.annotations.Test;
 
 /**
@@ -75,7 +75,7 @@ public class HttpToWebSocketUpgradeTestCase {
 
     private void validateSeverEndpoints(CompileResult compileResult) throws BallerinaConnectorException {
         BallerinaHttpServerConnector httpServerConnector = (BallerinaHttpServerConnector) ConnectorUtils.
-                getBallerinaServerConnector(compileResult.getProgFile(), Constants.HTTP_PACKAGE_PATH);
+                getBallerinaServerConnector(compileResult.getProgFile(), HttpConstants.HTTP_PACKAGE_PATH);
         httpServerConnector.getWebSocketServicesRegistry().completeDeployment();
     }
 }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/net/ws/NativeFunctionsTestCase.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/net/ws/NativeFunctionsTestCase.java
@@ -28,8 +28,8 @@ import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
-import org.ballerinalang.net.ws.Constants;
 import org.ballerinalang.net.ws.WebSocketConnectionManager;
+import org.ballerinalang.net.ws.WebSocketConstants;
 import org.ballerinalang.net.ws.WsOpenConnectionInfo;
 import org.ballerinalang.test.utils.ws.MockWebSocketSession;
 import org.ballerinalang.util.codegen.ProgramFile;
@@ -89,11 +89,11 @@ public class NativeFunctionsTestCase {
         BMap<String, BString> queryParams = new BMap<>();
         queryParams.put(paramKey, paramVal);
 
-        wsConnection = BCompileUtil.createAndGetStruct(programFile, Constants.PROTOCOL_PACKAGE_WS,
-                                                     Constants.STRUCT_WEBSOCKET_CONNECTION);
-        wsConnection.addNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION, session);
-        wsConnection.addNativeData(Constants.NATIVE_DATA_UPGRADE_HEADERS, upgradeHeaders);
-        wsConnection.addNativeData(Constants.NATIVE_DATA_QUERY_PARAMS, queryParams);
+        wsConnection = BCompileUtil.createAndGetStruct(programFile, WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                                                       WebSocketConstants.STRUCT_WEBSOCKET_CONNECTION);
+        wsConnection.addNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_SESSION, session);
+        wsConnection.addNativeData(WebSocketConstants.NATIVE_DATA_UPGRADE_HEADERS, upgradeHeaders);
+        wsConnection.addNativeData(WebSocketConstants.NATIVE_DATA_QUERY_PARAMS, queryParams);
     }
 
     @Test
@@ -172,9 +172,11 @@ public class NativeFunctionsTestCase {
         String testSessionID = "test_session_id";
         MockWebSocketSession testSession = new MockWebSocketSession(testSessionID);
         BStruct testParentWsConnection = BCompileUtil.createAndGetStruct(programFile,
-                                                Constants.PROTOCOL_PACKAGE_WS, Constants.STRUCT_WEBSOCKET_CONNECTION);
-        testParentWsConnection.addNativeData(Constants.NATIVE_DATA_WEBSOCKET_SESSION, testSession);
-        wsConnection.addNativeData(Constants.NATIVE_DATA_PARENT_CONNECTION_ID, testSessionID);
+                                                                         WebSocketConstants.PROTOCOL_PACKAGE_WS,
+                                                                         WebSocketConstants
+                                                                                 .STRUCT_WEBSOCKET_CONNECTION);
+        testParentWsConnection.addNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_SESSION, testSession);
+        wsConnection.addNativeData(WebSocketConstants.NATIVE_DATA_PARENT_CONNECTION_ID, testSessionID);
         WsOpenConnectionInfo connectionInfo =
                 new WsOpenConnectionInfo(null, testParentWsConnection, null);
         WebSocketConnectionManager.getInstance().addConnection(testSessionID, connectionInfo);

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/ServiceTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/ServiceTest.java
@@ -24,7 +24,7 @@ import org.ballerinalang.launcher.util.BServiceUtil;
 import org.ballerinalang.launcher.util.CompileResult;
 import org.ballerinalang.model.util.StringUtils;
 import org.ballerinalang.model.values.BJSON;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.runtime.message.StringDataSource;
 import org.ballerinalang.test.services.testutils.HTTPTestRequest;
 import org.ballerinalang.test.services.testutils.MessageUtils;
@@ -237,7 +237,7 @@ public class ServiceTest {
         HTTPCarbonMessage responseMsg = Services.invokeNew(compileResult, requestMsg);
 
         Assert.assertNotNull(responseMsg, "responseMsg message not found");
-        Assert.assertEquals(responseMsg.getProperty(Constants.HTTP_STATUS_CODE), 204);
+        Assert.assertEquals(responseMsg.getProperty(HttpConstants.HTTP_STATUS_CODE), 204);
     }
 
     @Test(description = "Test Http PATCH verb dispatching without a responseMsgPayload")
@@ -247,7 +247,7 @@ public class ServiceTest {
         HTTPCarbonMessage responseMsg = Services.invokeNew(compileResult, requestMsg);
 
         Assert.assertNotNull(responseMsg, "responseMsg message not found");
-        Assert.assertEquals(responseMsg.getProperty(Constants.HTTP_STATUS_CODE), 204);
+        Assert.assertEquals(responseMsg.getProperty(HttpConstants.HTTP_STATUS_CODE), 204);
     }
 
     //TODO: add more test cases

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/cors/HTTPCorsTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/cors/HTTPCorsTest.java
@@ -21,7 +21,7 @@ package org.ballerinalang.test.services.cors;
 import org.ballerinalang.launcher.util.BServiceUtil;
 import org.ballerinalang.launcher.util.CompileResult;
 import org.ballerinalang.model.values.BJSON;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.test.services.testutils.HTTPTestRequest;
 import org.ballerinalang.test.services.testutils.MessageUtils;
 import org.ballerinalang.test.services.testutils.Services;
@@ -45,119 +45,120 @@ public class HTTPCorsTest {
 
     public void assertEqualsCorsResponse(HTTPCarbonMessage response, int statusCode, String origin, String credentials
             , String headers, String methods, String maxAge) {
-        Assert.assertEquals(response.getProperty(Constants.HTTP_STATUS_CODE), statusCode);
-        Assert.assertEquals(response.getHeader(Constants.AC_ALLOW_ORIGIN), origin);
-        Assert.assertEquals(response.getHeader(Constants.AC_ALLOW_CREDENTIALS), credentials);
-        Assert.assertEquals(response.getHeader(Constants.AC_ALLOW_HEADERS), headers);
-        Assert.assertEquals(response.getHeader(Constants.AC_ALLOW_METHODS), methods);
-        Assert.assertEquals(response.getHeader(Constants.AC_MAX_AGE), maxAge);
+        Assert.assertEquals(response.getProperty(HttpConstants.HTTP_STATUS_CODE), statusCode);
+        Assert.assertEquals(response.getHeader(HttpConstants.AC_ALLOW_ORIGIN), origin);
+        Assert.assertEquals(response.getHeader(HttpConstants.AC_ALLOW_CREDENTIALS), credentials);
+        Assert.assertEquals(response.getHeader(HttpConstants.AC_ALLOW_HEADERS), headers);
+        Assert.assertEquals(response.getHeader(HttpConstants.AC_ALLOW_METHODS), methods);
+        Assert.assertEquals(response.getHeader(HttpConstants.AC_MAX_AGE), maxAge);
     }
 
     @Test(description = "Test for CORS override at two levels for simple requests")
     public void testSimpleReqServiceResourceCorsOverride() {
         String path = "/hello1/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "POST", "Hello there");
-        cMsg.setHeader(Constants.ORIGIN, "http://www.wso2.com");
+        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.wso2.com");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
         BJSON bJson = new BJSON(new HttpMessageDataStreamer(response).getInputStream());
         Assert.assertEquals(bJson.value().get("echo").asText(), "resCors");
-        Assert.assertEquals("http://www.wso2.com", response.getHeader(Constants.AC_ALLOW_ORIGIN));
-        Assert.assertEquals("true", response.getHeader(Constants.AC_ALLOW_CREDENTIALS));
+        Assert.assertEquals("http://www.wso2.com", response.getHeader(HttpConstants.AC_ALLOW_ORIGIN));
+        Assert.assertEquals("true", response.getHeader(HttpConstants.AC_ALLOW_CREDENTIALS));
     }
 
     @Test(description = "Test for simple request service CORS")
     public void testSimpleReqServiceCors() {
         String path = "/hello1/test2";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
-        cMsg.setHeader(Constants.ORIGIN, "http://www.hello.com");
+        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.hello.com");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
         BJSON bJson = new BJSON(new HttpMessageDataStreamer(response).getInputStream());
         Assert.assertEquals(bJson.value().get("echo").asText(), "serCors");
-        Assert.assertEquals("http://www.hello.com", response.getHeader(Constants.AC_ALLOW_ORIGIN));
-        Assert.assertEquals("true", response.getHeader(Constants.AC_ALLOW_CREDENTIALS));
+        Assert.assertEquals("http://www.hello.com", response.getHeader(HttpConstants.AC_ALLOW_ORIGIN));
+        Assert.assertEquals("true", response.getHeader(HttpConstants.AC_ALLOW_CREDENTIALS));
     }
 
     @Test(description = "Test for resource only CORS declaration")
     public void testSimpleReqResourceOnlyCors() {
         String path = "/hello2/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "POST", "hello");
-        cMsg.setHeader(Constants.ORIGIN, "http://www.hello.com");
+        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.hello.com");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
         BJSON bJson = new BJSON(new HttpMessageDataStreamer(response).getInputStream());
         Assert.assertEquals(bJson.value().get("echo").asText(), "resOnlyCors");
-        Assert.assertEquals("http://www.hello.com", response.getHeader(Constants.AC_ALLOW_ORIGIN));
-        Assert.assertEquals(null, response.getHeader(Constants.AC_ALLOW_CREDENTIALS));
-        Assert.assertEquals("X-PINGOTHER, X-Content-Type-Options", response.getHeader(Constants.AC_EXPOSE_HEADERS));
+        Assert.assertEquals("http://www.hello.com", response.getHeader(HttpConstants.AC_ALLOW_ORIGIN));
+        Assert.assertEquals(null, response.getHeader(HttpConstants.AC_ALLOW_CREDENTIALS));
+        Assert.assertEquals("X-PINGOTHER, X-Content-Type-Options", response.getHeader(HttpConstants.AC_EXPOSE_HEADERS));
     }
 
     @Test(description = "Test simple request with multiple origins")
     public void testSimpleReqMultipleOrigins() {
         String path = "/hello1/test3";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "POST", "Hello there");
-        cMsg.setHeader(Constants.ORIGIN, "http://www.wso2.com http://www.amazon.com");
+        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.wso2.com http://www.amazon.com");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
         BJSON bJson = new BJSON(new HttpMessageDataStreamer(response).getInputStream());
         Assert.assertEquals(bJson.value().get("echo").asText(), "moreOrigins");
-        Assert.assertEquals("http://www.wso2.com http://www.amazon.com", response.getHeader(Constants.AC_ALLOW_ORIGIN));
-        Assert.assertEquals("true", response.getHeader(Constants.AC_ALLOW_CREDENTIALS));
+        Assert.assertEquals("http://www.wso2.com http://www.amazon.com",
+                            response.getHeader(HttpConstants.AC_ALLOW_ORIGIN));
+        Assert.assertEquals("true", response.getHeader(HttpConstants.AC_ALLOW_CREDENTIALS));
     }
 
     @Test(description = "Test simple request for invalid origins")
     public void testSimpleReqInvalidOrigin() {
         String path = "/hello1/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "POST", "Hello there");
-        cMsg.setHeader(Constants.ORIGIN, "www.wso2.com");
+        cMsg.setHeader(HttpConstants.ORIGIN, "www.wso2.com");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
         BJSON bJson = new BJSON(new HttpMessageDataStreamer(response).getInputStream());
         Assert.assertEquals(bJson.value().get("echo").asText(), "resCors");
-        Assert.assertEquals(null, response.getHeader(Constants.AC_ALLOW_ORIGIN));
-        Assert.assertNull(null, response.getHeader(Constants.AC_ALLOW_CREDENTIALS));
+        Assert.assertEquals(null, response.getHeader(HttpConstants.AC_ALLOW_ORIGIN));
+        Assert.assertNull(null, response.getHeader(HttpConstants.AC_ALLOW_CREDENTIALS));
     }
 
     @Test(description = "Test simple request for null origins")
     public void testSimpleReqWithNullOrigin() {
         String path = "/hello1/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "POST", "Hello there");
-        cMsg.setHeader(Constants.ORIGIN, "");
+        cMsg.setHeader(HttpConstants.ORIGIN, "");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
         BJSON bJson = new BJSON(new HttpMessageDataStreamer(response).getInputStream());
         Assert.assertEquals(bJson.value().get("echo").asText(), "resCors");
-        Assert.assertEquals(null, response.getHeader(Constants.AC_ALLOW_ORIGIN));
-        Assert.assertNull(null, response.getHeader(Constants.AC_ALLOW_CREDENTIALS));
+        Assert.assertEquals(null, response.getHeader(HttpConstants.AC_ALLOW_ORIGIN));
+        Assert.assertNull(null, response.getHeader(HttpConstants.AC_ALLOW_CREDENTIALS));
     }
 
     @Test(description = "Test for values with extra white spaces")
     public void testSimpleReqwithExtraWS() {
         String path = "/hello2/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "POST", "hello");
-        cMsg.setHeader(Constants.ORIGIN, "http://www.facebook.com");
+        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.facebook.com");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
         BJSON bJson = new BJSON(new HttpMessageDataStreamer(response).getInputStream());
         Assert.assertEquals(bJson.value().get("echo").asText(), "resOnlyCors");
-        Assert.assertEquals("http://www.facebook.com", response.getHeader(Constants.AC_ALLOW_ORIGIN));
+        Assert.assertEquals("http://www.facebook.com", response.getHeader(HttpConstants.AC_ALLOW_ORIGIN));
     }
 
     @Test(description = "Test for CORS override at two levels with preflight")
     public void testPreFlightReqServiceResourceCorsOverride() {
         String path = "/hello1/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(Constants.ORIGIN, "http://www.wso2.com");
-        cMsg.setHeader(Constants.AC_REQUEST_METHOD, Constants.HTTP_METHOD_POST);
-        cMsg.setHeader(Constants.AC_REQUEST_HEADERS, "X-PINGOTHER");
+        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.wso2.com");
+        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_POST);
+        cMsg.setHeader(HttpConstants.AC_REQUEST_HEADERS, "X-PINGOTHER");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -169,8 +170,8 @@ public class HTTPCorsTest {
     public void testPreFlightReqwithNoOrigin() {
         String path = "/hello1/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(Constants.AC_REQUEST_METHOD, Constants.HTTP_METHOD_POST);
-        cMsg.setHeader(Constants.AC_REQUEST_HEADERS, "X-PINGOTHER");
+        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_POST);
+        cMsg.setHeader(HttpConstants.AC_REQUEST_HEADERS, "X-PINGOTHER");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -182,8 +183,8 @@ public class HTTPCorsTest {
     public void testPreFlightReqwithNoMethod() {
         String path = "/hello1/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(Constants.ORIGIN, "http://www.wso2.com");
-        cMsg.setHeader(Constants.AC_REQUEST_HEADERS, "X-PINGOTHER");
+        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.wso2.com");
+        cMsg.setHeader(HttpConstants.AC_REQUEST_HEADERS, "X-PINGOTHER");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -195,9 +196,9 @@ public class HTTPCorsTest {
     public void testPreFlightReqwithUnavailableMethod() {
         String path = "/hello1/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(Constants.ORIGIN, "http://www.wso2.com");
-        cMsg.setHeader(Constants.AC_REQUEST_METHOD, Constants.HTTP_METHOD_PUT);
-        cMsg.setHeader(Constants.AC_REQUEST_HEADERS, "X-PINGOTHER");
+        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.wso2.com");
+        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_PUT);
+        cMsg.setHeader(HttpConstants.AC_REQUEST_HEADERS, "X-PINGOTHER");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -209,23 +210,23 @@ public class HTTPCorsTest {
     public void testPreFlightReqwithHeadMethod() {
         String path = "/hello1/test2";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(Constants.ORIGIN, "http://www.m3.com");
-        cMsg.setHeader(Constants.AC_REQUEST_METHOD, Constants.HTTP_METHOD_HEAD);
-        cMsg.setHeader(Constants.AC_REQUEST_HEADERS, "CORELATION_ID");
+        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.m3.com");
+        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_HEAD);
+        cMsg.setHeader(HttpConstants.AC_REQUEST_HEADERS, "CORELATION_ID");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
         assertEqualsCorsResponse(response, 200, "http://www.m3.com", "true"
-                , "CORELATION_ID", Constants.HTTP_METHOD_HEAD, "1");
+                , "CORELATION_ID", HttpConstants.HTTP_METHOD_HEAD, "1");
     }
 
     @Test(description = "Test preflight for invalid headers")
     public void testPreFlightReqwithInvalidHeaders() {
         String path = "/hello1/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(Constants.ORIGIN, "http://www.wso2.com");
-        cMsg.setHeader(Constants.AC_REQUEST_METHOD, Constants.HTTP_METHOD_POST);
-        cMsg.setHeader(Constants.AC_REQUEST_HEADERS, "WSO2");
+        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.wso2.com");
+        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_POST);
+        cMsg.setHeader(HttpConstants.AC_REQUEST_HEADERS, "WSO2");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -237,22 +238,22 @@ public class HTTPCorsTest {
     public void testPreFlightReqwithNoHeaders() {
         String path = "/hello1/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(Constants.ORIGIN, "http://www.wso2.com");
-        cMsg.setHeader(Constants.AC_REQUEST_METHOD, Constants.HTTP_METHOD_POST);
+        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.wso2.com");
+        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_POST);
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
         assertEqualsCorsResponse(response, 200, "http://www.wso2.com", "true"
-                , null, Constants.HTTP_METHOD_POST, "-1");
+                , null, HttpConstants.HTTP_METHOD_POST, "-1");
     }
 
     @Test(description = "Test preflight with method restriction at service level")
     public void testPreFlightReqwithRestrictedMethodsServiceLevel() {
         String path = "/hello3/info1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(Constants.ORIGIN, "http://www.m3.com");
-        cMsg.setHeader(Constants.AC_REQUEST_METHOD, Constants.HTTP_METHOD_POST);
-        cMsg.setHeader(Constants.AC_REQUEST_HEADERS, "X-PINGOTHER");
+        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.m3.com");
+        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_POST);
+        cMsg.setHeader(HttpConstants.AC_REQUEST_HEADERS, "X-PINGOTHER");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -264,9 +265,9 @@ public class HTTPCorsTest {
     public void testPreFlightReqwithRestrictedMethodsResourceLevel() {
         String path = "/hello2/test2";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(Constants.ORIGIN, "http://www.bbc.com");
-        cMsg.setHeader(Constants.AC_REQUEST_METHOD, Constants.HTTP_METHOD_DELETE);
-        cMsg.setHeader(Constants.AC_REQUEST_HEADERS, "X-PINGOTHER");
+        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.bbc.com");
+        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_DELETE);
+        cMsg.setHeader(HttpConstants.AC_REQUEST_HEADERS, "X-PINGOTHER");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -278,9 +279,9 @@ public class HTTPCorsTest {
     public void testPreFlightReqwithAllowedMethod() {
         String path = "/hello3/info1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(Constants.ORIGIN, "http://www.m3.com");
-        cMsg.setHeader(Constants.AC_REQUEST_METHOD, Constants.HTTP_METHOD_PUT);
-        cMsg.setHeader(Constants.AC_REQUEST_HEADERS, "X-PINGOTHER");
+        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.m3.com");
+        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_PUT);
+        cMsg.setHeader(HttpConstants.AC_REQUEST_HEADERS, "X-PINGOTHER");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -292,9 +293,9 @@ public class HTTPCorsTest {
     public void testPreFlightReqwithMissingHeadersAtResourceLevel() {
         String path = "/hello2/test2";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(Constants.ORIGIN, "http://www.bbc.com");
-        cMsg.setHeader(Constants.AC_REQUEST_METHOD, Constants.HTTP_METHOD_PUT);
-        cMsg.setHeader(Constants.AC_REQUEST_HEADERS, "X-PINGOTHER");
+        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.bbc.com");
+        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_PUT);
+        cMsg.setHeader(HttpConstants.AC_REQUEST_HEADERS, "X-PINGOTHER");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -306,21 +307,21 @@ public class HTTPCorsTest {
     public void testPreFlightReqNoCorsResource() {
         String path = "/echo4/info1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(Constants.ORIGIN, "http://www.wso2.com");
-        cMsg.setHeader(Constants.AC_REQUEST_METHOD, Constants.HTTP_METHOD_POST);
+        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.wso2.com");
+        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_POST);
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
         assertEqualsCorsResponse(response, 200, null, null
                 , null, null, null);
-        Assert.assertEquals(response.getHeader(Constants.ALLOW), "POST, OPTIONS");
+        Assert.assertEquals(response.getHeader(HttpConstants.ALLOW), "POST, OPTIONS");
     }
 
     @Test(description = "Test for simple OPTIONS request")
     public void testSimpleOPTIONSReq() {
         String path = "/echo4/info2";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(Constants.ORIGIN, "http://www.wso2.com");
+        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.wso2.com");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -332,8 +333,8 @@ public class HTTPCorsTest {
     public void testPreFlightReqwithCaseInsensitiveOrigin() {
         String path = "/hello1/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(Constants.ORIGIN, "http://www.Wso2.com");
-        cMsg.setHeader(Constants.AC_REQUEST_METHOD, Constants.HTTP_METHOD_POST);
+        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.Wso2.com");
+        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_POST);
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -345,9 +346,9 @@ public class HTTPCorsTest {
     public void testPreFlightReqwithCaseInsensitiveHeader() {
         String path = "/hello1/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(Constants.ORIGIN, "http://www.wso2.com");
-        cMsg.setHeader(Constants.AC_REQUEST_METHOD, Constants.HTTP_METHOD_POST);
-        cMsg.setHeader(Constants.AC_REQUEST_HEADERS, "X-PINGOTHER");
+        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.wso2.com");
+        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_POST);
+        cMsg.setHeader(HttpConstants.AC_REQUEST_HEADERS, "X-PINGOTHER");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/dispatching/ProducesConsumesAnnotationTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/dispatching/ProducesConsumesAnnotationTest.java
@@ -21,7 +21,7 @@ package org.ballerinalang.test.services.dispatching;
 import org.ballerinalang.launcher.util.BServiceUtil;
 import org.ballerinalang.launcher.util.CompileResult;
 import org.ballerinalang.model.values.BJSON;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.test.services.testutils.HTTPTestRequest;
 import org.ballerinalang.test.services.testutils.MessageUtils;
 import org.ballerinalang.test.services.testutils.Services;
@@ -48,7 +48,7 @@ public class ProducesConsumesAnnotationTest {
     public void testConsumesAnnotation() {
         String path = "/echo66/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "POST", "Test");
-        cMsg.setHeader(Constants.CONTENT_TYPE_HEADER, "application/xml; charset=ISO-8859-4");
+        cMsg.setHeader(HttpConstants.CONTENT_TYPE_HEADER, "application/xml; charset=ISO-8859-4");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -60,11 +60,11 @@ public class ProducesConsumesAnnotationTest {
     public void testIncorrectConsumesAnnotation() {
         String path = "/echo66/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "POST", "Test");
-        cMsg.setHeader(Constants.CONTENT_TYPE_HEADER, "compileResult/json");
+        cMsg.setHeader(HttpConstants.CONTENT_TYPE_HEADER, "compileResult/json");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
-        int trueResponse = (int) response.getProperty(Constants.HTTP_STATUS_CODE);
+        int trueResponse = (int) response.getProperty(HttpConstants.HTTP_STATUS_CODE);
         Assert.assertEquals(trueResponse, 415, "Unsupported media type");
     }
 
@@ -72,11 +72,11 @@ public class ProducesConsumesAnnotationTest {
     public void testBogusConsumesAnnotation() {
         String path = "/echo66/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "POST", "Test");
-        cMsg.setHeader(Constants.CONTENT_TYPE_HEADER, ",:vhjv");
+        cMsg.setHeader(HttpConstants.CONTENT_TYPE_HEADER, ",:vhjv");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
-        int trueResponse = (int) response.getProperty(Constants.HTTP_STATUS_CODE);
+        int trueResponse = (int) response.getProperty(HttpConstants.HTTP_STATUS_CODE);
         Assert.assertEquals(trueResponse, 415, "Unsupported media type");
     }
 
@@ -84,7 +84,7 @@ public class ProducesConsumesAnnotationTest {
     public void testProducesAnnotation() {
         String path = "/echo66/test2";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
-        cMsg.setHeader(Constants.ACCEPT_HEADER, "text/xml;q=0.3, multipart/*;Level=1;q=0.7");
+        cMsg.setHeader(HttpConstants.ACCEPT_HEADER, "text/xml;q=0.3, multipart/*;Level=1;q=0.7");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -107,7 +107,7 @@ public class ProducesConsumesAnnotationTest {
     public void testProducesAnnotationWithWildCard() {
         String path = "/echo66/test2";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
-        cMsg.setHeader(Constants.ACCEPT_HEADER, "*/*, text/html;Level=1;q=0.7");
+        cMsg.setHeader(HttpConstants.ACCEPT_HEADER, "*/*, text/html;Level=1;q=0.7");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -119,7 +119,7 @@ public class ProducesConsumesAnnotationTest {
     public void testProducesAnnotationWithSubTypeWildCard() {
         String path = "/echo66/test2";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
-        cMsg.setHeader(Constants.ACCEPT_HEADER, "text/*;q=0.3, text/html;Level=1;q=0.7");
+        cMsg.setHeader(HttpConstants.ACCEPT_HEADER, "text/*;q=0.3, text/html;Level=1;q=0.7");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -131,11 +131,11 @@ public class ProducesConsumesAnnotationTest {
     public void testIncorrectProducesAnnotation() {
         String path = "/echo66/test2";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
-        cMsg.setHeader(Constants.ACCEPT_HEADER, "multipart/*;q=0.3, text/html;Level=1;q=0.7");
+        cMsg.setHeader(HttpConstants.ACCEPT_HEADER, "multipart/*;q=0.3, text/html;Level=1;q=0.7");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
-        int trueResponse = (int) response.getProperty(Constants.HTTP_STATUS_CODE);
+        int trueResponse = (int) response.getProperty(HttpConstants.HTTP_STATUS_CODE);
         Assert.assertEquals(trueResponse, 406, "Not acceptable");
     }
 
@@ -143,11 +143,11 @@ public class ProducesConsumesAnnotationTest {
     public void testBogusProducesAnnotation() {
         String path = "/echo66/test2";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
-        cMsg.setHeader(Constants.ACCEPT_HEADER, ":,;,v567br");
+        cMsg.setHeader(HttpConstants.ACCEPT_HEADER, ":,;,v567br");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
-        int trueResponse = (int) response.getProperty(Constants.HTTP_STATUS_CODE);
+        int trueResponse = (int) response.getProperty(HttpConstants.HTTP_STATUS_CODE);
         Assert.assertEquals(trueResponse, 406, "Not acceptable");
     }
 
@@ -155,8 +155,8 @@ public class ProducesConsumesAnnotationTest {
     public void testProducesConsumeAnnotation() {
         String path = "/echo66/test3";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "POST", "Test");
-        cMsg.setHeader(Constants.CONTENT_TYPE_HEADER, "text/plain; charset=ISO-8859-4");
-        cMsg.setHeader(Constants.ACCEPT_HEADER, "text/*;q=0.3, text/html;Level=1;q=0.7");
+        cMsg.setHeader(HttpConstants.CONTENT_TYPE_HEADER, "text/plain; charset=ISO-8859-4");
+        cMsg.setHeader(HttpConstants.ACCEPT_HEADER, "text/*;q=0.3, text/html;Level=1;q=0.7");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -168,12 +168,12 @@ public class ProducesConsumesAnnotationTest {
     public void testIncorrectProducesConsumeAnnotation() {
         String path = "/echo66/test3";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "POST", "Test");
-        cMsg.setHeader(Constants.CONTENT_TYPE_HEADER, "text/plain ; charset=ISO-8859-4");
-        cMsg.setHeader(Constants.ACCEPT_HEADER, "compileResult/xml, text/html");
+        cMsg.setHeader(HttpConstants.CONTENT_TYPE_HEADER, "text/plain ; charset=ISO-8859-4");
+        cMsg.setHeader(HttpConstants.ACCEPT_HEADER, "compileResult/xml, text/html");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
-        int trueResponse = (int) response.getProperty(Constants.HTTP_STATUS_CODE);
+        int trueResponse = (int) response.getProperty(HttpConstants.HTTP_STATUS_CODE);
         Assert.assertEquals(trueResponse, 406, "Not acceptable");
     }
 
@@ -181,8 +181,8 @@ public class ProducesConsumesAnnotationTest {
     public void testWithoutProducesConsumeAnnotation() {
         String path = "/echo67/echo1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
-        cMsg.setHeader(Constants.CONTENT_TYPE_HEADER, "text/plain; charset=ISO-8859-4");
-        cMsg.setHeader(Constants.ACCEPT_HEADER, "text/*;q=0.3, text/html;Level=1;q=0.7");
+        cMsg.setHeader(HttpConstants.CONTENT_TYPE_HEADER, "text/plain; charset=ISO-8859-4");
+        cMsg.setHeader(HttpConstants.ACCEPT_HEADER, "text/*;q=0.3, text/html;Level=1;q=0.7");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/dispatching/UriMatrixParametersMatchTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/dispatching/UriMatrixParametersMatchTest.java
@@ -22,7 +22,7 @@ import org.ballerinalang.launcher.util.BServiceUtil;
 import org.ballerinalang.launcher.util.CompileResult;
 import org.ballerinalang.model.util.StringUtils;
 import org.ballerinalang.model.values.BJSON;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.test.services.testutils.HTTPTestRequest;
 import org.ballerinalang.test.services.testutils.MessageUtils;
 import org.ballerinalang.test.services.testutils.Services;
@@ -97,7 +97,7 @@ public class UriMatrixParametersMatchTest {
 
         Assert.assertNotNull(response, "Response message not found");
         Assert.assertEquals(
-                response.getProperty(Constants.HTTP_STATUS_CODE), 404, "Response code mismatch");
+                response.getProperty(HttpConstants.HTTP_STATUS_CODE), 404, "Response code mismatch");
         //checking the exception message
         String errorMessage = StringUtils
                 .getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream());
@@ -114,7 +114,7 @@ public class UriMatrixParametersMatchTest {
 
         Assert.assertNotNull(response, "Response message not found");
         Assert.assertEquals(
-                response.getProperty(Constants.HTTP_STATUS_CODE), 500, "Response code mismatch");
+                response.getProperty(HttpConstants.HTTP_STATUS_CODE), 500, "Response code mismatch");
         //checking the exception message
         String errorMessage = StringUtils
                 .getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream());

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/dispatching/UriTemplateBestMatchTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/dispatching/UriTemplateBestMatchTest.java
@@ -20,7 +20,7 @@ package org.ballerinalang.test.services.dispatching;
 import org.ballerinalang.launcher.util.BServiceUtil;
 import org.ballerinalang.launcher.util.CompileResult;
 import org.ballerinalang.model.values.BJSON;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.test.services.testutils.HTTPTestRequest;
 import org.ballerinalang.test.services.testutils.MessageUtils;
 import org.ballerinalang.test.services.testutils.Services;
@@ -300,7 +300,7 @@ public class UriTemplateBestMatchTest {
         HTTPCarbonMessage response = Services.invokeNew(application, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
-        int trueResponse = (int) response.getProperty(Constants.HTTP_STATUS_CODE);
+        int trueResponse = (int) response.getProperty(HttpConstants.HTTP_STATUS_CODE);
         Assert.assertEquals(trueResponse, 405, "Method not found");
     }
 
@@ -311,7 +311,7 @@ public class UriTemplateBestMatchTest {
         HTTPCarbonMessage response = Services.invokeNew(application, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
-        int trueResponse = (int) response.getProperty(Constants.HTTP_STATUS_CODE);
+        int trueResponse = (int) response.getProperty(HttpConstants.HTTP_STATUS_CODE);
         Assert.assertEquals(trueResponse, 405, "Method not found");
     }
 

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/dispatching/UriTemplateDispatcherTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/dispatching/UriTemplateDispatcherTest.java
@@ -21,7 +21,7 @@ import org.ballerinalang.launcher.util.BServiceUtil;
 import org.ballerinalang.launcher.util.CompileResult;
 import org.ballerinalang.model.util.StringUtils;
 import org.ballerinalang.model.values.BJSON;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.test.services.testutils.HTTPTestRequest;
 import org.ballerinalang.test.services.testutils.MessageUtils;
 import org.ballerinalang.test.services.testutils.Services;
@@ -74,7 +74,7 @@ public class UriTemplateDispatcherTest {
         cMsg.setHeader(xOrderIdHeadeName, xOrderIdHeadeValue);
         HTTPCarbonMessage response = Services.invokeNew(application, cMsg);
         Assert.assertEquals(
-                response.getProperty(Constants.HTTP_STATUS_CODE), 404, "Response code mismatch");
+                response.getProperty(HttpConstants.HTTP_STATUS_CODE), 404, "Response code mismatch");
         //checking the exception message
         String errorMessage = StringUtils
                 .getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream());
@@ -240,10 +240,10 @@ public class UriTemplateDispatcherTest {
         Assert.assertNotNull(response, "Response message not found");
         Assert.assertEquals(StringUtils
                 .getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream()), "");
-        Assert.assertEquals(response.getProperty(Constants.HTTP_STATUS_CODE), 200
+        Assert.assertEquals(response.getProperty(HttpConstants.HTTP_STATUS_CODE), 200
                 , "Response code mismatch");
 
-        String allowHeader = cMsg.getHeader(Constants.ALLOW);
+        String allowHeader = cMsg.getHeader(HttpConstants.ALLOW);
         Assert.assertEquals(allowHeader, "GET, HEAD, OPTIONS");
     }
 
@@ -256,10 +256,10 @@ public class UriTemplateDispatcherTest {
         Assert.assertNotNull(response, "Response message not found");
         Assert.assertEquals(StringUtils
                 .getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream()), "");
-        Assert.assertEquals(response.getProperty(Constants.HTTP_STATUS_CODE), 200
+        Assert.assertEquals(response.getProperty(HttpConstants.HTTP_STATUS_CODE), 200
                 , "Response code mismatch");
 
-        String allowHeader = cMsg.getHeader(Constants.ALLOW);
+        String allowHeader = cMsg.getHeader(HttpConstants.ALLOW);
         Assert.assertEquals(allowHeader, "POST, OPTIONS");
     }
 
@@ -272,10 +272,10 @@ public class UriTemplateDispatcherTest {
         Assert.assertNotNull(response, "Response message not found");
         Assert.assertEquals(StringUtils
                 .getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream()), "");
-        Assert.assertEquals(response.getProperty(Constants.HTTP_STATUS_CODE), 200
+        Assert.assertEquals(response.getProperty(HttpConstants.HTTP_STATUS_CODE), 200
                 , "Response code mismatch");
 
-        String allowHeader = response.getHeader(Constants.ALLOW);
+        String allowHeader = response.getHeader(HttpConstants.ALLOW);
         Assert.assertEquals(allowHeader, "PUT, OPTIONS");
     }
 
@@ -288,10 +288,10 @@ public class UriTemplateDispatcherTest {
         Assert.assertNotNull(response, "Response message not found");
         Assert.assertEquals(StringUtils
                 .getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream()), "");
-        Assert.assertEquals(response.getProperty(Constants.HTTP_STATUS_CODE), 200
+        Assert.assertEquals(response.getProperty(HttpConstants.HTTP_STATUS_CODE), 200
                 , "Response code mismatch");
 
-        String allowHeader = response.getHeader(Constants.ALLOW);
+        String allowHeader = response.getHeader(HttpConstants.ALLOW);
         Assert.assertEquals(allowHeader, "UPDATE, POST, PUT, GET, HEAD, OPTIONS");
     }
 
@@ -303,10 +303,10 @@ public class UriTemplateDispatcherTest {
 
         Assert.assertNotNull(response, "Response message not found");
         Assert.assertEquals(0, response.getFullMessageLength());
-        Assert.assertEquals(response.getProperty(Constants.HTTP_STATUS_CODE), 200
+        Assert.assertEquals(response.getProperty(HttpConstants.HTTP_STATUS_CODE), 200
                 , "Response code mismatch");
 
-        String allowHeader = response.getHeader(Constants.ALLOW);
+        String allowHeader = response.getHeader(HttpConstants.ALLOW);
         Assert.assertEquals(allowHeader, "OPTIONS, POST, GET, UPDATE, PUT, HEAD");
     }
 
@@ -317,7 +317,7 @@ public class UriTemplateDispatcherTest {
         HTTPCarbonMessage response = Services.invokeNew(application, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
-        Assert.assertEquals(response.getProperty(Constants.HTTP_STATUS_CODE), 404
+        Assert.assertEquals(response.getProperty(HttpConstants.HTTP_STATUS_CODE), 404
                 , "Response code mismatch");
         Assert.assertEquals(StringUtils
                         .getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream()),
@@ -331,7 +331,7 @@ public class UriTemplateDispatcherTest {
         HTTPCarbonMessage response = Services.invokeNew(application, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
-        Assert.assertEquals(response.getProperty(Constants.HTTP_STATUS_CODE), 404
+        Assert.assertEquals(response.getProperty(HttpConstants.HTTP_STATUS_CODE), 404
                 , "Response code mismatch");
         Assert.assertEquals(StringUtils
                         .getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream()),
@@ -345,7 +345,7 @@ public class UriTemplateDispatcherTest {
         HTTPCarbonMessage response = Services.invokeNew(application, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
-        Assert.assertEquals(response.getProperty(Constants.HTTP_STATUS_CODE), 404
+        Assert.assertEquals(response.getProperty(HttpConstants.HTTP_STATUS_CODE), 404
                 , "Response code mismatch");
         Assert.assertEquals(StringUtils
                         .getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream()),

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/connection/ConnectionNativeFunctionNegativeTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/connection/ConnectionNativeFunctionNegativeTest.java
@@ -20,7 +20,7 @@ package org.ballerinalang.test.services.nativeimpl.connection;
 import org.ballerinalang.launcher.util.BServiceUtil;
 import org.ballerinalang.launcher.util.CompileResult;
 import org.ballerinalang.model.util.StringUtils;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.test.services.testutils.HTTPTestRequest;
 import org.ballerinalang.test.services.testutils.MessageUtils;
 import org.ballerinalang.test.services.testutils.Services;
@@ -47,11 +47,11 @@ public class ConnectionNativeFunctionNegativeTest {
     @Test(description = "Test respond with null parameter")
     public void testRespondWithNullParameter() {
         String path = "/hello/10";
-        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
-        Assert.assertEquals(response.getProperty(Constants.HTTP_STATUS_CODE), 500);
+        Assert.assertEquals(response.getProperty(HttpConstants.HTTP_STATUS_CODE), 500);
         Assert.assertTrue(StringUtils
                 .getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream())
                 .contains("argument 1 is null"));
@@ -60,7 +60,7 @@ public class ConnectionNativeFunctionNegativeTest {
     @Test(description = "Test respond with invalid connection struct")
     public void testRespondWithInvalidConnectionStruct() {
         String path = "/hello/11";
-        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, cMsg);
         Assert.assertTrue(StringUtils
                 .getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream())
@@ -70,11 +70,11 @@ public class ConnectionNativeFunctionNegativeTest {
     @Test(description = "Test forward with null parameter")
     public void testForwardWithNullParameter() {
         String path = "/hello/20";
-        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
-        Assert.assertEquals(response.getProperty(Constants.HTTP_STATUS_CODE), 500);
+        Assert.assertEquals(response.getProperty(HttpConstants.HTTP_STATUS_CODE), 500);
         Assert.assertTrue(StringUtils
                 .getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream())
                 .contains("argument 1 is null"));
@@ -83,7 +83,7 @@ public class ConnectionNativeFunctionNegativeTest {
     @Test(description = "Test forward with invalid connection struct")
     public void testForwardWithInvalidConnectionStruct() {
         String path = "/hello/21";
-        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, cMsg);
         Assert.assertTrue(StringUtils
                 .getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream())

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/inbound/request/InRequestNativeFunctionNegativeTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/inbound/request/InRequestNativeFunctionNegativeTest.java
@@ -26,7 +26,7 @@ import org.ballerinalang.model.values.BJSON;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -49,10 +49,10 @@ import static org.ballerinalang.mime.util.Constants.TEXT_PLAIN;
 public class InRequestNativeFunctionNegativeTest {
 
     private CompileResult result, resultNegative;
-    private final String inReqStruct = Constants.IN_REQUEST;
-    private final String entityStruct = Constants.ENTITY;
+    private final String inReqStruct = HttpConstants.IN_REQUEST;
+    private final String entityStruct = HttpConstants.ENTITY;
     private final String mediaTypeStruct = MEDIA_TYPE;
-    private final String protocolPackageHttp = Constants.PROTOCOL_PACKAGE_HTTP;
+    private final String protocolPackageHttp = HttpConstants.PROTOCOL_PACKAGE_HTTP;
     private final String protocolPackageMime = PROTOCOL_PACKAGE_MIME;
 
     @BeforeClass

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/inbound/request/InRequestNativeFunctionSuccessTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/inbound/request/InRequestNativeFunctionSuccessTest.java
@@ -32,7 +32,7 @@ import org.ballerinalang.model.values.BStringArray;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.model.values.BXMLItem;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.test.services.testutils.HTTPTestRequest;
 import org.ballerinalang.test.services.testutils.MessageUtils;
@@ -70,10 +70,10 @@ import static org.ballerinalang.mime.util.Constants.XML_DATA_INDEX;
 public class InRequestNativeFunctionSuccessTest {
 
     private CompileResult result, serviceResult;
-    private final String inReqStruct = Constants.IN_REQUEST;
-    private final String protocolPackageHttp = Constants.PROTOCOL_PACKAGE_HTTP;
+    private final String inReqStruct = HttpConstants.IN_REQUEST;
+    private final String protocolPackageHttp = HttpConstants.PROTOCOL_PACKAGE_HTTP;
     private final String protocolPackageMime = PROTOCOL_PACKAGE_MIME;
-    private final String entityStruct = Constants.ENTITY;
+    private final String entityStruct = HttpConstants.ENTITY;
     private final String mediaTypeStruct = MEDIA_TYPE;
 
     @BeforeClass
@@ -109,7 +109,8 @@ public class InRequestNativeFunctionSuccessTest {
         BStruct entity = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageMime, entityStruct);
         String payload = "ballerina";
         BMap<String, BStringArray> headersMap = new BMap<>();
-        headersMap.put(Constants.HTTP_CONTENT_LENGTH, new BStringArray(new String[]{String.valueOf(payload.length())}));
+        headersMap.put(HttpConstants.HTTP_CONTENT_LENGTH,
+                       new BStringArray(new String[]{String.valueOf(payload.length())}));
         entity.setRefField(ENTITY_HEADERS_INDEX, headersMap);
         inRequest.addNativeData(MESSAGE_ENTITY, entity);
 
@@ -127,8 +128,9 @@ public class InRequestNativeFunctionSuccessTest {
         String path = "/hello/getContentLength";
         String jsonString = "{\"" + key + "\":\"" + value + "\"}";
         int length = jsonString.length();
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_POST, jsonString);
-        inRequestMsg.setHeader(Constants.HTTP_CONTENT_LENGTH, String.valueOf(length));
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_POST,
+                                                                        jsonString);
+        inRequestMsg.setHeader(HttpConstants.HTTP_CONTENT_LENGTH, String.valueOf(length));
 
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
@@ -140,7 +142,7 @@ public class InRequestNativeFunctionSuccessTest {
     @Test
     public void testGetHeader() {
         BStruct inRequest = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageHttp, inReqStruct);
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage("", Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage("", HttpConstants.HTTP_METHOD_GET);
         inRequestMsg.setHeader(CONTENT_TYPE, APPLICATION_FORM);
 
         BStruct entity = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageMime, entityStruct);
@@ -158,7 +160,7 @@ public class InRequestNativeFunctionSuccessTest {
     @Test(description = "Test GetHeader function within a service")
     public void testServiceGetHeader() {
         String path = "/hello/getHeader";
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         inRequestMsg.setHeader(CONTENT_TYPE, APPLICATION_FORM);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
@@ -170,7 +172,7 @@ public class InRequestNativeFunctionSuccessTest {
     @Test(description = "Test GetHeaders function within a function")
     public void testGetHeaders() {
         BStruct inRequest = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageHttp, inReqStruct);
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage("", Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage("", HttpConstants.HTTP_METHOD_GET);
         HttpHeaders headers = inRequestMsg.getHeaders();
         headers.set("test-header", APPLICATION_FORM);
         headers.add("test-header", TEXT_PLAIN);
@@ -215,7 +217,7 @@ public class InRequestNativeFunctionSuccessTest {
         List<Header> headers = new ArrayList<>();
         headers.add(new Header("Content-Type", APPLICATION_JSON));
         HTTPTestRequest inRequestMsg = MessageUtils
-                .generateHTTPMessage(path, Constants.HTTP_METHOD_POST, headers, jsonString);
+                .generateHTTPMessage(path, HttpConstants.HTTP_METHOD_POST, headers, jsonString);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
         Assert.assertNotNull(response, "Response message not found");
         Assert.assertEquals(new BJSON(ResponseReader.getReturnValue(response)).value().stringValue(), value);
@@ -242,7 +244,7 @@ public class InRequestNativeFunctionSuccessTest {
         String propertyName = "wso2";
         String propertyValue = "Ballerina";
         String path = "/hello/GetProperty";
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         inRequestMsg.setProperty(propertyName, propertyValue);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
@@ -277,7 +279,7 @@ public class InRequestNativeFunctionSuccessTest {
         List<Header> headers = new ArrayList<>();
         headers.add(new Header("Content-Type", TEXT_PLAIN));
         HTTPTestRequest inRequestMsg = MessageUtils
-                .generateHTTPMessage(path, Constants.HTTP_METHOD_POST, headers, value);
+                .generateHTTPMessage(path, HttpConstants.HTTP_METHOD_POST, headers, value);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
         Assert.assertNotNull(response, "Response message not found");
         Assert.assertEquals(ResponseReader.getReturnValue(response), value);
@@ -310,7 +312,7 @@ public class InRequestNativeFunctionSuccessTest {
         List<Header> headers = new ArrayList<>();
         headers.add(new Header("Content-Type", APPLICATION_XML));
         HTTPTestRequest inRequestMsg = MessageUtils
-                .generateHTTPMessage(path, Constants.HTTP_METHOD_POST, headers, bxmlItemString);
+                .generateHTTPMessage(path, HttpConstants.HTTP_METHOD_POST, headers, bxmlItemString);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
         Assert.assertNotNull(response, "Response message not found");
         Assert.assertEquals(ResponseReader.getReturnValue(response), value);
@@ -319,19 +321,19 @@ public class InRequestNativeFunctionSuccessTest {
     @Test
     public void testGetMethod() {
         String path = "/hello/11";
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");
         Assert.assertEquals(
                 StringUtils.getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream()),
-                Constants.HTTP_METHOD_GET);
+                HttpConstants.HTTP_METHOD_GET);
     }
 
     @Test
     public void testGetRequestURL() {
         String path = "/hello/12";
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/inbound/response/InResponseNativeFunctionNegativeTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/inbound/response/InResponseNativeFunctionNegativeTest.java
@@ -26,7 +26,7 @@ import org.ballerinalang.model.values.BJSON;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -49,10 +49,10 @@ import static org.ballerinalang.mime.util.Constants.TEXT_PLAIN;
 public class InResponseNativeFunctionNegativeTest {
 
     private CompileResult result, resultNegative;
-    private final String inRespStruct = Constants.IN_RESPONSE;
-    private final String entityStruct = Constants.ENTITY;
+    private final String inRespStruct = HttpConstants.IN_RESPONSE;
+    private final String entityStruct = HttpConstants.ENTITY;
     private final String mediaTypeStruct = MEDIA_TYPE;
-    private final String protocolPackageHttp = Constants.PROTOCOL_PACKAGE_HTTP;
+    private final String protocolPackageHttp = HttpConstants.PROTOCOL_PACKAGE_HTTP;
     private final String protocolPackageMime = PROTOCOL_PACKAGE_MIME;
 
     @BeforeClass

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/inbound/response/InResponseNativeFunctionSuccessTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/inbound/response/InResponseNativeFunctionSuccessTest.java
@@ -30,7 +30,7 @@ import org.ballerinalang.model.values.BStringArray;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.model.values.BXMLItem;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.test.services.testutils.HTTPTestRequest;
 import org.ballerinalang.test.services.testutils.MessageUtils;
@@ -61,10 +61,10 @@ import static org.ballerinalang.mime.util.Constants.XML_DATA_INDEX;
 public class InResponseNativeFunctionSuccessTest {
 
     private CompileResult result, serviceResult;
-    private final String inResStruct = Constants.IN_RESPONSE;
-    private final String entityStruct = Constants.ENTITY;
+    private final String inResStruct = HttpConstants.IN_RESPONSE;
+    private final String entityStruct = HttpConstants.ENTITY;
     private final String mediaTypeStruct = MEDIA_TYPE;
-    private final String protocolPackageHttp = Constants.PROTOCOL_PACKAGE_HTTP;
+    private final String protocolPackageHttp = HttpConstants.PROTOCOL_PACKAGE_HTTP;
     private final String protocolPackageMime = PROTOCOL_PACKAGE_MIME;
 
     @BeforeClass
@@ -100,8 +100,8 @@ public class InResponseNativeFunctionSuccessTest {
         HTTPCarbonMessage inResponseMsg = HttpUtil.createHttpCarbonMessage(false);
 
         String payload = "ballerina";
-        inResponseMsg.setHeader(Constants.HTTP_CONTENT_LENGTH, String.valueOf(payload.length()));
-        inResponseMsg.setProperty(Constants.HTTP_STATUS_CODE, 200);
+        inResponseMsg.setHeader(HttpConstants.HTTP_CONTENT_LENGTH, String.valueOf(payload.length()));
+        inResponseMsg.setProperty(HttpConstants.HTTP_STATUS_CODE, 200);
         HttpUtil.addCarbonMsg(inResponse, inResponseMsg);
 
         BStruct entity = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageMime, entityStruct);
@@ -120,7 +120,7 @@ public class InResponseNativeFunctionSuccessTest {
         BStruct inResponse = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageHttp, inResStruct);
         HTTPCarbonMessage inResponseMsg = HttpUtil.createHttpCarbonMessage(false);
         inResponseMsg.setHeader(CONTENT_TYPE, APPLICATION_FORM);
-        inResponseMsg.setProperty(Constants.HTTP_STATUS_CODE, 200);
+        inResponseMsg.setProperty(HttpConstants.HTTP_STATUS_CODE, 200);
         HttpUtil.addCarbonMsg(inResponse, inResponseMsg);
 
         BStruct entity = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageMime, entityStruct);
@@ -143,7 +143,7 @@ public class InResponseNativeFunctionSuccessTest {
         headers.set("test-header", APPLICATION_FORM);
         headers.add("test-header", TEXT_PLAIN);
 
-        inResponseMsg.setProperty(Constants.HTTP_STATUS_CODE, 200);
+        inResponseMsg.setProperty(HttpConstants.HTTP_STATUS_CODE, 200);
         BStruct entity = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageMime, entityStruct);
         BStruct mediaType = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageMime, mediaTypeStruct);
         HttpUtil.populateInboundResponse(inResponse, entity, mediaType, inResponseMsg);
@@ -234,7 +234,7 @@ public class InResponseNativeFunctionSuccessTest {
     @Test
     public void testForwardMethod() {
         String path = "/hello/11";
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
         Assert.assertNotNull(response, "Response message not found");
     }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/outbound/request/OutRequestNativeFunctionNegativeTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/outbound/request/OutRequestNativeFunctionNegativeTest.java
@@ -28,7 +28,7 @@ import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStringArray;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -50,10 +50,10 @@ import static org.ballerinalang.mime.util.Constants.TEXT_PLAIN;
 public class OutRequestNativeFunctionNegativeTest {
 
     private CompileResult result, resultNegative;
-    private final String outReqStruct = Constants.OUT_REQUEST;
-    private final String entityStruct = Constants.ENTITY;
+    private final String outReqStruct = HttpConstants.OUT_REQUEST;
+    private final String entityStruct = HttpConstants.ENTITY;
     private final String mediaTypeStruct = MEDIA_TYPE;
-    private final String protocolPackageHttp = Constants.PROTOCOL_PACKAGE_HTTP;
+    private final String protocolPackageHttp = HttpConstants.PROTOCOL_PACKAGE_HTTP;
     private final String protocolPackageMime = PROTOCOL_PACKAGE_MIME;
 
     @BeforeClass

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/outbound/request/OutRequestNativeFunctionSuccessTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/outbound/request/OutRequestNativeFunctionSuccessTest.java
@@ -32,7 +32,7 @@ import org.ballerinalang.model.values.BStringArray;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.model.values.BXMLItem;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.runtime.message.BlobDataSource;
 import org.ballerinalang.test.services.testutils.HTTPTestRequest;
@@ -81,10 +81,10 @@ public class OutRequestNativeFunctionSuccessTest {
     private static final Logger LOG = LoggerFactory.getLogger(OutRequestNativeFunctionSuccessTest.class);
 
     private CompileResult result, serviceResult;
-    private final String outReqStruct = Constants.OUT_REQUEST;
-    private final String protocolPackageHttp = Constants.PROTOCOL_PACKAGE_HTTP;
+    private final String outReqStruct = HttpConstants.OUT_REQUEST;
+    private final String protocolPackageHttp = HttpConstants.PROTOCOL_PACKAGE_HTTP;
     private final String protocolPackageMime = PROTOCOL_PACKAGE_MIME;
-    private final String entityStruct = Constants.ENTITY;
+    private final String entityStruct = HttpConstants.ENTITY;
     private final String mediaTypeStruct = MEDIA_TYPE;
 
     @BeforeClass
@@ -117,7 +117,7 @@ public class OutRequestNativeFunctionSuccessTest {
         String key = "lang";
         String value = "ballerina";
         String path = "/hello/addheader/" + key + "/" + value;
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
         Assert.assertNotNull(response, "Response message not found");
         BJSON bJson = new BJSON(ResponseReader.getReturnValue(response));
@@ -152,7 +152,8 @@ public class OutRequestNativeFunctionSuccessTest {
         BStruct entity = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageMime, entityStruct);
 
         BMap<String, BStringArray> headersMap = new BMap<>();
-        headersMap.put(Constants.HTTP_CONTENT_LENGTH, new BStringArray(new String[]{String.valueOf(payload.length())}));
+        headersMap.put(HttpConstants.HTTP_CONTENT_LENGTH,
+                       new BStringArray(new String[]{String.valueOf(payload.length())}));
         entity.setRefField(ENTITY_HEADERS_INDEX, headersMap);
         outRequest.addNativeData(MESSAGE_ENTITY, entity);
 
@@ -166,7 +167,7 @@ public class OutRequestNativeFunctionSuccessTest {
     @Test(description = "Test GetContentLength function within a service")
     public void testServiceGetContentLength() {
         String path = "/hello/getContentLength";
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -195,7 +196,7 @@ public class OutRequestNativeFunctionSuccessTest {
     @Test(description = "Test GetHeader function within a service")
     public void testServiceGetHeader() {
         String path = "/hello/getHeader";
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -247,7 +248,7 @@ public class OutRequestNativeFunctionSuccessTest {
     public void testServiceGetJsonPayload() {
         String value = "ballerina";
         String path = "/hello/getJsonPayload";
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
         Assert.assertNotNull(response, "Response message not found");
         Assert.assertEquals(new BJSON(ResponseReader.getReturnValue(response)).value().stringValue(), value);
@@ -274,7 +275,7 @@ public class OutRequestNativeFunctionSuccessTest {
     public void testServiceGetProperty() {
         String propertyValue = "Ballerina";
         String path = "/hello/GetProperty";
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -305,7 +306,7 @@ public class OutRequestNativeFunctionSuccessTest {
     public void testServiceGetStringPayload() {
         String value = "ballerina";
         String path = "/hello/GetStringPayload";
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
         Assert.assertNotNull(response, "Response message not found");
         Assert.assertEquals(
@@ -334,7 +335,7 @@ public class OutRequestNativeFunctionSuccessTest {
     @Test(description = "Test GetXmlPayload function within a service")
     public void testServiceGetXmlPayload() {
         String path = "/hello/GetXmlPayload";
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
         Assert.assertNotNull(response, "Response message not found");
         Assert.assertEquals(ResponseReader.getReturnValue(response), "ballerina");
@@ -367,7 +368,7 @@ public class OutRequestNativeFunctionSuccessTest {
     @Test(description = "Test RemoveHeader function within a service")
     public void testServiceRemoveHeader() {
         String path = "/hello/RemoveHeader";
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -403,7 +404,7 @@ public class OutRequestNativeFunctionSuccessTest {
     @Test(description = "Test RemoveAllHeaders function within a service")
     public void testServiceRemoveAllHeaders() {
         String path = "/hello/RemoveAllHeaders";
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -452,7 +453,7 @@ public class OutRequestNativeFunctionSuccessTest {
         String key = "lang";
         String value = "ballerina";
         String path = "/hello/setHeader/" + key + "/" + value;
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -477,7 +478,7 @@ public class OutRequestNativeFunctionSuccessTest {
     public void testServiceSetJsonPayload() {
         String value = "ballerina";
         String path = "/hello/SetJsonPayload/" + value;
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -506,7 +507,7 @@ public class OutRequestNativeFunctionSuccessTest {
         String key = "lang";
         String value = "ballerina";
         String path = "/hello/SetProperty/" + key + "/" + value;
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -532,7 +533,7 @@ public class OutRequestNativeFunctionSuccessTest {
     public void testServiceSetStringPayload() {
         String value = "ballerina";
         String path = "/hello/SetStringPayload/" + value;
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -558,7 +559,7 @@ public class OutRequestNativeFunctionSuccessTest {
     public void testServiceSetXmlPayload() {
         String value = "Ballerina";
         String path = "/hello/SetXmlPayload/";
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -570,7 +571,7 @@ public class OutRequestNativeFunctionSuccessTest {
     public void testServiceSetBinaryPayload() {
         String value = "Ballerina";
         String path = "/hello/SetBinaryPayload/";
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -582,7 +583,7 @@ public class OutRequestNativeFunctionSuccessTest {
     public void testServiceGetBinaryPayload() {
         String payload = "ballerina";
         String path = "/hello/GetBinaryPayload";
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_POST, payload);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_POST, payload);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/outbound/response/OutResponseNativeFunctionNegativeTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/outbound/response/OutResponseNativeFunctionNegativeTest.java
@@ -28,7 +28,7 @@ import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStringArray;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -52,11 +52,11 @@ import static org.ballerinalang.mime.util.Constants.TEXT_PLAIN;
 public class OutResponseNativeFunctionNegativeTest {
 
     private CompileResult result, resultNegative;
-    private final String inRespStruct = Constants.IN_RESPONSE;
-    private final String outRespStruct = Constants.OUT_RESPONSE;
-    private final String entityStruct = Constants.ENTITY;
+    private final String inRespStruct = HttpConstants.IN_RESPONSE;
+    private final String outRespStruct = HttpConstants.OUT_RESPONSE;
+    private final String entityStruct = HttpConstants.ENTITY;
     private final String mediaTypeStruct = MEDIA_TYPE;
-    private final String protocolPackageHttp = Constants.PROTOCOL_PACKAGE_HTTP;
+    private final String protocolPackageHttp = HttpConstants.PROTOCOL_PACKAGE_HTTP;
     private final String protocolPackageMime = PROTOCOL_PACKAGE_MIME;
 
     @BeforeClass

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/outbound/response/OutResponseNativeFunctionSuccessTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/outbound/response/OutResponseNativeFunctionSuccessTest.java
@@ -31,7 +31,7 @@ import org.ballerinalang.model.values.BStringArray;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.model.values.BXMLItem;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.test.services.testutils.HTTPTestRequest;
 import org.ballerinalang.test.services.testutils.MessageUtils;
@@ -64,10 +64,10 @@ import static org.ballerinalang.mime.util.Constants.XML_DATA_INDEX;
 public class OutResponseNativeFunctionSuccessTest {
 
     private CompileResult result, serviceResult;
-    private final String outRespStruct = Constants.OUT_RESPONSE;
-    private final String entityStruct = Constants.ENTITY;
+    private final String outRespStruct = HttpConstants.OUT_RESPONSE;
+    private final String entityStruct = HttpConstants.ENTITY;
     private final String mediaTypeStruct = MEDIA_TYPE;
-    private final String protocolPackageHttp = Constants.PROTOCOL_PACKAGE_HTTP;
+    private final String protocolPackageHttp = HttpConstants.PROTOCOL_PACKAGE_HTTP;
     private final String protocolPackageMime = PROTOCOL_PACKAGE_MIME;
 
     @BeforeClass
@@ -101,7 +101,7 @@ public class OutResponseNativeFunctionSuccessTest {
         String key = "lang";
         String value = "ballerina";
         String path = "/hello/addheader/" + key + "/" + value;
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -135,7 +135,8 @@ public class OutResponseNativeFunctionSuccessTest {
         BStruct entity = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageMime, entityStruct);
 
         BMap<String, BStringArray> headersMap = new BMap<>();
-        headersMap.put(Constants.HTTP_CONTENT_LENGTH, new BStringArray(new String[]{String.valueOf(payload.length())}));
+        headersMap.put(HttpConstants.HTTP_CONTENT_LENGTH,
+                       new BStringArray(new String[]{String.valueOf(payload.length())}));
         entity.setRefField(ENTITY_HEADERS_INDEX, headersMap);
         outResponse.addNativeData(MESSAGE_ENTITY, entity);
         BValue[] inputArg = {outResponse};
@@ -168,7 +169,7 @@ public class OutResponseNativeFunctionSuccessTest {
     public void testServiceGetHeader() {
         String value = "x-www-form-urlencoded";
         String path = "/hello/getHeader/" + CONTENT_TYPE + "/" + value;
-        HTTPTestRequest inRequest = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequest = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequest);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -220,7 +221,7 @@ public class OutResponseNativeFunctionSuccessTest {
     public void testServiceGetJsonPayload() {
         String value = "ballerina";
         String path = "/hello/getJsonPayload/" + value;
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage responseMsg = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(responseMsg, "Response message not found");
@@ -249,7 +250,7 @@ public class OutResponseNativeFunctionSuccessTest {
         String propertyName = "wso2";
         String propertyValue = "Ballerina";
         String path = "/hello/GetProperty/" + propertyName + "/" + propertyValue;
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -280,7 +281,7 @@ public class OutResponseNativeFunctionSuccessTest {
     public void testServiceGetStringPayload() {
         String value = "ballerina";
         String path = "/hello/GetStringPayload/" + value;
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -311,7 +312,7 @@ public class OutResponseNativeFunctionSuccessTest {
     public void testServiceGetXmlPayload() {
         String value = "ballerina";
         String path = "/hello/GetXmlPayload";
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -347,7 +348,7 @@ public class OutResponseNativeFunctionSuccessTest {
     public void testServiceRemoveHeader() {
         String value = "x-www-form-urlencoded";
         String path = "/hello/RemoveHeader/" + CONTENT_TYPE + "/" + value;
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -383,7 +384,7 @@ public class OutResponseNativeFunctionSuccessTest {
     @Test(description = "Test RemoveAllHeaders function within a service")
     public void testServiceRemoveAllHeaders() {
         String path = "/hello/RemoveAllHeaders";
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -394,7 +395,7 @@ public class OutResponseNativeFunctionSuccessTest {
     @Test
     public void testRespondMethod() {
         String path = "/hello/11";
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
         Assert.assertNotNull(response, "Response message not found");
     }
@@ -449,21 +450,21 @@ public class OutResponseNativeFunctionSuccessTest {
     public void testSetReasonPhase() {
         String phase = "ballerina";
         String path = "/hello/12/" + phase;
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");
-        Assert.assertEquals(response.getProperty(Constants.HTTP_REASON_PHRASE), phase);
+        Assert.assertEquals(response.getProperty(HttpConstants.HTTP_REASON_PHRASE), phase);
     }
 
     @Test
     public void testSetStatusCode() {
         String path = "/hello/13";
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, Constants.HTTP_METHOD_GET);
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");
-        Assert.assertEquals(response.getProperty(Constants.HTTP_STATUS_CODE), 203);
+        Assert.assertEquals(response.getProperty(HttpConstants.HTTP_STATUS_CODE), 203);
     }
 
     @Test

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/session/HTTPSessionEssentialMethodsTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/session/HTTPSessionEssentialMethodsTest.java
@@ -35,9 +35,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.ballerinalang.mime.util.Constants.TEXT_PLAIN;
-import static org.ballerinalang.net.http.Constants.COOKIE_HEADER;
-import static org.ballerinalang.net.http.Constants.RESPONSE_COOKIE_HEADER;
-import static org.ballerinalang.net.http.Constants.SESSION_ID;
+import static org.ballerinalang.net.http.HttpConstants.COOKIE_HEADER;
+import static org.ballerinalang.net.http.HttpConstants.RESPONSE_COOKIE_HEADER;
+import static org.ballerinalang.net.http.HttpConstants.SESSION_ID;
 
 /**
  * HTTP session Essential Methods Test Class.

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/session/HTTPSessionSubMethodsTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/session/HTTPSessionSubMethodsTest.java
@@ -30,9 +30,9 @@ import org.testng.annotations.Test;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 
-import static org.ballerinalang.net.http.Constants.COOKIE_HEADER;
-import static org.ballerinalang.net.http.Constants.RESPONSE_COOKIE_HEADER;
-import static org.ballerinalang.net.http.Constants.SESSION_ID;
+import static org.ballerinalang.net.http.HttpConstants.COOKIE_HEADER;
+import static org.ballerinalang.net.http.HttpConstants.RESPONSE_COOKIE_HEADER;
+import static org.ballerinalang.net.http.HttpConstants.SESSION_ID;
 
 /**
  * HTTP session sub Methods Test Class.

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/testutils/MessageUtils.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/testutils/MessageUtils.java
@@ -21,7 +21,7 @@ package org.ballerinalang.test.services.testutils;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpHeaders;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.wso2.carbon.messaging.CarbonMessage;
 import org.wso2.carbon.messaging.DefaultCarbonMessage;
 import org.wso2.carbon.messaging.Header;
@@ -73,18 +73,18 @@ public class MessageUtils {
 
     private static HTTPTestRequest getHttpTestRequest(String path, String method) {
         HTTPTestRequest carbonMessage = new HTTPTestRequest();
-        carbonMessage.setProperty(Constants.PROTOCOL,
-                Constants.PROTOCOL_HTTP);
-        carbonMessage.setProperty(Constants.LISTENER_INTERFACE_ID,
-                Constants.DEFAULT_INTERFACE);
+        carbonMessage.setProperty(HttpConstants.PROTOCOL,
+                HttpConstants.PROTOCOL_HTTP);
+        carbonMessage.setProperty(HttpConstants.LISTENER_INTERFACE_ID,
+                HttpConstants.DEFAULT_INTERFACE);
         // Set url
-        carbonMessage.setProperty(Constants.TO, path);
-        carbonMessage.setProperty(Constants.REQUEST_URL, path);
-        carbonMessage.setProperty(Constants.HTTP_METHOD, method.trim().toUpperCase(Locale.getDefault()));
-        carbonMessage.setProperty(Constants.LOCAL_ADDRESS,
-                new InetSocketAddress(Constants.HTTP_DEFAULT_HOST, 9090));
-        carbonMessage.setProperty(Constants.LISTENER_PORT, 9090);
-        carbonMessage.setProperty(Constants.RESOURCE_ARGS, new HashMap<String, String>());
+        carbonMessage.setProperty(HttpConstants.TO, path);
+        carbonMessage.setProperty(HttpConstants.REQUEST_URL, path);
+        carbonMessage.setProperty(HttpConstants.HTTP_METHOD, method.trim().toUpperCase(Locale.getDefault()));
+        carbonMessage.setProperty(HttpConstants.LOCAL_ADDRESS,
+                new InetSocketAddress(HttpConstants.HTTP_DEFAULT_HOST, 9090));
+        carbonMessage.setProperty(HttpConstants.LISTENER_PORT, 9090);
+        carbonMessage.setProperty(HttpConstants.RESOURCE_ARGS, new HashMap<String, String>());
         return carbonMessage;
     }
 }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/testutils/Services.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/testutils/Services.java
@@ -25,7 +25,7 @@ import org.ballerinalang.connector.api.Executor;
 import org.ballerinalang.launcher.util.CompileResult;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.net.http.BallerinaHttpServerConnector;
-import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpDispatcher;
 import org.ballerinalang.net.http.HttpResource;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
@@ -42,7 +42,7 @@ public class Services {
 
     public static HTTPCarbonMessage invokeNew(CompileResult compileResult, HTTPTestRequest request) {
         BallerinaHttpServerConnector httpServerConnector = (BallerinaHttpServerConnector) ConnectorUtils.
-                getBallerinaServerConnector(compileResult.getProgFile(), Constants.HTTP_PACKAGE_PATH);
+                getBallerinaServerConnector(compileResult.getProgFile(), HttpConstants.HTTP_PACKAGE_PATH);
         TestHttpFutureListener futureListener = new TestHttpFutureListener(request);
         request.setFutureListener(futureListener);
         HttpResource resource = HttpDispatcher.findResource(httpServerConnector.getHttpServicesRegistry(), request);
@@ -52,9 +52,9 @@ public class Services {
         //TODO below should be fixed properly
         //basically need to find a way to pass information from server connector side to client connector side
         Map<String, Object> properties = null;
-        if (request.getProperty(Constants.SRC_HANDLER) != null) {
-            Object srcHandler = request.getProperty(Constants.SRC_HANDLER);
-            properties = Collections.singletonMap(Constants.SRC_HANDLER, srcHandler);
+        if (request.getProperty(HttpConstants.SRC_HANDLER) != null) {
+            Object srcHandler = request.getProperty(HttpConstants.SRC_HANDLER);
+            properties = Collections.singletonMap(HttpConstants.SRC_HANDLER, srcHandler);
         }
         BValue[] signatureParams = HttpDispatcher.getSignatureParameters(resource, request);
         ConnectorFuture future = Executor.submit(resource.getBalResource(), properties, signatureParams);

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/testutils/TestHttpFutureListener.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/testutils/TestHttpFutureListener.java
@@ -21,8 +21,8 @@ import org.ballerinalang.connector.api.BallerinaConnectorException;
 import org.ballerinalang.connector.api.ConnectorFutureListener;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
-import org.ballerinalang.net.http.Constants;
 import org.ballerinalang.net.http.CorsHeaderGenerator;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.net.http.session.Session;
 import org.ballerinalang.services.ErrorHandlerUtils;
@@ -60,7 +60,7 @@ public class TestHttpFutureListener implements ConnectorFutureListener {
     public void notifyReply(BValue... response) {
         //TODO check below line
         HTTPCarbonMessage responseMessage = HttpUtil.getCarbonMsg((BStruct) response[0], null);
-        Session session = (Session) ((BStruct) request).getNativeData(Constants.HTTP_SESSION);
+        Session session = (Session) ((BStruct) request).getNativeData(HttpConstants.HTTP_SESSION);
         if (session != null) {
             session.generateSessionHeader(responseMessage);
         }
@@ -74,7 +74,7 @@ public class TestHttpFutureListener implements ConnectorFutureListener {
 
     @Override
     public void notifyFailure(BallerinaConnectorException ex) {
-        Object carbonStatusCode = requestMessage.getProperty(Constants.HTTP_STATUS_CODE);
+        Object carbonStatusCode = requestMessage.getProperty(HttpConstants.HTTP_STATUS_CODE);
         int statusCode = (carbonStatusCode == null) ? 500 : Integer.parseInt(carbonStatusCode.toString());
         String errorMsg = ex.getMessage();
         ErrorHandlerUtils.printError(ex);


### PR DESCRIPTION


## Purpose
> Related issue: https://github.com/ballerina-lang/ballerina/issues/4558

## Goals
> Reduce naming confusions in the standard lib package because of the similarly named Constants classes.

## Approach
> Rename the two Constants classes and refactoring. 

## User stories
> N/A

## Release note
> Code refactor for Constants classes

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - N/A

## Security checks
> N/A

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A