### PR TITLE
Pack vscode plugin to a .vsix in maven package phase

### DIFF
--- a/composer/integration-tests/ui-integration-tests/pom.xml
+++ b/composer/integration-tests/ui-integration-tests/pom.xml
@@ -481,6 +481,5 @@
     </build>
     <properties>
         <maven.test.skip>false</maven.test.skip>
-        <npm.executable>npm</npm.executable>
     </properties>
 </project>

--- a/composer/modules/js-tests/pom.xml
+++ b/composer/modules/js-tests/pom.xml
@@ -116,7 +116,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.5.0</version>
+                <version>${maven.exec.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>npm install (initialize)</id>
@@ -167,23 +167,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>platform-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <properties>
-                <!-- Override the executable names for Windows -->
-                <npm.executable>npm.cmd</npm.executable>
-            </properties>
-        </profile>
-    </profiles>
-
-    <properties>
-        <npm.executable>npm</npm.executable>
-    </properties>
 </project>

--- a/composer/modules/web/pom.xml
+++ b/composer/modules/web/pom.xml
@@ -195,18 +195,6 @@
 
     <profiles>
         <profile>
-            <id>platform-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <properties>
-                <!-- Override the executable names for Windows -->
-                <npm.executable>npm.cmd</npm.executable>
-            </properties>
-        </profile>
-        <profile>
             <id>electron-build</id>
             <properties>
                 <!-- for electron the build command should be build-electron -->
@@ -223,7 +211,6 @@
 
     <properties>
         <maven.test.skip>false</maven.test.skip>
-        <npm.executable>npm</npm.executable>
         <npm.build.command>build</npm.build.command>
         <build.helper.maven.plugin.version>1.8</build.helper.maven.plugin.version>
         <replacer.plugin.version>1.5.3</replacer.plugin.version>

--- a/distribution/docker/pom.xml
+++ b/distribution/docker/pom.xml
@@ -233,7 +233,7 @@
             <plugin>
                 <groupId>com.google.code.maven-replacer-plugin</groupId>
                 <artifactId>replacer</artifactId>
-                <version>${replacer.plugin.version}</version>
+                <version>${maven.replacer.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>replace-versions</id>
@@ -264,7 +264,6 @@
         <maven.findbugsplugin.version.exclude>findbugs-exclude.xml</maven.findbugsplugin.version.exclude>
         <surefireArgLine>-Dfile.encoding=UTF-8</surefireArgLine>
         <jackson.version>2.6.1</jackson.version>
-        <replacer.plugin.version>1.5.3</replacer.plugin.version>
         <mavan.findbugsplugin.exclude.file>findbugs-exclude.xml</mavan.findbugsplugin.exclude.file>
     </properties>
 </project>

--- a/misc/testerina/modules/testerina-core/pom.xml
+++ b/misc/testerina/modules/testerina-core/pom.xml
@@ -130,7 +130,7 @@
             <!--<plugin>-->
                 <!--<groupId>org.codehaus.mojo</groupId>-->
                 <!--<artifactId>exec-maven-plugin</artifactId>-->
-                <!--<version>${mvn.exec.plugin.version}</version>-->
+                <!--<version>${maven.exec.plugin.version}</version>-->
                 <!--<executions>-->
                     <!--<execution>-->
                         <!--<phase>process-classes</phase>-->

--- a/pom.xml
+++ b/pom.xml
@@ -853,6 +853,18 @@
                 <module>tool-plugins/vscode</module>
             </modules>
         </profile>
+        <profile>
+            <id>platform-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <properties>
+                <!-- Override the executable names for Windows -->
+                <npm.executable>npm.cmd</npm.executable>
+            </properties>
+        </profile>
     </profiles>
 
     <build>
@@ -886,7 +898,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>${mvn.exec.plugin.version}</version>
+                    <version>${maven.exec.plugin.version}</version>
                 </plugin>
 
                 <plugin>
@@ -1147,6 +1159,7 @@
 
     <properties>
         <ballerina.version>0.961.1-SNAPSHOT</ballerina.version>
+        <npm.executable>npm</npm.executable>
         <ballerina.package.export.version>0.8.0</ballerina.package.export.version>
 
         <commons-net.version>3.6</commons-net.version>
@@ -1157,7 +1170,6 @@
         <ballerina.package.repository.provider.class>BallerinaBuiltinPackageRepository
         </ballerina.package.repository.provider.class>
         <mvn.processor.plugin.version>2.2.4</mvn.processor.plugin.version>
-        <mvn.exec.plugin.version>1.6.0</mvn.exec.plugin.version>
         <ant.contrib.plugin.version>1.0b3</ant.contrib.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -1257,6 +1269,9 @@
         <maven.site.plugin.version>3.5</maven.site.plugin.version>
         <maven.source.plugin.version>3.0.0</maven.source.plugin.version>
         <maven.surefire.plugin.version>2.19.1</maven.surefire.plugin.version>
+        <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
+        <maven.replacer.plugin.version>1.5.3</maven.replacer.plugin.version>
+
         <apache.rat.plugin.version>0.11</apache.rat.plugin.version>
         <clirr.maven.plugin.version>2.7</clirr.maven.plugin.version>
         <apache.source.release.assembly.descriptor.version>1.0.5</apache.source.release.assembly.descriptor.version>

--- a/tool-plugins/vscode/.vscodeignore
+++ b/tool-plugins/vscode/.vscodeignore
@@ -1,3 +1,4 @@
 pom.xml
 .idea/
 *.iml
+target

--- a/tool-plugins/vscode/package-lock.json
+++ b/tool-plugins/vscode/package-lock.json
@@ -1,9 +1,15 @@
 {
     "name": "Ballerina",
-    "version": "0.95.8",
+    "version": "0.961.1-SNAPSHOT",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@types/node": {
+            "version": "9.4.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.5.tgz",
+            "integrity": "sha512-DvC7bzO5797bkApgukxouHmkOdYN2D0yL5olw0RncDpXUa6n39qTVsUi/5g2QJjPgl8qn4zh+4h0sofNoWGLRg==",
+            "dev": true
+        },
         "ajv": {
             "version": "5.5.2",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -53,6 +59,15 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
             "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+        },
+        "argparse": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+            "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "1.0.3"
+            }
         },
         "arr-diff": {
             "version": "1.1.0",
@@ -163,6 +178,12 @@
                 "inherits": "2.0.3"
             }
         },
