### PR TITLE
Add node modules in vscode to cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,4 @@ cache:
   directories:
   - $HOME/.m2
   - composer/modules/web/node_modules
+  - tool-plugins/vscode/node_modules


### PR DESCRIPTION
## Purpose
Adds node modules directory to the cache in travis.