### PR TITLE
Add table iteration support

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IterableAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IterableAnalyzer.java
@@ -27,6 +27,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BIterableTypeVisitor;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BJSONType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BMapType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTupleCollectionType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLType;
@@ -278,6 +279,18 @@ public class IterableAnalyzer {
         }
 
         @Override
+        public List<BType> visit(BTableType type, Operation op) {
+            if (op.arity == 0) {
+                logNotEnoughVariablesError(op, 1);
+                return Lists.of(symTable.errType);
+            } else if (op.arity == 1) {
+                return Lists.of(type.getConstraint());
+            }
+            logTooMayVariablesError(op);
+            return Lists.of(symTable.errType);
+        }
+
+        @Override
         public List<BType> visit(BTupleCollectionType type, Operation op) {
             if (type.tupleTypes.size() == op.arity) {
                 return type.tupleTypes;
@@ -324,6 +337,11 @@ public class IterableAnalyzer {
 
         @Override
         public List<BType> visit(BTupleCollectionType t, Operation operation) {
+            return Lists.of(calculateType(operation, t));
+        }
+
+        @Override
+        public List<BType> visit(BTableType t, Operation operation) {
             return Lists.of(calculateType(operation, t));
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -958,6 +958,7 @@ public class TypeChecker extends BLangNodeVisitor {
             case TypeTags.MAP:
             case TypeTags.JSON:
             case TypeTags.XML:
+            case TypeTags.TABLE:
             case TypeTags.TUPLE_COLLECTION:
                 return IterableKind.getFromString(iExpr.name.value) != IterableKind.UNDEFINED;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -720,6 +720,11 @@ public class Types {
         }
 
         @Override
+        public BSymbol visit(BTableType t, BType s) {
+            return symTable.notFoundSymbol;
+        }
+
+        @Override
         public BSymbol visit(BConnectorType t, BType s) {
             if (s == symTable.anyType) {
                 return createCastOperatorSymbol(s, t, false, InstructionCodes.ANY2C);
@@ -812,6 +817,11 @@ public class Types {
         }
 
         @Override
+        public BSymbol visit(BTableType t, BType s) {
+            return symTable.notFoundSymbol;
+        }
+
+        @Override
         public BSymbol visit(BConnectorType t, BType s) {
             return symTable.notFoundSymbol;
         }
@@ -881,6 +891,11 @@ public class Types {
 
         @Override
         public Boolean visit(BStructType t, BType s) {
+            return t == s;
+        }
+
+        @Override
+        public Boolean visit(BTableType t, BType s) {
             return t == s;
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BIterableTypeVisitor.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BIterableTypeVisitor.java
@@ -68,6 +68,11 @@ public abstract class BIterableTypeVisitor implements BTypeVisitor<Operation, Li
     }
 
     @Override
+    public List<BType> visit(BTableType type, Operation op) {
+        return visit((BType) type, op);
+    }
+
+    @Override
     public List<BType> visit(BConnectorType type, Operation op) {
         return visit((BType) type, op);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BTypeVisitor.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BTypeVisitor.java
@@ -39,6 +39,8 @@ public interface BTypeVisitor<T, R> {
 
     R visit(BStructType t, T s);
 
+    R visit(BTableType t, T s);
+
     R visit(BConnectorType t, T s);
 
     R visit(BEnumType t, T s);

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/table/TableIterationTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/table/TableIterationTest.java
@@ -1,0 +1,162 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.ballerinalang.test.types.table;
+
+import org.ballerinalang.launcher.util.BCompileUtil;
+import org.ballerinalang.launcher.util.BRunUtil;
+import org.ballerinalang.launcher.util.CompileResult;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BInteger;
+import org.ballerinalang.model.values.BStringArray;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.test.utils.SQLDBUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+
+/**
+ * Class to test table iteration functionality.
+ */
+public class TableIterationTest {
+
+    CompileResult result;
+    private static final String DB_NAME = "TEST_DATA_TABLE__ITR_DB";
+
+    @BeforeClass
+    public void setup() {
+        result = BCompileUtil.compile("test-src/types/table/table-iteration.bal");
+        SQLDBUtils.deleteFiles(new File(SQLDBUtils.DB_DIRECTORY), DB_NAME);
+        SQLDBUtils.initDatabase(SQLDBUtils.DB_DIRECTORY, DB_NAME, "datafiles/sql/TableIterationTestData.sql");
+    }
+
+    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    public void testForEachInTableWithStmt() {
+        BValue[] returns = BRunUtil.invoke(result, "testForEachInTableWithStmt");
+        Assert.assertEquals(returns.length, 4);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 1);
+        Assert.assertEquals(((BInteger) returns[1]).intValue(), 25);
+        Assert.assertEquals(((BFloat) returns[2]).floatValue(), 400.25);
+        Assert.assertEquals(returns[3].stringValue(), "John");
+    }
+
+    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    public void testForEachInTable() {
+        BValue[] returns = BRunUtil.invoke(result, "testForEachInTable");
+        Assert.assertEquals(returns.length, 4);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 1);
+        Assert.assertEquals(((BInteger) returns[1]).intValue(), 25);
+        Assert.assertEquals(((BFloat) returns[2]).floatValue(), 400.25);
+        Assert.assertEquals(returns[3].stringValue(), "John");
+    }
+
+    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    public void testCountInTable() {
+        BValue[] returns = BRunUtil.invoke(result, "testCountInTable");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 3);
+    }
+
+    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    public void testFilterTable() {
+        BValue[] returns = BRunUtil.invoke(result, "testFilterTable");
+        Assert.assertEquals(returns.length, 3);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 2);
+        Assert.assertEquals(((BInteger) returns[1]).intValue(), 1);
+        Assert.assertEquals(((BInteger) returns[2]).intValue(), 10);
+    }
+
+    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    public void testFilterTableWithCount() {
+        BValue[] returns = BRunUtil.invoke(result, "testFilterTableWithCount");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 2);
+    }
+
+    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    public void testMapTable() {
+        BValue[] returns = BRunUtil.invoke(result, "testMapTable");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BStringArray) returns[0]).get(0), "John");
+        Assert.assertEquals(((BStringArray) returns[0]).get(1), "Anne");
+        Assert.assertEquals(((BStringArray) returns[0]).get(2), "Mary");
+        Assert.assertEquals(((BStringArray) returns[0]).get(3), "Peter");
+    }
+
+    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    public void testMapWithFilterTable() {
+        BValue[] returns = BRunUtil.invoke(result, "testMapWithFilterTable");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BStringArray) returns[0]).get(0), "Peter");
+    }
+
+    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    public void testFilterWithMapTable() {
+        BValue[] returns = BRunUtil.invoke(result, "testFilterWithMapTable");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BStringArray) returns[0]).get(0), "Peter");
+    }
+
+    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    public void testFilterWithMapAndCountTable() {
+        BValue[] returns = BRunUtil.invoke(result, "testFilterWithMapAndCountTable");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 1);
+    }
+
+    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    public void testMinWithTable() {
+        BValue[] returns = BRunUtil.invoke(result, "testMinWithTable");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 100.25);
+    }
+
+    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    public void testMaxWithTable() {
+        BValue[] returns = BRunUtil.invoke(result, "testMaxWithTable");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 600.25);
+    }
+
+    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    public void testSumWithTable() {
+        BValue[] returns = BRunUtil.invoke(result, "testSumWithTable");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 1701.0);
+    }
+
+    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    public void testAverageWithTable() {
+        BValue[] returns = BRunUtil.invoke(result, "testAverageWithTable");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 425.25);
+    }
+
+    @Test(dependsOnGroups = "TableIterTest")
+    public void testCloseConnectionPool() {
+        BValue[] returns = BRunUtil.invoke(result, "testCloseConnectionPool");
+        BInteger retValue = (BInteger) returns[0];
+        Assert.assertEquals(retValue.intValue(), 1);
+    }
+
+    @AfterSuite
+    public void cleanup() {
+        SQLDBUtils.deleteDirectory(new File(SQLDBUtils.DB_DIRECTORY));
+    }
+}

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/table/TableIterationTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/table/TableIterationTest.java
@@ -66,14 +66,14 @@ public class TableIterationTest {
         Assert.assertEquals(returns[3].stringValue(), "John");
     }
 
