### PR TITLE
Add lock statement support and completion trigger characters

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
@@ -51,7 +51,10 @@ public class BallerinaLanguageServer implements LanguageServer, LanguageClientAw
     public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
         final InitializeResult res = new InitializeResult(new ServerCapabilities());
         final SignatureHelpOptions signatureHelpOptions = new SignatureHelpOptions(Arrays.asList("(", ","));
-        res.getCapabilities().setCompletionProvider(new CompletionOptions());
+        final CompletionOptions completionOptions = new CompletionOptions();
+        completionOptions.setTriggerCharacters(Arrays.asList(":", "."));
+        
+        res.getCapabilities().setCompletionProvider(completionOptions);
         res.getCapabilities().setTextDocumentSync(TextDocumentSyncKind.Full);
         res.getCapabilities().setSignatureHelpProvider(signatureHelpOptions);
         res.getCapabilities().setHoverProvider(true);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/TreeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/TreeVisitor.java
@@ -96,6 +96,7 @@ import org.wso2.ballerinalang.compiler.tree.statements.BLangExpressionStmt;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangForeach;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangForkJoin;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangIf;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangLock;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangNext;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangReturn;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangThrow;
@@ -895,6 +896,16 @@ public class TreeVisitor extends BLangNodeVisitor {
     @Override
     public void visit(BLangFieldBasedAccess.BLangEnumeratorAccessExpr enumeratorAccessExpr) {
         // No Implementation
+    }
+
+    @Override
+    public void visit(BLangLock lockNode) {
+        if (!ScopeResolverConstants.getResolverByClass(cursorPositionResolver)
+                .isCursorBeforeNode(lockNode.getPosition(), lockNode, this, this.documentServiceContext)) {
+            this.blockOwnerStack.push(lockNode);
+            this.acceptNode(lockNode.body, symbolEnv);
+            this.blockOwnerStack.pop();
+        }
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ItemResolverConstants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ItemResolverConstants.java
@@ -33,6 +33,7 @@ public class ItemResolverConstants {
     public static final String ABORT = "abort";
     public static final String TRY = "try";
     public static final String WHILE = "while";
+    public static final String LOCK = "lock";
     public static final String BIND = "bind";
     public static final String ENDPOINT = "endpoint";
     public static final String NEXT = "next";

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/Snippet.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/Snippet.java
@@ -33,6 +33,7 @@ public enum Snippet {
     FORK("fork {\n\t${1}\n} join (${2:all}) (map ${3:results}) {\n\t${4}\n}"),
     FUNCTION("function ${1:name} (${2}) {\n\t${3}\n}"),
     IF("if (${1:true}) {\n\t${2}\n}"),
+    LOCK("lock {\n\t${1}\n}"),
     MAIN_FUNCTION("function main (string[] args) {\n\t${1}\n}"),
     NAMESPACE_DECLARATION("xmlns \"${1}\" as ${2:ns};"),
     NEXT("next;"),

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/filters/StatementTemplateFilter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/filters/StatementTemplateFilter.java
@@ -52,6 +52,13 @@ public class StatementTemplateFilter extends AbstractSymbolFilter {
         whileItem.setDetail(ItemResolverConstants.STATEMENT_TYPE);
         completionItems.add(whileItem);
 
+        // Populate Lock Statement template
+        CompletionItem lockItem = new CompletionItem();
+        lockItem.setLabel(ItemResolverConstants.LOCK);
+        lockItem.setInsertText(Snippet.LOCK.toString());
+        lockItem.setDetail(ItemResolverConstants.STATEMENT_TYPE);
+        completionItems.add(lockItem);
+
         // Populate Foreach Statement template
         CompletionItem forEachItem = new CompletionItem();
         forEachItem.setLabel(ItemResolverConstants.FOREACH);


### PR DESCRIPTION
## Purpose
- Add the support for the lock statement completion resolving, Resolves #4571 
- Add the completion trigger characters for completion capabilities

## Goals
> Support the lock statement. Auto-completion operation trigger with the trigger characters ( ":" and ".").

## Approach
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/1329674/36259718-2077c77e-1285-11e8-886d-692bd85d5c39.gif)
![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/1329674/36260256-cbf75ad2-1286-11e8-87f8-04afd61387ae.gif)