### PR TITLE
Set Accept-Encoding header to outbound request

### DIFF
--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/AbstractHTTPAction.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/AbstractHTTPAction.java
@@ -56,6 +56,9 @@ import static org.ballerinalang.mime.util.Constants.MULTIPART_ENCODER;
 import static org.ballerinalang.mime.util.Constants.MULTIPART_FORM_DATA;
 import static org.ballerinalang.mime.util.Constants.PROTOCOL_PACKAGE_MIME;
 import static org.ballerinalang.runtime.Constants.BALLERINA_VERSION;
+import static org.wso2.transport.http.netty.common.Constants.ACCEPT_ENCODING;
+import static org.wso2.transport.http.netty.common.Constants.ENCODING_DEFLATE;
+import static org.wso2.transport.http.netty.common.Constants.ENCODING_GZIP;
 
 /**
  * {@code AbstractHTTPAction} is the base class for all HTTP Connector Actions.
@@ -92,6 +95,7 @@ public abstract class AbstractHTTPAction extends AbstractNativeAction {
             logger.error("Error occurred while parsing Content-Type header in createOutboundRequestMsg",
                     e.getMessage());
         }
+        requestMsg.setHeader(ACCEPT_ENCODING, ENCODING_DEFLATE + ", " + ENCODING_GZIP);
         return requestMsg;
     }
 

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Execute.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Execute.java
@@ -34,6 +34,10 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
 import java.util.Locale;
 
+import static org.wso2.transport.http.netty.common.Constants.ACCEPT_ENCODING;
+import static org.wso2.transport.http.netty.common.Constants.ENCODING_DEFLATE;
+import static org.wso2.transport.http.netty.common.Constants.ENCODING_GZIP;
+
 /**
  * {@code Execute} action can be used to invoke execute a http call with any httpVerb.
  */
@@ -94,6 +98,7 @@ public class Execute extends AbstractHTTPAction {
             httpVerb = (String) outboundRequestMsg.getProperty(HttpConstants.HTTP_METHOD);
         }
         outboundRequestMsg.setProperty(HttpConstants.HTTP_METHOD, httpVerb.trim().toUpperCase(Locale.getDefault()));
+        outboundRequestMsg.setHeader(ACCEPT_ENCODING, ENCODING_DEFLATE + ", " + ENCODING_GZIP);
         return outboundRequestMsg;
     }
 }


### PR DESCRIPTION
## Purpose
>  Resolve https://github.com/ballerina-lang/ballerina/issues/4706

## Goals
>  Accept-Encoding header for outbound request will no more be set in the transport and hence will be set in ballerina.

## Approach
> Except for the Forward method set Accept-Encoding header for all other http methods.

## Test environment
> JDK 8 | Ubuntu 17.10
 