### PR TITLE
Add placeholder values for resource path & methods

### DIFF
--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/http-resource-header.jsx
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/decorators/http-resource-header.jsx
@@ -45,7 +45,7 @@ class HttpResourceHeader extends React.Component {
         if (pathAtributeNode && pathAtributeNode.getValue() && pathAtributeNode.getValue()) {
             return pathAtributeNode.getValue().getValue().unescapedValue;
         }
-        return '';
+        return '/' + this.props.model.name.value;
     }
     /**
      * Get Name of the resource
@@ -109,7 +109,29 @@ class HttpResourceHeader extends React.Component {
         const methods = this.getMethods().reverse();
         return (
             <g className='http-resource-header'>
-                {methods.map((method) => {
+                {methods.length === 0 &&
+                    (<g className='http-methods'>
+                        <rect
+                            x={x - 15}
+                            y={y + 5}
+                            width={20}
+                            height={20}
+                            fill='#e2e2e2'
+                            rx='3'
+                            ry='3'
+                        />
+                        <text
+                            style={{ dominantBaseline: 'central' }}
+                            x={x - 8}
+                            y={basePathY}
+                            className='editable-text-label'
+                        >
+                            {'*'}
+                        </text>
+                    </g>)
+            
+                }
+                {methods.length > 0 && methods.map((method) => {
                     return (
                         <g className='http-methods'>
                             <rect


### PR DESCRIPTION

When neither the path or any method is configured
for a resource, display resource name as the path
and '*' as the method by default in diagram view.
