### PR TITLE
Add go to definition support between packages

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -187,19 +187,19 @@ public class BallerinaTextDocumentService implements TextDocumentService {
     @Override
     public CompletableFuture<List<? extends Location>> definition(TextDocumentPositionParams position) {
         return CompletableFuture.supplyAsync(() -> {
-            TextDocumentServiceContext hoverContext = new TextDocumentServiceContext();
-            hoverContext.put(DocumentServiceKeys.FILE_URI_KEY, position.getTextDocument().getUri());
-            hoverContext.put(DocumentServiceKeys.POSITION_KEY, position);
+            TextDocumentServiceContext definitionContext = new TextDocumentServiceContext();
+            definitionContext.put(DocumentServiceKeys.FILE_URI_KEY, position.getTextDocument().getUri());
+            definitionContext.put(DocumentServiceKeys.POSITION_KEY, position);
 
             BLangPackage currentBLangPackage =
-                    TextDocumentServiceUtil.getBLangPackage(hoverContext, documentManager);
+                    TextDocumentServiceUtil.getBLangPackage(definitionContext, documentManager);
             bLangPackageContext.addPackage(currentBLangPackage);
             List<Location> contents;
             try {
-                PositionTreeVisitor positionTreeVisitor = new PositionTreeVisitor(hoverContext);
+                PositionTreeVisitor positionTreeVisitor = new PositionTreeVisitor(definitionContext);
                 currentBLangPackage.accept(positionTreeVisitor);
 
-                contents = DefinitionUtil.getDefinitionPosition(hoverContext, currentBLangPackage);
+                contents = DefinitionUtil.getDefinitionPosition(definitionContext, bLangPackageContext);
             } catch (Exception e) {
                 contents = new ArrayList<>();
             }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/NodeContextKeys.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/NodeContextKeys.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,6 +36,8 @@ public class NodeContextKeys {
     public static final LanguageServerContext.Key<Object> PREVIOUSLY_VISITED_NODE_KEY
             = new LanguageServerContext.Key<>();
     public static final LanguageServerContext.Key<String> NODE_OWNER_KEY
+            = new LanguageServerContext.Key<>();
+    public static final LanguageServerContext.Key<PackageID> NODE_OWNER_PACKAGE_KEY
             = new LanguageServerContext.Key<>();
     public static final LanguageServerContext.Key<Stack<BLangNode>> NODE_STACK_KEY
             = new LanguageServerContext.Key<>();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/position/PositionTreeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/position/PositionTreeVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -163,7 +163,12 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
         }
 
         previousNode = funcNode;
-        this.nodeStack.push(funcNode);
+        if (!terminateVisitor) {
+            if (!this.nodeStack.empty()) {
+                this.nodeStack.pop();
+            }
+            this.nodeStack.push(funcNode);
+        }
 
         if (!funcNode.params.isEmpty()) {
             funcNode.params.forEach(this::acceptNode);
@@ -198,6 +203,9 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
             this.context.put(NodeContextKeys.PACKAGE_OF_NODE_KEY, userDefinedType.type.tsymbol.pkgID);
             this.context.put(NodeContextKeys.SYMBOL_KIND_OF_NODE_PARENT_KEY, userDefinedType.type.tsymbol.kind.name());
             this.context.put(NodeContextKeys.SYMBOL_KIND_OF_NODE_KEY, userDefinedType.type.tsymbol.kind.name());
+            this.context.put(NodeContextKeys.NODE_OWNER_KEY, userDefinedType.type.tsymbol.owner.name.getValue());
+            this.context.put(NodeContextKeys.NODE_OWNER_PACKAGE_KEY,
+                    userDefinedType.type.tsymbol.owner.pkgID);
             terminateVisitor = true;
         }
     }
@@ -248,6 +256,8 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
             this.context.put(NodeContextKeys.SYMBOL_KIND_OF_NODE_KEY, ContextConstants.VARIABLE);
             if (varRefExpr.symbol != null) {
                 this.context.put(NodeContextKeys.NODE_OWNER_KEY, varRefExpr.symbol.owner.name.getValue());
+                this.context.put(NodeContextKeys.NODE_OWNER_PACKAGE_KEY,
+                        varRefExpr.symbol.owner.pkgID);
                 this.context.put(NodeContextKeys.VAR_NAME_OF_NODE_KEY, varRefExpr.variableName.getValue());
             }
             terminateVisitor = true;
@@ -263,6 +273,8 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
             this.context.put(NodeContextKeys.SYMBOL_KIND_OF_NODE_KEY, ContextConstants.VARIABLE);
             if (varRefExpr.symbol != null) {
                 this.context.put(NodeContextKeys.NODE_OWNER_KEY, varRefExpr.symbol.owner.name.getValue());
+                this.context.put(NodeContextKeys.NODE_OWNER_PACKAGE_KEY,
+                        varRefExpr.symbol.owner.pkgID);
                 this.context.put(NodeContextKeys.VAR_NAME_OF_NODE_KEY, varRefExpr.variableName.getValue());
                 this.context.put(NodeContextKeys.SYMBOL_KIND_OF_NODE_KEY, ContextConstants.VARIABLE);
             } else {
@@ -279,6 +291,8 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
             this.context.put(NodeContextKeys.SYMBOL_KIND_OF_NODE_KEY, ContextConstants.VARIABLE);
             if (varRefExpr.symbol != null) {
                 this.context.put(NodeContextKeys.NODE_OWNER_KEY, varRefExpr.symbol.owner.name.getValue());
+                this.context.put(NodeContextKeys.NODE_OWNER_PACKAGE_KEY,
+                        varRefExpr.symbol.owner.pkgID);
                 this.context.put(NodeContextKeys.VAR_NAME_OF_NODE_KEY, varRefExpr.variableName.getValue());
             }
             terminateVisitor = true;
@@ -361,7 +375,12 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
 
     public void visit(BLangStruct structNode) {
         previousNode = structNode;
-        this.nodeStack.push(structNode);
+        if (!terminateVisitor) {
+            if (!this.nodeStack.empty()) {
+                this.nodeStack.pop();
+            }
+            this.nodeStack.push(structNode);
+        }
 
         if (!structNode.fields.isEmpty()) {
             structNode.fields.forEach(this::acceptNode);
@@ -380,7 +399,12 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
 
     public void visit(BLangTransformer transformerNode) {
         previousNode = transformerNode;
-        this.nodeStack.push(transformerNode);
+        if (!terminateVisitor) {
+            if (!this.nodeStack.empty()) {
+                this.nodeStack.pop();
+            }
+            this.nodeStack.push(transformerNode);
+        }
 
         if (transformerNode.source != null) {
             acceptNode(transformerNode.source);
@@ -405,7 +429,12 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
 
     public void visit(BLangConnector connectorNode) {
         previousNode = connectorNode;
-        this.nodeStack.push(connectorNode);
+        if (!terminateVisitor) {
+            if (!this.nodeStack.empty()) {
+                this.nodeStack.pop();
+            }
+            this.nodeStack.push(connectorNode);
+        }
 
         if (!connectorNode.params.isEmpty()) {
             connectorNode.params.forEach(this::acceptNode);
@@ -422,7 +451,12 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
 
     public void visit(BLangAction actionNode) {
         previousNode = actionNode;
-        this.nodeStack.push(actionNode);
+        if (!terminateVisitor) {
+            if (!this.nodeStack.empty()) {
+                this.nodeStack.pop();
+            }
+            this.nodeStack.push(actionNode);
+        }
 
         if (!actionNode.params.isEmpty()) {
             actionNode.params.forEach(this::acceptNode);
@@ -443,7 +477,12 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
 
     public void visit(BLangService serviceNode) {
         previousNode = serviceNode;
-        this.nodeStack.push(serviceNode);
+        if (!terminateVisitor) {
+            if (!this.nodeStack.empty()) {
+                this.nodeStack.pop();
+            }
+            this.nodeStack.push(serviceNode);
+        }
 
         if (!serviceNode.resources.isEmpty()) {
             serviceNode.resources.forEach(this::acceptNode);
@@ -456,7 +495,12 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
 
     public void visit(BLangResource resourceNode) {
         previousNode = resourceNode;
-        this.nodeStack.push(resourceNode);
+        if (!terminateVisitor) {
+            if (!this.nodeStack.empty()) {
+                this.nodeStack.pop();
+            }
+            this.nodeStack.push(resourceNode);
+        }
 
         if (!resourceNode.params.isEmpty()) {
             resourceNode.params.forEach(this::acceptNode);
@@ -614,6 +658,9 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
             this.context.put(NodeContextKeys.PACKAGE_OF_NODE_KEY, invocationExpr.symbol.pkgID);
             this.context.put(NodeContextKeys.SYMBOL_KIND_OF_NODE_PARENT_KEY, invocationExpr.symbol.kind.name());
             this.context.put(NodeContextKeys.SYMBOL_KIND_OF_NODE_KEY, invocationExpr.symbol.kind.name());
+            this.context.put(NodeContextKeys.NODE_OWNER_KEY, invocationExpr.symbol.owner.name.getValue());
+            this.context.put(NodeContextKeys.NODE_OWNER_PACKAGE_KEY,
+                    invocationExpr.symbol.owner.pkgID);
             this.terminateVisitor = true;
         }
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/position/PositionTreeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/position/PositionTreeVisitor.java
@@ -163,12 +163,7 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
         }
 
         previousNode = funcNode;
-        if (!terminateVisitor) {
-            if (!this.nodeStack.empty()) {
-                this.nodeStack.pop();
-            }
-            this.nodeStack.push(funcNode);
-        }
+        this.addToNodeStack(funcNode);
 
         if (!funcNode.params.isEmpty()) {
             funcNode.params.forEach(this::acceptNode);
@@ -375,12 +370,7 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
 
     public void visit(BLangStruct structNode) {
         previousNode = structNode;
-        if (!terminateVisitor) {
-            if (!this.nodeStack.empty()) {
-                this.nodeStack.pop();
-            }
-            this.nodeStack.push(structNode);
-        }
+        this.addToNodeStack(structNode);
 
         if (!structNode.fields.isEmpty()) {
             structNode.fields.forEach(this::acceptNode);
@@ -399,12 +389,7 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
 
     public void visit(BLangTransformer transformerNode) {
         previousNode = transformerNode;
-        if (!terminateVisitor) {
-            if (!this.nodeStack.empty()) {
-                this.nodeStack.pop();
-            }
-            this.nodeStack.push(transformerNode);
-        }
+        this.addToNodeStack(transformerNode);
 
         if (transformerNode.source != null) {
             acceptNode(transformerNode.source);
@@ -429,12 +414,7 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
 
     public void visit(BLangConnector connectorNode) {
         previousNode = connectorNode;
-        if (!terminateVisitor) {
-            if (!this.nodeStack.empty()) {
-                this.nodeStack.pop();
-            }
-            this.nodeStack.push(connectorNode);
-        }
+        this.addToNodeStack(connectorNode);
 
         if (!connectorNode.params.isEmpty()) {
             connectorNode.params.forEach(this::acceptNode);
@@ -451,12 +431,7 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
 
     public void visit(BLangAction actionNode) {
         previousNode = actionNode;
-        if (!terminateVisitor) {
-            if (!this.nodeStack.empty()) {
-                this.nodeStack.pop();
-            }
-            this.nodeStack.push(actionNode);
-        }
+        this.addToNodeStack(actionNode);
 
         if (!actionNode.params.isEmpty()) {
             actionNode.params.forEach(this::acceptNode);
@@ -477,12 +452,7 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
 
     public void visit(BLangService serviceNode) {
         previousNode = serviceNode;
-        if (!terminateVisitor) {
-            if (!this.nodeStack.empty()) {
-                this.nodeStack.pop();
-            }
-            this.nodeStack.push(serviceNode);
-        }
+        this.addToNodeStack(serviceNode);
 
         if (!serviceNode.resources.isEmpty()) {
             serviceNode.resources.forEach(this::acceptNode);
@@ -495,12 +465,7 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
 
     public void visit(BLangResource resourceNode) {
         previousNode = resourceNode;
-        if (!terminateVisitor) {
-            if (!this.nodeStack.empty()) {
-                this.nodeStack.pop();
-            }
-            this.nodeStack.push(resourceNode);
-        }
+        this.addToNodeStack(resourceNode);
 
         if (!resourceNode.params.isEmpty()) {
             resourceNode.params.forEach(this::acceptNode);
@@ -960,5 +925,19 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
             return;
         }
         node.accept(this);
+    }
+
+    /**
+     * Add node in to a stack to track the visited nodes.
+     *
+     * @param node BLangNode to be added to the stack
+     * */
+    private void addToNodeStack(BLangNode node) {
+        if (!terminateVisitor) {
+            if (!this.nodeStack.empty()) {
+                this.nodeStack.pop();
+            }
+            this.nodeStack.push(node);
+        }
     }
 }


### PR DESCRIPTION
## Purpose
> Fix https://github.com/ballerina-lang/ballerina/issues/4621

## Goals
> Introduce support for go to definition between different packages.

## Approach
![ezgif com-video-to-gif 14](https://user-images.githubusercontent.com/9109762/36140443-4f36b94a-10c7-11e8-8b8c-b0a089a84ccb.gif)


## User stories
> Find the definition of the functions, structs, enums, connectors, actions and global variables which are imported from a different package.