+        "boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+            "dev": true
+        },
         "boom": {
             "version": "2.10.1",
             "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
@@ -215,6 +236,20 @@
                 "has-ansi": "2.0.0",
                 "strip-ansi": "3.0.1",
                 "supports-color": "2.0.0"
+            }
+        },
+        "cheerio": {
+            "version": "1.0.0-rc.2",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
+            "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+            "dev": true,
+            "requires": {
+                "css-select": "1.2.0",
+                "dom-serializer": "0.1.0",
+                "entities": "1.1.1",
+                "htmlparser2": "3.9.2",
+                "lodash": "4.17.5",
+                "parse5": "3.0.3"
             }
         },
         "clone": {
@@ -288,6 +323,24 @@
                 "boom": "2.10.1"
             }
         },
+        "css-select": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+            "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+            "dev": true,
+            "requires": {
+                "boolbase": "1.0.0",
+                "css-what": "2.1.0",
+                "domutils": "1.5.1",
+                "nth-check": "1.0.1"
+            }
+        },
+        "css-what": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
+            "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
+            "dev": true
+        },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -329,10 +382,59 @@
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
+        "denodeify": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
+            "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
+            "dev": true
+        },
         "diff": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
             "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+        },
+        "dom-serializer": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+            "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+            "dev": true,
+            "requires": {
+                "domelementtype": "1.1.3",
+                "entities": "1.1.1"
+            },
+            "dependencies": {
+                "domelementtype": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                    "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+                    "dev": true
+                }
+            }
+        },
+        "domelementtype": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+            "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+            "dev": true
+        },
+        "domhandler": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
+            "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+            "dev": true,
+            "requires": {
+                "domelementtype": "1.3.0"
+            }
+        },
+        "domutils": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+            "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+            "dev": true,
+            "requires": {
+                "dom-serializer": "0.1.0",
+                "domelementtype": "1.3.0"
+            }
         },
         "duplexer": {
             "version": "0.1.1",
@@ -397,6 +499,12 @@
             "requires": {
                 "once": "1.4.0"
             }
+        },
+        "entities": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+            "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+            "dev": true
         },
         "escape-string-regexp": {
             "version": "1.0.5",
@@ -1077,6 +1185,20 @@
             "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
             "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
         },
