### PR TITLE
Redirect function for HTTP Server Connector

### DIFF
--- a/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/connection.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/connection.bal
@@ -2,7 +2,7 @@ package ballerina.net.http;
 
 const string HEADER_KEY_LOCATION = "Location";
 
-public enum redirectCode {
+public enum RedirectCode {
     MULTIPLE_CHOICES_300,
     MOVED_PERMANENTLY_301,
     FOUND_302,
@@ -22,26 +22,26 @@ public function <Connection conn> respondContinue () (HttpConnectorError) {
     return err;
 }
 
-@Description { value:"Sends a redirect response code to the user with given redirection status code." }
+@Description { value:"Sends a redirect response to the user with given redirection status code." }
 @Param { value:"conn: The server connector connection" }
-@Param { value:"response: Response which user wants to send." }
+@Param { value:"response: Response to be sent to client." }
 @Param { value:"redirectCode: Status code of the specific redirect." }
 @Param { value:"locations: Array of locations where the redirection can happen." }
 @Return { value:"Returns an HttpConnectorError if there was any issue in sending the response." }
-public function <Connection conn> redirect(OutResponse response, redirectCode code, string[] locations) (HttpConnectorError) {
-    if (code == redirectCode.MULTIPLE_CHOICES_300) {
+public function <Connection conn> redirect (OutResponse response, RedirectCode code, string[] locations) (HttpConnectorError) {
+    if (code == RedirectCode.MULTIPLE_CHOICES_300) {
         response.statusCode = 300;
-    } else if (code == redirectCode.MOVED_PERMANENTLY_301) {
+    } else if (code == RedirectCode.MOVED_PERMANENTLY_301) {
         response.statusCode = 301;
-    } else if (code == redirectCode.FOUND_302) {
+    } else if (code == RedirectCode.FOUND_302) {
         response.statusCode = 302;
-    } else if (code == redirectCode.SEE_OTHER_303) {
+    } else if (code == RedirectCode.SEE_OTHER_303) {
         response.statusCode = 303;
-    } else if (code == redirectCode.NOT_MODIFIED_304) {
+    } else if (code == RedirectCode.NOT_MODIFIED_304) {
         response.statusCode = 304;
-    } else if (code == redirectCode.USE_PROXY_305) {
+    } else if (code == RedirectCode.USE_PROXY_305) {
         response.statusCode = 305;
-    } else if (code == redirectCode.TEMPORARY_REDIRECT_307) {
+    } else if (code == RedirectCode.TEMPORARY_REDIRECT_307) {
         response.statusCode = 307;
     }
 

--- a/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/connection.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/connection.bal
@@ -1,5 +1,17 @@
 package ballerina.net.http;
 
+const string HEADER_KEY_LOCATION = "Location";
+
+enum redirectCode {
+    MULTIPLE_CHOICES_300,
+    MOVED_PERMANENTLY_301,
+    FOUND_302,
+    SEE_OTHER_303,
+    NOT_MODIFIED_304,
+    USE_PROXY_305,
+    TEMPORARY_REDIRECT_307
+}
+
 @Description { value:"Sends a 100-continue response to the client."}
 @Param { value:"conn: The server connector connection" }
 @Return { value:"Returns an HttpConnectorError if there was any issue in sending the response." }
@@ -8,4 +20,38 @@ public function <Connection conn> respondContinue () (HttpConnectorError) {
     res.statusCode = 100;
     HttpConnectorError err = conn.respond(res);
     return err;
+}
+
+@Description { value:"Sends a redirect response code to the user with given redirection status code." }
+@Param { value:"conn: The server connector connection" }
+@Param { value:"response: Response which user wants to send." }
+@Param { value:"redirectCode: Status code of the specific redirect." }
+@Param { value:"locations: Array of locations where the redirection can happen." }
+@Return { value:"Returns an HttpConnectorError if there was any issue in sending the response." }
+public function <Connection conn> redirect(OutResponse response, redirectCode code, string[] locations) (HttpConnectorError) {
+    if (code == redirectCode.MULTIPLE_CHOICES_300) {
+        response.statusCode = 300;
+    } else if (code == redirectCode.MOVED_PERMANENTLY_301) {
+        response.statusCode = 301;
+    } else if (code == redirectCode.FOUND_302) {
+        response.statusCode = 302;
+    } else if (code == redirectCode.SEE_OTHER_303) {
+        response.statusCode = 303;
+    } else if (code == redirectCode.NOT_MODIFIED_304) {
+        response.statusCode = 304;
+    } else if (code == redirectCode.USE_PROXY_305) {
+        response.statusCode = 305;
+    } else if (code == redirectCode.TEMPORARY_REDIRECT_307) {
+        response.statusCode = 307;
+    }
+
+    string locationsStr = "";
+    foreach location in locations {
+        locationsStr = locationsStr + location + ",";
+    }
+    locationsStr = locationsStr.substring(0, (lengthof locationsStr) - 1);
+
+    response.setHeader(HEADER_KEY_LOCATION, locationsStr);
+    var e = conn.respond(response);
+    return e;
 }

--- a/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/connection.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/connection.bal
@@ -2,6 +2,14 @@ package ballerina.net.http;
 
 const string HEADER_KEY_LOCATION = "Location";
 
+@Description { value:"Status codes for HTTP redirect"}
+@Field { value:"MULTIPLE_CHOICES_300: Represent status code 300 - Mutlipe choises."}
+@Field { value:"MOVED_PERMANENTLY_301: Represent status code 301 - Moved Permanantly."}
+@Field { value:"FOUND_302: Represent status code 302 - Found."}
+@Field { value:"SEE_OTHER_303: Represent status code 303 - See Other."}
+@Field { value:"NOT_MODIFIED_304: Represent status code 304 - Not Modified."}
+@Field { value:"USE_PROXY_305: Represent status code 305 - Use Proxy."}
+@Field { value:"TEMPORARY_REDIRECT_307: Represent status code 307 - Temporary Redirect."}
 public enum RedirectCode {
     MULTIPLE_CHOICES_300,
     MOVED_PERMANENTLY_301,

--- a/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/connection.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/connection.bal
@@ -2,7 +2,7 @@ package ballerina.net.http;
 
 const string HEADER_KEY_LOCATION = "Location";
 
-enum redirectCode {
+public enum redirectCode {
     MULTIPLE_CHOICES_300,
     MOVED_PERMANENTLY_301,
     FOUND_302,
@@ -49,7 +49,7 @@ public function <Connection conn> redirect(OutResponse response, redirectCode co
     foreach location in locations {
         locationsStr = locationsStr + location + ",";
     }
-    locationsStr = locationsStr.substring(0, (lengthof locationsStr) - 1);
+    locationsStr = locationsStr.subString(0, (lengthof locationsStr) - 1);
 
     response.setHeader(HEADER_KEY_LOCATION, locationsStr);
     var e = conn.respond(response);

--- a/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/connection.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/connection.bal
@@ -3,13 +3,13 @@ package ballerina.net.http;
 const string HEADER_KEY_LOCATION = "Location";
 
 @Description { value:"Status codes for HTTP redirect"}
-@Field { value:"MULTIPLE_CHOICES_300: Represent status code 300 - Mutlipe choises."}
-@Field { value:"MOVED_PERMANENTLY_301: Represent status code 301 - Moved Permanantly."}
-@Field { value:"FOUND_302: Represent status code 302 - Found."}
-@Field { value:"SEE_OTHER_303: Represent status code 303 - See Other."}
-@Field { value:"NOT_MODIFIED_304: Represent status code 304 - Not Modified."}
-@Field { value:"USE_PROXY_305: Represent status code 305 - Use Proxy."}
-@Field { value:"TEMPORARY_REDIRECT_307: Represent status code 307 - Temporary Redirect."}
+@Field { value:"MULTIPLE_CHOICES_300: Represents status code 300 - Multiple Choices."}
+@Field { value:"MOVED_PERMANENTLY_301: Represents status code 301 - Moved Permanently."}
+@Field { value:"FOUND_302: Represents status code 302 - Found."}
+@Field { value:"SEE_OTHER_303: Represents status code 303 - See Other."}
+@Field { value:"NOT_MODIFIED_304: Represents status code 304 - Not Modified."}
+@Field { value:"USE_PROXY_305: Represents status code 305 - Use Proxy."}
+@Field { value:"TEMPORARY_REDIRECT_307: Represents status code 307 - Temporary Redirect."}
 public enum RedirectCode {
     MULTIPLE_CHOICES_300,
     MOVED_PERMANENTLY_301,
@@ -60,6 +60,5 @@ public function <Connection conn> redirect (OutResponse response, RedirectCode c
     locationsStr = locationsStr.subString(0, (lengthof locationsStr) - 1);
 
     response.setHeader(HEADER_KEY_LOCATION, locationsStr);
-    var e = conn.respond(response);
-    return e;
+    return conn.respond(response);
 }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/connection/ConnectionNativeFunctionTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/connection/ConnectionNativeFunctionTest.java
@@ -29,6 +29,9 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
+/**
+ * Test cases for ballerina.net.http.response native functions.
+ */
 public class ConnectionNativeFunctionTest {
 
     private CompileResult serviceResult;

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/connection/ConnectionNativeFunctionTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/connection/ConnectionNativeFunctionTest.java
@@ -35,11 +35,10 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 public class ConnectionNativeFunctionTest {
 
     private CompileResult serviceResult;
-    private String filePath =
-            "test-src/statements/services/nativeimpl/connection/connection-native-function.bal";
 
     @BeforeClass
     public void setup() {
+        String filePath = "test-src/statements/services/nativeimpl/connection/connection-native-function.bal";
         serviceResult = BServiceUtil.setupProgramFile(this, filePath);
     }
 

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/connection/ConnectionNativeFunctionTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/connection/ConnectionNativeFunctionTest.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.test.services.nativeimpl.connection;
+
+import org.ballerinalang.launcher.util.BServiceUtil;
+import org.ballerinalang.launcher.util.CompileResult;
+import org.ballerinalang.net.http.HttpConstants;
+import org.ballerinalang.test.services.testutils.HTTPTestRequest;
+import org.ballerinalang.test.services.testutils.MessageUtils;
+import org.ballerinalang.test.services.testutils.Services;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+
+public class ConnectionNativeFunctionTest {
+
+    private CompileResult serviceResult;
+    private String filePath =
+            "test-src/statements/services/nativeimpl/connection/connection-native-function.bal";
+
+    @BeforeClass
+    public void setup() {
+        serviceResult = BServiceUtil.setupProgramFile(this, filePath);
+    }
+
+    @Test(description = "Test whether the headers and status codes are set correctly.")
+    public void testRedirect() {
+        String path = "/hello/redirect";
+        HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
+        HTTPCarbonMessage response = Services.invokeNew(serviceResult, cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        Assert.assertEquals(response.getProperty(HttpConstants.HTTP_STATUS_CODE), 301);
+        Assert.assertEquals(response.getHeader("Location"), "location1");
+    }
+}

--- a/tests/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/connection/connection-native-function.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/connection/connection-native-function.bal
@@ -10,6 +10,6 @@ service<http> helloServer {
     }
     resource redirect(http:Connection conn, http:InRequest req) {
         http:OutResponse res = {};
-        _ = conn.redirect(res, http:redirectCode.MOVED_PERMANENTLY_301, ["location1"]);
+        _ = conn.redirect(res, http:RedirectCode.MOVED_PERMANENTLY_301, ["location1"]);
     }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/connection/connection-native-function.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/connection/connection-native-function.bal
@@ -1,0 +1,15 @@
+import ballerina.net.http;
+
+@http:configuration {
+    basePath:"/hello"
+}
+service<http> helloServer {
+    @http:resourceConfig {
+        path:"/redirect",
+        methods:["GET"]
+    }
+    resource redirect(http:Connection conn, http:InRequest req) {
+        http:OutResponse res = {};
+        _ = conn.redirect(res, http:redirectCode.MOVED_PERMANENTLY_301, ["location1"]);
+    }
+}


### PR DESCRIPTION
## Purpose
ATM users can manually define redirect responses in any HTTP server connector code but it is better is we can provide more systematic way to do this.
This PR resolves https://github.com/ballerina-lang/ballerina/issues/4246

## Goals
To ease the way of responding with redirection details.

## Approach
Add method to http: Connection struct.
```ballerina
public function <Connection conn> redirect(OutResponse response, RedirectCode code, string[] locations) (HttpConnectorError)
```
## Automation tests
 - Unit tests 
   >Yes
 - Integration tests
   > No
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
```ballerina
import ballerina.net.http;

@http:configuration {
    basePath:"/hello"
}
service<http> helloServer {
    @http:resourceConfig {
        path:"/redirect",
        methods:["GET"]
    }
    resource redirect(http:Connection conn, http:InRequest req) {
        http:OutResponse res = {};
        _ = conn.redirect(res, http:RedirectCode.MOVED_PERMANENTLY_301, ["location1"]);
    }
}
```