-    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    @Test(groups = "TableIterTest", description = "Check count operation function on table")
     public void testCountInTable() {
         BValue[] returns = BRunUtil.invoke(result, "testCountInTable");
         Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 3);
     }
 
-    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    @Test(groups = "TableIterTest", description = "Check filter operation")
     public void testFilterTable() {
         BValue[] returns = BRunUtil.invoke(result, "testFilterTable");
         Assert.assertEquals(returns.length, 3);
@@ -82,7 +82,16 @@ public class TableIterationTest {
         Assert.assertEquals(((BInteger) returns[2]).intValue(), 10);
     }
 
-    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    @Test(groups = "TableIterTest", description = "Check filter operation")
+    public void testFilterWithAnnonymousFuncOnTable() {
+        BValue[] returns = BRunUtil.invoke(result, "testFilterWithAnnonymousFuncOnTable");
+        Assert.assertEquals(returns.length, 3);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 2);
+        Assert.assertEquals(((BInteger) returns[1]).intValue(), 1);
+        Assert.assertEquals(((BInteger) returns[2]).intValue(), 10);
+    }
+
+    @Test(groups = "TableIterTest", description = "Check filter and count operation")
     public void testFilterTableWithCount() {
         BValue[] returns = BRunUtil.invoke(result, "testFilterTableWithCount");
         Assert.assertEquals(returns.length, 1);
@@ -99,49 +108,49 @@ public class TableIterationTest {
         Assert.assertEquals(((BStringArray) returns[0]).get(3), "Peter");
     }
 
-    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    @Test(groups = "TableIterTest", description = "Check map with filter operation")
     public void testMapWithFilterTable() {
         BValue[] returns = BRunUtil.invoke(result, "testMapWithFilterTable");
         Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(((BStringArray) returns[0]).get(0), "Peter");
     }
 
-    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    @Test(groups = "TableIterTest", description = "Check filter with map operation")
     public void testFilterWithMapTable() {
         BValue[] returns = BRunUtil.invoke(result, "testFilterWithMapTable");
         Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(((BStringArray) returns[0]).get(0), "Peter");
     }
 
-    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    @Test(groups = "TableIterTest", description = "Check filter count and map operation")
     public void testFilterWithMapAndCountTable() {
         BValue[] returns = BRunUtil.invoke(result, "testFilterWithMapAndCountTable");
         Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 1);
     }
 