+        "htmlparser2": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+            "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+            "dev": true,
+            "requires": {
+                "domelementtype": "1.3.0",
+                "domhandler": "2.4.1",
+                "domutils": "1.5.1",
+                "entities": "1.1.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3"
+            }
+        },
         "http-signature": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
@@ -1299,6 +1421,21 @@
                 "readable-stream": "2.3.3"
             }
         },
+        "linkify-it": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
+            "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
+            "dev": true,
+            "requires": {
+                "uc.micro": "1.0.5"
+            }
+        },
+        "lodash": {
+            "version": "4.17.5",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+            "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+            "dev": true
+        },
         "lodash._basecopy": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
@@ -1412,6 +1549,25 @@
             "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
             "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
         },
+        "markdown-it": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.0.tgz",
+            "integrity": "sha512-tNuOCCfunY5v5uhcO2AUMArvKAyKMygX8tfup/JrgnsDqcCATQsAExBq7o5Ml9iMmO82bk6jYNLj6khcrl0JGA==",
+            "dev": true,
+            "requires": {
+                "argparse": "1.0.9",
+                "entities": "1.1.1",
+                "linkify-it": "2.0.3",
+                "mdurl": "1.0.1",
+                "uc.micro": "1.0.5"
+            }
+        },
+        "mdurl": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+            "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+            "dev": true
+        },
         "merge-stream": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
@@ -1470,6 +1626,12 @@
                     }
                 }
             }
+        },
+        "mime": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+            "dev": true
         },
         "mime-db": {
             "version": "1.30.0",
@@ -1561,6 +1723,12 @@
                 "duplexer2": "0.0.2"
             }
         },
+        "mute-stream": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+            "dev": true
+        },
         "node.extend": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
@@ -1575,6 +1743,15 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "requires": {
                 "remove-trailing-separator": "1.1.0"
+            }
+        },
+        "nth-check": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
+            "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+            "dev": true,
+            "requires": {
+                "boolbase": "1.0.0"
             }
         },
         "oauth-sign": {
@@ -1618,6 +1795,28 @@
                 "readable-stream": "2.3.3"
             }
         },
+        "os-homedir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "dev": true
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
+        },
+        "osenv": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+            "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+            "dev": true,
+            "requires": {
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
+            }
+        },
         "parse-glob": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -1642,6 +1841,24 @@
                         "is-extglob": "1.0.0"
                     }
                 }
+            }
+        },
+        "parse-semver": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/parse-semver/-/parse-semver-1.1.1.tgz",
+            "integrity": "sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg=",
+            "dev": true,
+            "requires": {
+                "semver": "5.5.0"
+            }
+        },
+        "parse5": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+            "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+            "dev": true,
+            "requires": {
+                "@types/node": "9.4.5"
             }
         },
         "path-dirname": {
@@ -1712,6 +1929,12 @@
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
+        "q": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+            "dev": true
+        },
         "qs": {
             "version": "6.3.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
@@ -1765,6 +1988,15 @@
                         "is-buffer": "1.1.6"
                     }
                 }
+            }
+        },
+        "read": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+            "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+            "dev": true,
+            "requires": {
+                "mute-stream": "0.0.7"
             }
         },
         "readable-stream": {
@@ -2004,6 +2236,12 @@
                 "through": "2.3.8"
             }
         },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
         "sshpk": {
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
@@ -2138,6 +2376,15 @@
             "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
             "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
         },
+        "tmp": {
+            "version": "0.0.29",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
+            "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+            "dev": true,
+            "requires": {
+                "os-tmpdir": "1.0.2"
+            }
+        },
         "to-absolute-glob": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
