### PR TITLE
Fix type name resolving issue for service and connector

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/TreeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/TreeVisitor.java
@@ -172,6 +172,7 @@ public class TreeVisitor extends BLangNodeVisitor {
             cursorPositionResolver = PackageNodeScopeResolver.class;
             topLevelNodes.forEach(topLevelNode -> {
                 cursorPositionResolver = TopLevelNodeScopeResolver.class;
+                this.blockOwnerStack.push(pkgNode);
                 acceptNode((BLangNode) topLevelNode, pkgEnv);
             });
         }
@@ -953,13 +954,15 @@ public class TreeVisitor extends BLangNodeVisitor {
     }
 
     public void setTerminateVisitor(boolean terminateVisitor) {
-        if (terminateVisitor && !blockOwnerStack.isEmpty()) {
+        if (terminateVisitor) {
             boolean currentNodeIsTransaction = !this.isCurrentNodeTransactionStack.isEmpty();
             documentServiceContext.put(CompletionKeys.CURRENT_NODE_TRANSACTION_KEY, currentNodeIsTransaction);
-            documentServiceContext.put(CompletionKeys.BLOCK_OWNER_KEY, blockOwnerStack.peek());
             documentServiceContext.put(CompletionKeys.LOOP_COUNT_KEY, this.loopCount);
             documentServiceContext.put(CompletionKeys.TRANSACTION_COUNT_KEY, this.transactionCount);
             documentServiceContext.put(CompletionKeys.PREVIOUS_NODE_KEY, this.previousNode);
+            if (!blockOwnerStack.isEmpty()) {
+                documentServiceContext.put(CompletionKeys.BLOCK_OWNER_KEY, blockOwnerStack.peek());
+            }
         }
         this.terminateVisitor = terminateVisitor;
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleTypeNameContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleTypeNameContextResolver.java
@@ -22,6 +22,8 @@ import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
 import org.ballerinalang.langserver.completions.util.filters.StatementTemplateFilter;
+import org.ballerinalang.langserver.completions.util.sorters.CompletionItemSorter;
+import org.ballerinalang.langserver.completions.util.sorters.ItemSorters;
 import org.eclipse.lsp4j.CompletionItem;
 
 import java.util.ArrayList;
@@ -39,6 +41,9 @@ public class ParserRuleTypeNameContextResolver extends AbstractItemResolver {
         // Add the statement templates
         completionItems.addAll(statementTemplateFilter.filterItems(completionContext));
         this.populateBasicTypes(completionItems, completionContext.get(CompletionKeys.VISIBLE_SYMBOLS_KEY));
+        CompletionItemSorter itemSorter = ItemSorters
+                .getSorterByClass(completionContext.get(CompletionKeys.SYMBOL_ENV_NODE_KEY).getClass());
+        itemSorter.sortItems(completionContext, completionItems);
         return completionItems;
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/CompletionItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/CompletionItemSorter.java
@@ -107,4 +107,13 @@ public abstract class CompletionItemSorter {
         endpointItem.setDetail(ItemResolverConstants.SNIPPET_TYPE);
         return endpointItem;
     }
+
+    /**
+     * Remove the specific type of completion items from the completion items list.
+     * @param type              Completion Item type
+     * @param completionItems   List of completion Items
+     */
+    void removeCompletionsByType(String type, List<CompletionItem> completionItems) {
+        completionItems.removeIf(completionItem -> completionItem.getDetail().equals(type));
+    }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/ConnectorContextItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/ConnectorContextItemSorter.java
@@ -40,6 +40,12 @@ class ConnectorContextItemSorter extends CompletionItemSorter {
     public void sortItems(TextDocumentServiceContext ctx, List<CompletionItem> completionItems) {
         BLangNode previousNode = ctx.get(CompletionKeys.PREVIOUS_NODE_KEY);
 
+        /*
+        Remove the statement type completion type. When the going through the parser
+        rule contexts such as typeNameContext, we add the statements as well.
+        Sorters are responsible for to the next level of such filtering.
+         */
+        this.removeCompletionsByType(ItemResolverConstants.STATEMENT_TYPE, completionItems);
         if (previousNode == null) {
             this.populateWhenCursorBeforeOrAfterEp(completionItems);
         } else if (previousNode instanceof BLangVariableDef) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/ServiceContextItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/ServiceContextItemSorter.java
@@ -40,6 +40,12 @@ public class ServiceContextItemSorter extends CompletionItemSorter {
     public void sortItems(TextDocumentServiceContext ctx, List<CompletionItem> completionItems) {
         BLangNode previousNode = ctx.get(CompletionKeys.PREVIOUS_NODE_KEY);
         
+        /*
+        Remove the statement type completion type. When the going through the parser
+        rule contexts such as typeNameContext, we add the statements as well.
+        Sorters are responsible for to the next level of such filtering.
+         */
+        this.removeCompletionsByType(ItemResolverConstants.STATEMENT_TYPE, completionItems);
         if (previousNode == null) {
             this.populateWhenCursorBeforeOrAfterEp(completionItems);
         } else if (previousNode instanceof BLangVariableDef) {


### PR DESCRIPTION
## Purpose
> In the Service and the Connector level when resolving the type names it goes through the type name context resolver. This adds the statements and the types. In the Service and Action level, specially removed the types and routed to the sorter from type name resolver.

## Goals
> Route to the relevant sorter for further sorting of the items

## Approach
> 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/1329674/36248833-c4c8bd0a-125e-11e8-9249-cfed97a2b6ff.gif)