-    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    @Test(groups = "TableIterTest", description = "Check min operation")
     public void testMinWithTable() {
         BValue[] returns = BRunUtil.invoke(result, "testMinWithTable");
         Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(((BFloat) returns[0]).floatValue(), 100.25);
     }
 
-    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    @Test(groups = "TableIterTest", description = "Check max operation")
     public void testMaxWithTable() {
         BValue[] returns = BRunUtil.invoke(result, "testMaxWithTable");
         Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(((BFloat) returns[0]).floatValue(), 600.25);
     }
 
-    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    @Test(groups = "TableIterTest", description = "Check sum operation")
     public void testSumWithTable() {
         BValue[] returns = BRunUtil.invoke(result, "testSumWithTable");
         Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(((BFloat) returns[0]).floatValue(), 1701.0);
     }
 
-    @Test(groups = "TableIterTest", description = "Check accessing data using foreach iteration")
+    @Test(groups = "TableIterTest", description = "Check average operation")
     public void testAverageWithTable() {
         BValue[] returns = BRunUtil.invoke(result, "testAverageWithTable");
         Assert.assertEquals(returns.length, 1);

--- a/tests/ballerina-test/src/test/resources/datafiles/sql/TableIterationTestData.sql
+++ b/tests/ballerina-test/src/test/resources/datafiles/sql/TableIterationTestData.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS Person(
+  id       INTEGER,
+  age      INTEGER,
+  salary   FLOAT,
+  name  VARCHAR(50),
+  PRIMARY KEY (id)
+);
+/
+
+insert into Person (id, age, salary, name) values (1, 25, 400.25, 'John');
+/
+insert into Person (id, age, salary, name) values (2, 35, 600.25, 'Anne');
+/
+insert into Person (id, age, salary, name) values (3, 45, 600.25, 'Mary');
+/
+insert into Person (id, age, salary, name) values (10, 22, 100.25, 'Peter');
+/

--- a/tests/ballerina-test/src/test/resources/test-src/types/table/table-iteration.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/table/table-iteration.bal
@@ -1,0 +1,219 @@
+import ballerina.data.sql;
+
+struct Person {
+    int id;
+    int age;
+    float salary;
+    string name;
+}
+
+struct ResultCount {
+    int COUNTVAL;
+}
+
+int idValue = -1;
+int ageValue = -1;
+float salValue = -1;
+string nameValue = "";
+
+function testForEachInTableWithStmt () (int id, int age, float salary, string name) {
+    endpoint<sql:ClientConnector> testDB {
+        create sql:ClientConnector(sql:DB.HSQLDB_FILE, "./target/tempdb/",
+                                   0, "TEST_DATA_TABLE__ITR_DB", "SA", "", {maximumPoolSize:1});
+    }
+    table<Person> dt = testDB.select("SELECT * from Person where id = 1", null, typeof Person);
+    foreach x in dt {
+        id = x.id;
+        age = x.age;
+        salary = x.salary;
+        name = x.name;
+    }
+    testDB.close();
+    return;
+}
+
+
+function testForEachInTable () (int id, int age, float salary, string name) {
+    endpoint<sql:ClientConnector> testDB {
+        create sql:ClientConnector(sql:DB.HSQLDB_FILE, "./target/tempdb/",
+                                   0, "TEST_DATA_TABLE__ITR_DB", "SA", "", {maximumPoolSize:1});
+    }
+    table<Person> dt = testDB.select("SELECT * from Person where id = 1", null, typeof Person);
+    dt.foreach (function (Person p) {
+                    idValue = p.id;
+                    ageValue = p.age;
+                    salValue = p.salary;
+                    nameValue = p.name;
+                }
+       );
+    id = idValue;
+    age = ageValue;
+    salary = salValue;
+    name = nameValue;
+    testDB.close();
+    return;
+}
+
+
+function testCountInTable () (int count) {
+    endpoint<sql:ClientConnector> testDB {
+        create sql:ClientConnector(sql:DB.HSQLDB_FILE, "./target/tempdb/",
+                                   0, "TEST_DATA_TABLE__ITR_DB", "SA", "", {maximumPoolSize:1});
+    }
+    table<Person> dt = testDB.select("SELECT * from Person where id < 10", null, typeof Person);
+    count = dt.count();
+    testDB.close();
+    return;
+}
+
+function testFilterTable () (int count, int id1, int id2) {
+    endpoint<sql:ClientConnector> testDB {
+        create sql:ClientConnector(sql:DB.HSQLDB_FILE, "./target/tempdb/",
+                                   0, "TEST_DATA_TABLE__ITR_DB", "SA", "", {maximumPoolSize:1});
+    }
+    table<Person> dt = testDB.select("SELECT * from Person", null, typeof Person);
+    Person[] personBelow35 = dt.filter(isBellow35);
+    count = lengthof personBelow35;
+    id1 = personBelow35[0].id;
+    id2 = personBelow35[1].id;
+    testDB.close();
+    return;
+}
+
+
+function testFilterTableWithCount () (int count) {
+    endpoint<sql:ClientConnector> testDB {
+        create sql:ClientConnector(sql:DB.HSQLDB_FILE, "./target/tempdb/",
+                                   0, "TEST_DATA_TABLE__ITR_DB", "SA", "", {maximumPoolSize:1});
+    }
+    table<Person> dt = testDB.select("SELECT * from Person", null, typeof Person);
+    count = dt.filter(isBellow35).count();
+    testDB.close();
+    return;
+}
+
+
+function testMapTable () (string[] names) {
+    endpoint<sql:ClientConnector> testDB {
+        create sql:ClientConnector(sql:DB.HSQLDB_FILE, "./target/tempdb/",
+                                   0, "TEST_DATA_TABLE__ITR_DB", "SA", "", {maximumPoolSize:1});
+    }
+    table<Person> dt = testDB.select("SELECT * from Person order by id", null, typeof Person);
+    names = dt.map(getName);
+    testDB.close();
+    return;
+}
+
+
+function testMapWithFilterTable () (string[] names) {
+    endpoint<sql:ClientConnector> testDB {
+        create sql:ClientConnector(sql:DB.HSQLDB_FILE, "./target/tempdb/",
+                                   0, "TEST_DATA_TABLE__ITR_DB", "SA", "", {maximumPoolSize:1});
+    }
+    table<Person> dt = testDB.select("SELECT * from Person order by id", null, typeof Person);
+    names = dt.map(getName).filter(isGeraterThan4String);
+    testDB.close();
+    return;
+}
+
+function testFilterWithMapTable () (string[] names) {
+    endpoint<sql:ClientConnector> testDB {
+        create sql:ClientConnector(sql:DB.HSQLDB_FILE, "./target/tempdb/",
+                                   0, "TEST_DATA_TABLE__ITR_DB", "SA", "", {maximumPoolSize:1});
+    }
+    table<Person> dt = testDB.select("SELECT * from Person order by id", null, typeof Person);
+    names = dt.filter(isGeraterThan4).map(getName);
+    testDB.close();
+    return;
+}
+
+function testFilterWithMapAndCountTable () (int count) {
+    endpoint<sql:ClientConnector> testDB {
+        create sql:ClientConnector(sql:DB.HSQLDB_FILE, "./target/tempdb/",
+                                   0, "TEST_DATA_TABLE__ITR_DB", "SA", "", {maximumPoolSize:1});
+    }
+    table<Person> dt = testDB.select("SELECT * from Person order by id", null, typeof Person);
+    count = dt.filter(isGeraterThan4).map(getName).count();
+    testDB.close();
+    return;
+}
+
+
+function testAverageWithTable () (float avgSal) {
+    endpoint<sql:ClientConnector> testDB {
+        create sql:ClientConnector(sql:DB.HSQLDB_FILE, "./target/tempdb/",
+                                   0, "TEST_DATA_TABLE__ITR_DB", "SA", "", {maximumPoolSize:1});
+    }
+    table<Person> dt = testDB.select("SELECT * from Person order by id", null, typeof Person);
+    avgSal = dt.map(getSalary).average();
+    testDB.close();
+    return;
+}
+
+function testMinWithTable () (float avgSal) {
+    endpoint<sql:ClientConnector> testDB {
+        create sql:ClientConnector(sql:DB.HSQLDB_FILE, "./target/tempdb/",
+                                   0, "TEST_DATA_TABLE__ITR_DB", "SA", "", {maximumPoolSize:1});
+    }
+    table<Person> dt = testDB.select("SELECT * from Person order by id", null, typeof Person);
+    avgSal = dt.map(getSalary).min();
+    testDB.close();
+    return;
+}
+
+function testMaxWithTable () (float avgSal) {
+    endpoint<sql:ClientConnector> testDB {
+        create sql:ClientConnector(sql:DB.HSQLDB_FILE, "./target/tempdb/",
+                                   0, "TEST_DATA_TABLE__ITR_DB", "SA", "", {maximumPoolSize:1});
+    }
+    table<Person> dt = testDB.select("SELECT * from Person order by id", null, typeof Person);
+    avgSal = dt.map(getSalary).max();
+    testDB.close();
+    return;
+}
+
+function testSumWithTable () (float avgSal) {
+    endpoint<sql:ClientConnector> testDB {
+        create sql:ClientConnector(sql:DB.HSQLDB_FILE, "./target/tempdb/",
+                                   0, "TEST_DATA_TABLE__ITR_DB", "SA", "", {maximumPoolSize:1});
+    }
+    table<Person> dt = testDB.select("SELECT * from Person order by id", null, typeof Person);
+    avgSal = dt.map(getSalary).sum();
+    testDB.close();
+    return;
+}
+
+function testCloseConnectionPool () (int count) {
+    endpoint<sql:ClientConnector> testDB {
+        create sql:ClientConnector(sql:DB.HSQLDB_FILE, "./target/tempdb/",
+                                   0, "TEST_DATA_TABLE__ITR_DB", "SA", "", {maximumPoolSize:1});
+    }
+    table dt = testDB.select ("SELECT COUNT(*) as countVal FROM INFORMATION_SCHEMA.SYSTEM_SESSIONS", null,
+                              typeof ResultCount);
+    while (dt.hasNext()) {
+        var rs, _ = (ResultCount) dt.getNext();
+        count = rs.COUNTVAL;
+    }
+    testDB.close();
+    return;
+}
+
+function isBellow35(Person p)(boolean){
+    return p.age < 35;
+}
+
+function getName(Person p)(string s){
+    return p.name;
+}
+
+function getSalary(Person p)(float f){
+    return p.salary;
+}
+
+function isGeraterThan4(Person p) (boolean) {
+    return lengthof p.name > 4;
+}
+
+function isGeraterThan4String(string s) (boolean) {
+    return lengthof s > 4;
+}

--- a/tests/ballerina-test/src/test/resources/test-src/types/table/table-iteration.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/table/table-iteration.bal
@@ -80,6 +80,22 @@ function testFilterTable () (int count, int id1, int id2) {
     return;
 }
 
+function testFilterWithAnnonymousFuncOnTable () (int count, int id1, int id2) {
+    endpoint<sql:ClientConnector> testDB {
+        create sql:ClientConnector(sql:DB.HSQLDB_FILE, "./target/tempdb/",
+                                   0, "TEST_DATA_TABLE__ITR_DB", "SA", "", {maximumPoolSize:1});
+    }
+    table<Person> dt = testDB.select("SELECT * from Person", null, typeof Person);
+    Person[] personBelow35 = dt.filter(function (Person p) (boolean) {
+                                           return p.age < 35;
+                                       });
+    count = lengthof personBelow35;
+    id1 = personBelow35[0].id;
+    id2 = personBelow35[1].id;
+    testDB.close();
+    return;
+}
+
 
 function testFilterTableWithCount () (int count) {
     endpoint<sql:ClientConnector> testDB {


### PR DESCRIPTION
## Purpose
> With this PR table can also considered as an iterable collection. 
Fixes https://github.com/ballerina-lang/ballerina/issues/4670
## Goals
> Following operations can be applied to table.

- foreach
- filter
- map
- max
- min
- average
- sum
- count

## Release note
> Added support for iterable operation for tables.


## Automation tests
 - Unit tests 
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