@@ -2164,6 +2411,12 @@
                 "punycode": "1.4.1"
             }
         },
+        "tunnel": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+            "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
+            "dev": true
+        },
         "tunnel-agent": {
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
@@ -2175,10 +2428,32 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
             "optional": true
         },
+        "typed-rest-client": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.9.0.tgz",
+            "integrity": "sha1-92jMDcP06VDwbgSCXDaz54NKofI=",
+            "dev": true,
+            "requires": {
+                "tunnel": "0.0.4",
+                "underscore": "1.8.3"
+            }
+        },
+        "uc.micro": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.5.tgz",
+            "integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg==",
+            "dev": true
+        },
         "ultron": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
             "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+        },
+        "underscore": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+            "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+            "dev": true
         },
         "unique-stream": {
             "version": "2.2.1",
@@ -2188,6 +2463,12 @@
                 "json-stable-stringify": "1.0.1",
                 "through2-filter": "2.0.0"
             }
+        },
+        "url-join": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
+            "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
+            "dev": true
         },
         "url-parse": {
             "version": "1.2.0",
@@ -2294,6 +2575,31 @@
                 "vinyl": "0.4.6"
             }
         },
+        "vsce": {
+            "version": "1.36.2",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.36.2.tgz",
+            "integrity": "sha512-LiQjHdoaXOHKdk/PRN5OWWeEm/4w7tnFLf8EM+pzvlz/8uk7uJiqtMjVYAYawnU7c8KbMSz9nE9M6nCTV4ZSQA==",
+            "dev": true,
+            "requires": {
+                "cheerio": "1.0.0-rc.2",
+                "commander": "2.13.0",
+                "denodeify": "1.2.1",
+                "glob": "7.1.2",
+                "lodash": "4.17.5",
+                "markdown-it": "8.4.0",
+                "mime": "1.6.0",
+                "minimatch": "3.0.4",
+                "osenv": "0.1.4",
+                "parse-semver": "1.1.1",
+                "read": "1.0.7",
+                "semver": "5.5.0",
+                "tmp": "0.0.29",
+                "url-join": "1.1.0",
+                "vso-node-api": "6.1.2-preview",
+                "yauzl": "2.9.1",
+                "yazl": "2.4.3"
+            }
+        },
         "vscode": {
             "version": "1.1.10",
             "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.10.tgz",
@@ -2354,6 +2660,18 @@
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz",
             "integrity": "sha1-5I15li8LjgLelV4/UkkI4rGcA3Q="
+        },
+        "vso-node-api": {
+            "version": "6.1.2-preview",
+            "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.1.2-preview.tgz",
+            "integrity": "sha1-qrNUbfJFHs2JTgcbuZtd8Zxfp48=",
+            "dev": true,
+            "requires": {
+                "q": "1.5.1",
+                "tunnel": "0.0.4",
+                "typed-rest-client": "0.9.0",
+                "underscore": "1.8.3"
+            }
         },
         "wrappy": {
             "version": "1.0.2",

--- a/tool-plugins/vscode/package.json
+++ b/tool-plugins/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "Ballerina",
     "displayName": "Ballerina",
     "description": " Ballerina is a flexible, powerful, beautiful programming language designed for integration",
-    "version": "0.96.0",
+    "version": "0.961.1-SNAPSHOT",
     "publisher": "WSO2",
     "repository": "https://github.com/ballerinalang/plugin-vscode",
     "icon": "images/ballerina.png",
@@ -121,7 +121,9 @@
     "main": "./extension.js",
     "scripts": {
         "postinstall": "node ./node_modules/vscode/bin/install",
-        "test": "node ./node_modules/vscode/bin/test"
+        "test": "node ./node_modules/vscode/bin/test",
+        "clean": "rimraf server-build target",
+        "package": "vsce package"
     },
     "dependencies": {
         "openport": "0.0.4",
@@ -129,5 +131,8 @@
         "vscode-debugadapter": "^1.25.0",
         "vscode-languageclient": "^3.4.2",
         "ws": "^4.0.0"
+    },
+    "devDependencies": {
+        "vsce": "^1.36.2"
     }
 }

