### PR TITLE
Add filtering and sorting support for transformer

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/TreeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/TreeVisitor.java
@@ -329,10 +329,12 @@ public class TreeVisitor extends BLangNodeVisitor {
         if (!ScopeResolverConstants.getResolverByClass(cursorPositionResolver)
                 .isCursorBeforeNode(transformerNode.getPosition(), transformerNode, this,
                         this.documentServiceContext)) {
+            SymbolEnv transformerEnv = SymbolEnv
+                    .createTransformerEnv(transformerNode, transformerNode.symbol.scope, symbolEnv);
             this.blockOwnerStack.push(transformerNode);
             // Cursor position is calculated against the Block statement scope resolver
             cursorPositionResolver = BlockStatementScopeResolver.class;
-            this.acceptNode(transformerNode.body, symbolEnv);
+            this.acceptNode(transformerNode.body, transformerEnv);
             this.blockOwnerStack.pop();
         }
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/CompletionItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/CompletionItemSorter.java
@@ -110,10 +110,10 @@ public abstract class CompletionItemSorter {
 
     /**
      * Remove the specific type of completion items from the completion items list.
-     * @param type              Completion Item type
+     * @param types              Completion Item types
      * @param completionItems   List of completion Items
      */
-    void removeCompletionsByType(String type, List<CompletionItem> completionItems) {
-        completionItems.removeIf(completionItem -> completionItem.getDetail().equals(type));
+    void removeCompletionsByType(List<String> types, List<CompletionItem> completionItems) {
+        completionItems.removeIf(completionItem -> types.contains(completionItem.getDetail()));
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/ConnectorContextItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/ConnectorContextItemSorter.java
@@ -30,6 +30,8 @@ import org.wso2.ballerinalang.compiler.tree.BLangAction;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangVariableDef;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -45,7 +47,8 @@ class ConnectorContextItemSorter extends CompletionItemSorter {
         rule contexts such as typeNameContext, we add the statements as well.
         Sorters are responsible for to the next level of such filtering.
          */
-        this.removeCompletionsByType(ItemResolverConstants.STATEMENT_TYPE, completionItems);
+        this.removeCompletionsByType(new ArrayList<>(Collections.singletonList(ItemResolverConstants.STATEMENT_TYPE)),
+                completionItems);
         if (previousNode == null) {
             this.populateWhenCursorBeforeOrAfterEp(completionItems);
         } else if (previousNode instanceof BLangVariableDef) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/ItemSorters.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/ItemSorters.java
@@ -23,6 +23,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangConnector;
 import org.wso2.ballerinalang.compiler.tree.BLangFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangResource;
 import org.wso2.ballerinalang.compiler.tree.BLangService;
+import org.wso2.ballerinalang.compiler.tree.BLangTransformer;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -48,6 +49,8 @@ public enum ItemSorters {
             new ServiceContextItemSorter()),
     STATEMENT_CONTEXT_ITEM_SORTER(StatementContextItemSorter.class,
             new StatementContextItemSorter()),
+    TRANSFORMER_CONTEXT_ITEM_SORTER(BLangTransformer.class,
+            new TransformerContextItemSorter()),
     VAR_DEF_CONTEXT_ITEM_SORTER(BallerinaParser.VariableDefinitionStatementContext.class,
             new VariableDefContextItemSorter());
     

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/ServiceContextItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/ServiceContextItemSorter.java
@@ -30,6 +30,8 @@ import org.wso2.ballerinalang.compiler.tree.BLangNode;
 import org.wso2.ballerinalang.compiler.tree.BLangResource;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangVariableDef;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -45,7 +47,8 @@ public class ServiceContextItemSorter extends CompletionItemSorter {
         rule contexts such as typeNameContext, we add the statements as well.
         Sorters are responsible for to the next level of such filtering.
          */
-        this.removeCompletionsByType(ItemResolverConstants.STATEMENT_TYPE, completionItems);
+        this.removeCompletionsByType(new ArrayList<>(Collections.singletonList(ItemResolverConstants.STATEMENT_TYPE)),
+                completionItems);
         if (previousNode == null) {
             this.populateWhenCursorBeforeOrAfterEp(completionItems);
         } else if (previousNode instanceof BLangVariableDef) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/TransformerContextItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/TransformerContextItemSorter.java
@@ -1,0 +1,51 @@
+/*
+*  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.ballerinalang.langserver.completions.util.sorters;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.ballerinalang.langserver.DocumentServiceKeys;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
+import org.eclipse.lsp4j.CompletionItem;
+import org.wso2.ballerinalang.compiler.parser.antlr4.BallerinaParser;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Completion item sorter for the transformer scope context.
+ */
+class TransformerContextItemSorter extends CompletionItemSorter {
+    /**
+     * Sort Completion Items based on a particular criteria.
+     *
+     * @param ctx             Completion context
+     * @param completionItems List of initial completion items
+     */
+    @Override
+    public void sortItems(TextDocumentServiceContext ctx, List<CompletionItem> completionItems) {
+        ParserRuleContext parserRuleContext = ctx.get(DocumentServiceKeys.PARSER_RULE_CONTEXT_KEY);
+        if (parserRuleContext == null || parserRuleContext instanceof BallerinaParser.StatementContext) {
+            List<String> typesToRemove = new ArrayList<>(Arrays.asList(ItemResolverConstants.STATEMENT_TYPE,
+                    ItemResolverConstants.FUNCTION_TYPE));
+            this.removeCompletionsByType(typesToRemove, completionItems);
+            this.setPriorities(completionItems);
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
> Add support for completion item filtering and the sorting for transformer scope.

## Goals
> With this, try to do the transform scope sensitive item filtering based on the parser rule context and the scoping criteria

## Approach
> 
![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/1329674/36256503-4e71500c-1279-11e8-9e6d-922295505cec.gif)