--- a/tool-plugins/vscode/pom.xml
+++ b/tool-plugins/vscode/pom.xml
@@ -58,8 +58,8 @@
         <dependencies>
             <dependency>
                 <groupId>org.ballerinalang</groupId>
-                <artifactId>${langserver.launcher.id}</artifactId>
-                <version>${langserver.launcher.version}</version>
+                <artifactId>language-server-stdio-launcher</artifactId>
+                <version>${project.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -68,7 +68,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.5.0</version>
+                <version>${maven.exec.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>npm-install</id>
@@ -105,7 +105,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
+                <version>${maven.antrun.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>clean-target-server-build-dirs</id>
@@ -174,7 +174,7 @@
             <plugin>
                 <groupId>com.google.code.maven-replacer-plugin</groupId>
                 <artifactId>replacer</artifactId>
-                <version>1.5.3</version>
+                <version>${maven.replacer.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>replace-version</id>
@@ -198,24 +198,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>platform-windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <properties>
-                <!-- Override the executable names for Windows -->
-                <npm.executable>npm.cmd</npm.executable>
-            </properties>
-        </profile>
-    </profiles>
-
-    <properties>
-        <npm.executable>npm</npm.executable>
-        <langserver.launcher.id>language-server-stdio-launcher</langserver.launcher.id>
-        <langserver.launcher.version>${project.version}</langserver.launcher.version>
-    </properties>
 </project>

--- a/tool-plugins/vscode/pom.xml
+++ b/tool-plugins/vscode/pom.xml
@@ -30,15 +30,117 @@
 
     <name>Ballerina - Plugin VSCode</name>
 
+    <repositories>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 Releases Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+        <repository>
+            <id>wso2.snapshots</id>
+            <name>WSO2 Snapshot Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.ballerinalang</groupId>
+                <artifactId>${langserver.launcher.id}</artifactId>
+                <version>${langserver.launcher.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.5.0</version>
+                <executions>
+                    <execution>
+                        <id>npm-install</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                        <configuration>
+                            <executable>${npm.executable}</executable>
+                            <arguments>
+                                <argument>install</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>vsix-package</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <executable>${npm.executable}</executable>
+                            <arguments>
+                                <argument>run</argument>
+                                <argument>package</argument>
+                                <argument>--</argument>
+                                <argument>--out</argument>
+                                <argument>target/ballerina-vscode-plugin-${project.version}.vsix</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>clean-target-server-build-dirs</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <delete dir="${project.basedir}/server-build" includeemptydirs="true"/>
+                                <delete dir="${project.basedir}/target" includeemptydirs="true"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>make-target-dir</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${project.basedir}/target" />
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>copy</id>
-                        <phase>package</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>copy</goal>
                         </goals>
@@ -69,6 +171,51 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+                <version>1.5.3</version>
+                <executions>
+                    <execution>
+                        <id>replace-version</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <includes>
+                        <include>${basedir}/package.json</include>
+                    </includes>
+                    <replacements>
+                        <replacement>
+                            <token>"version": "(.*?)",</token>
+                            <value>"version": "${project.version}",</value>
+                        </replacement>
+                    </replacements>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>platform-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <properties>
+                <!-- Override the executable names for Windows -->
+                <npm.executable>npm.cmd</npm.executable>
+            </properties>
+        </profile>
+    </profiles>
+
+    <properties>
+        <npm.executable>npm</npm.executable>
+        <langserver.launcher.id>language-server-stdio-launcher</langserver.launcher.id>
+        <langserver.launcher.version>${project.version}</langserver.launcher.version>
+    </properties>
 </project>


### PR DESCRIPTION
## Purpose
The vscode plugin at the moment is manually packaged and published following a ballerina release. This PR to make sure the vscode plugin is packaged to a `.vsix` file in the package phase of the parent ballerina repo.

## Goals
The built `.vsix` file can be uploaded to some store and then downloaded and published. It can even be distributed so users can download and install.
