### PR TITLE
Ballerina service generation from OAS definition

### DIFF
--- a/distribution/zip/ballerina-tools/pom.xml
+++ b/distribution/zip/ballerina-tools/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>org.ballerinalang</groupId>
-            <artifactId>swagger-ballerina-generator</artifactId>
+            <artifactId>swagger-to-ballerina-generator</artifactId>
         </dependency>
         <dependency>
             <groupId>org.ballerinalang</groupId>

--- a/distribution/zip/ballerina-tools/pom.xml
+++ b/distribution/zip/ballerina-tools/pom.xml
@@ -60,6 +60,10 @@
         </dependency>
         <dependency>
             <groupId>org.ballerinalang</groupId>
+            <artifactId>swagger-to-ballerina-generator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ballerinalang</groupId>
             <artifactId>ballerina-container-support</artifactId>
         </dependency>
         <dependency>

--- a/distribution/zip/ballerina-tools/src/assembly/bin.xml
+++ b/distribution/zip/ballerina-tools/src/assembly/bin.xml
@@ -125,7 +125,7 @@
             <includes>
                 <include>org.ballerinalang:ballerina-packerina:jar</include>
                 <include>org.ballerinalang:testerina-core:jar</include>
-                <include>org.ballerinalang:swagger-ballerina-generator:jar</include>
+                <include>org.ballerinalang:swagger-to-ballerina-generator:jar</include>
                 <include>org.ballerinalang:ballerina-container-support:jar</include>
                 <include>org.ballerinalang:docerina:jar</include>
                 <include>com.fasterxml.jackson.core:jackson-databind</include>

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/pom.xml
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>swagger-ballerina</artifactId>
+        <groupId>org.ballerinalang</groupId>
+        <version>0.961.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>swagger-to-ballerina-generator</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-models</artifactId>
+            <version>2.0.0-rc2</version>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-parser</artifactId>
+            <version>2.0.0-rc1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jknack</groupId>
+            <artifactId>handlebars</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.beust</groupId>
+            <artifactId>jcommander</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ballerinalang</groupId>
+            <artifactId>ballerina-launcher</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.4.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.github.jknack:handlebars</include>
+                                    <include>commons-io:commons-io</include>
+                                    <include>io.swagger:swagger-core</include>
+                                    <include>io.swagger:swagger-models</include>
+                                    <include>io.swagger:swagger-parser</include>
+                                    <include>io.swagger:swagger-parser-core</include>
+                                    <include>io.swagger:swagger-parser-v2</include>
+                                    <include>io.swagger:swagger-parser-v2-converter</include>
+                                    <include>io.swagger:swagger-parser-v3</include>
+                                    <include>javax.validation:validation-api</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/pom.xml
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/pom.xml
@@ -71,6 +71,10 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <dependencyReducedPomLocation>
+                                ${java.io.tmpdir}/dependency-reduced-pom.xml
+                            </dependencyReducedPomLocation>
                             <artifactSet>
                                 <includes>
                                     <include>com.github.jknack:handlebars</include>

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/CodeGenerator.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/CodeGenerator.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballerinalang.swagger;
+
+import com.github.jknack.handlebars.Context;
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.context.FieldValueResolver;
+import com.github.jknack.handlebars.helper.StringHelpers;
+import com.github.jknack.handlebars.io.ClassPathTemplateLoader;
+import com.github.jknack.handlebars.io.FileTemplateLoader;
+import io.swagger.oas.models.OpenAPI;
+import io.swagger.parser.v3.OpenAPIV3Parser;
+import org.ballerinalang.swagger.utils.GeneratorConstants;
+import org.ballerinalang.swagger.utils.GeneratorConstants.GenType;
+import org.ballerinalang.swagger.utils.OpenApiWrapper;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+/**
+ * <p>This class generates Ballerina Services/Connectors for a provided OAS definition.</p>
+ */
+public class CodeGenerator {
+    private String apiPackage;
+
+    /**
+     * Generates ballerina source for provided Open API Definition in <code>definitionPath</code>
+     * <p>Method can be user for generating Ballerina service skeletons, mock services and connectors</p>
+     *
+     * @param type           Output type. Following types are supported
+     *                       <ul>
+     *                       <li>skeleton</li>
+     *                       <li>mock</li>
+     *                       <li>connector</li>
+     *                       </ul>
+     * @param definitionPath Input Open Api Definition file path
+     * @param outPath        Destination file path to save generated source files. If not provided
+     *                       <code>destinationPath</code> will be used as the default destination path
+     * @throws IOException when file operations fail
+     */
+    public void generate(GenType type, String definitionPath, String outPath) throws IOException {
+
+        OpenAPI api = new OpenAPIV3Parser().read(definitionPath);
+        OpenApiWrapper context = new OpenApiWrapper().buildFromOpenAPI(api).apiPackage(apiPackage);
+
+        // Write output to the input definition location if no destination directory is provided
+        if (outPath == null || "".equals(outPath)) {
+            String fileName = api.getInfo().getTitle().replaceAll(" ", "") + ".bal";
+            outPath = definitionPath.substring(0, definitionPath.lastIndexOf(File.separator) + 1);
+            outPath += fileName;
+        }
+        switch (type) {
+        case SKELETON:
+            writeBallerina(context, GeneratorConstants.DEFAULT_SKELETON_DIR, GeneratorConstants.SKELETON_TEMPLATE_NAME,
+                    outPath);
+            break;
+        case CONNECTOR:
+            writeBallerina(context, GeneratorConstants.DEFAULT_CONNECTOR_DIR,
+                    GeneratorConstants.CONNECTOR_TEMPLATE_NAME, outPath);
+            break;
+        case MOCK:
+            writeBallerina(context, GeneratorConstants.DEFAULT_MOCK_DIR, GeneratorConstants.MOCK_TEMPLATE_NAME,
+                    outPath);
+            break;
+        default:
+            return;
+        }
+    }
+
+    /**
+     * Write ballerina definition of a <code>object</code> to a file as described by <code>template.</code>
+     *
+     * @param object       Context object to be used by the template parser
+     * @param templateDir  Directory with all the templates required for generating the source file
+     * @param templateName Name of the parent template to be used
+     * @param outPath      Destination path for writing the resulting source file
+     * @throws IOException when file operations fail
+     */
+    public void writeBallerina(Object object, String templateDir, String templateName, String outPath)
+            throws IOException {
+        PrintWriter writer = null;
+
+        try {
+            Template template = compileTemplate(templateDir, templateName);
+            Context context = Context.newBuilder(object).resolver(FieldValueResolver.INSTANCE).build();
+            writer = new PrintWriter(outPath, "UTF-8");
+            writer.println(template.apply(context));
+        } finally {
+            if (writer != null) {
+                writer.close();
+            }
+        }
+    }
+
+    private Template compileTemplate(String defaultTemplateDir, String templateName) throws IOException {
+        String templatesDirPath = System.getProperty(GeneratorConstants.TEMPLATES_DIR_PATH_KEY, defaultTemplateDir);
+        ClassPathTemplateLoader cpTemplateLoader = new ClassPathTemplateLoader((templatesDirPath));
+        FileTemplateLoader fileTemplateLoader = new FileTemplateLoader(templatesDirPath);
+
+        cpTemplateLoader.setSuffix(GeneratorConstants.TEMPLATES_SUFFIX);
+        fileTemplateLoader.setSuffix(GeneratorConstants.TEMPLATES_SUFFIX);
+        Handlebars handlebars = new Handlebars().with(cpTemplateLoader, fileTemplateLoader);
+        handlebars.registerHelpers(StringHelpers.class);
+        handlebars.registerHelper("equals", (object, options) -> {
+            CharSequence result;
+            Object param0 = options.param(0);
+
+            if (param0 == null) {
+                throw new IllegalArgumentException("found 'null', expected 'string'");
+            }
+            if (object != null && object.toString().equals(param0.toString())) {
+                result = options.fn(object);
+            } else {
+                result = null;
+            }
+
+            return result;
+        });
+
+        return handlebars.compile(templateName);
+    }
+
+    public String getApiPackage() {
+        return apiPackage;
+    }
+
+    public void setApiPackage(String apiPackage) {
+        this.apiPackage = apiPackage;
+    }
+}

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/CodeGenerator.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/CodeGenerator.java
@@ -67,8 +67,8 @@ public class CodeGenerator {
         }
         switch (type) {
             case SKELETON:
-                writeBallerina(context, GeneratorConstants.DEFAULT_SKELETON_DIR, GeneratorConstants.SKELETON_TEMPLATE_NAME,
-                        outPath);
+                writeBallerina(context, GeneratorConstants.DEFAULT_SKELETON_DIR,
+                        GeneratorConstants.SKELETON_TEMPLATE_NAME, outPath);
                 break;
             case CONNECTOR:
                 writeBallerina(context, GeneratorConstants.DEFAULT_CONNECTOR_DIR,

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/CodeGenerator.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/CodeGenerator.java
@@ -112,9 +112,9 @@ public class CodeGenerator {
         String templatesDirPath = System.getProperty(GeneratorConstants.TEMPLATES_DIR_PATH_KEY, defaultTemplateDir);
         ClassPathTemplateLoader cpTemplateLoader = new ClassPathTemplateLoader((templatesDirPath));
         FileTemplateLoader fileTemplateLoader = new FileTemplateLoader(templatesDirPath);
-
         cpTemplateLoader.setSuffix(GeneratorConstants.TEMPLATES_SUFFIX);
         fileTemplateLoader.setSuffix(GeneratorConstants.TEMPLATES_SUFFIX);
+        
         Handlebars handlebars = new Handlebars().with(cpTemplateLoader, fileTemplateLoader);
         handlebars.registerHelpers(StringHelpers.class);
         handlebars.registerHelper("equals", (object, options) -> {
@@ -125,7 +125,7 @@ public class CodeGenerator {
                 throw new IllegalArgumentException("found 'null', expected 'string'");
             }
             if (object != null && object.toString().equals(param0.toString())) {
-                result = options.fn(object);
+                result = options.fn(options.context);
             } else {
                 result = null;
             }

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/CodeGenerator.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/CodeGenerator.java
@@ -60,26 +60,26 @@ public class CodeGenerator {
         OpenApiWrapper context = new OpenApiWrapper().buildFromOpenAPI(api).apiPackage(apiPackage);
 
         // Write output to the input definition location if no destination directory is provided
-        if (outPath == null || "".equals(outPath)) {
+        if (outPath == null || outPath.isEmpty()) {
             String fileName = api.getInfo().getTitle().replaceAll(" ", "") + ".bal";
             outPath = definitionPath.substring(0, definitionPath.lastIndexOf(File.separator) + 1);
             outPath += fileName;
         }
         switch (type) {
-        case SKELETON:
-            writeBallerina(context, GeneratorConstants.DEFAULT_SKELETON_DIR, GeneratorConstants.SKELETON_TEMPLATE_NAME,
-                    outPath);
-            break;
-        case CONNECTOR:
-            writeBallerina(context, GeneratorConstants.DEFAULT_CONNECTOR_DIR,
-                    GeneratorConstants.CONNECTOR_TEMPLATE_NAME, outPath);
-            break;
-        case MOCK:
-            writeBallerina(context, GeneratorConstants.DEFAULT_MOCK_DIR, GeneratorConstants.MOCK_TEMPLATE_NAME,
-                    outPath);
-            break;
-        default:
-            return;
+            case SKELETON:
+                writeBallerina(context, GeneratorConstants.DEFAULT_SKELETON_DIR, GeneratorConstants.SKELETON_TEMPLATE_NAME,
+                        outPath);
+                break;
+            case CONNECTOR:
+                writeBallerina(context, GeneratorConstants.DEFAULT_CONNECTOR_DIR,
+                        GeneratorConstants.CONNECTOR_TEMPLATE_NAME, outPath);
+                break;
+            case MOCK:
+                writeBallerina(context, GeneratorConstants.DEFAULT_MOCK_DIR, GeneratorConstants.MOCK_TEMPLATE_NAME,
+                        outPath);
+                break;
+            default:
+                return;
         }
     }
 

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/cmd/SwaggerCmd.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/cmd/SwaggerCmd.java
@@ -75,21 +75,21 @@ public class SwaggerCmd implements BLauncherCmd {
         StringBuilder msg = new StringBuilder("successfully generated ballerina ");
 
         switch (action) {
-        case connector:
-            generateFromSwagger(connector);
-            msg.append("connector");
-            break;
-        case skeleton:
-            generateFromSwagger(skeleton);
-            msg.append("skeleton");
-            break;
-        case mock:
-            generateFromSwagger(mock);
-            msg.append("mock service");
-            break;
-        default:
-            throw LauncherUtils.createUsageException(
-                    "Only following actions(connector, skeleton, mock) are " + "supported in swagger command");
+            case connector:
+                generateFromSwagger(connector);
+                msg.append("connector");
+                break;
+            case skeleton:
+                generateFromSwagger(skeleton);
+                msg.append("skeleton");
+                break;
+            case mock:
+                generateFromSwagger(mock);
+                msg.append("mock service");
+                break;
+            default:
+                throw LauncherUtils.createUsageException(
+                        "Only following actions(connector, skeleton, mock) are " + "supported in swagger command");
         }
         msg.append(" for swagger file - " + argList.get(1));
         outStream.println(msg.toString());

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/cmd/SwaggerCmd.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/cmd/SwaggerCmd.java
@@ -1,0 +1,147 @@
+/*
+*  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.ballerinalang.swagger.cmd;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.ballerinalang.launcher.BLauncherCmd;
+import org.ballerinalang.launcher.LauncherUtils;
+import org.ballerinalang.swagger.CodeGenerator;
+import org.ballerinalang.swagger.utils.GeneratorConstants.GenType;
+
+import java.io.PrintStream;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Class to implement "swagger" command for ballerina.
+ * Ex: ballerina swagger (connector | skeleton | mock) (swaggerFile) -p(package name) -d(output directory name)
+ */
+@Parameters(commandNames = "swagger", commandDescription = "Generate connector/service using swagger definition")
+public class SwaggerCmd implements BLauncherCmd {
+    private static final String connector = "CONNECTOR";
+    private static final String skeleton = "SKELETON";
+    private static final String mock = "MOCK";
+
+    private static final PrintStream outStream = System.err;
+    private JCommander parentCmdParser;
+
+    @Parameter(arity = 1, description = "<action> <swagger specification>. action : connector|skeleton|mock")
+    private List<String> argList;
+
+    @Parameter(names = { "-d", "--directory" },
+               description = "where to write the generated files (current dir by default)")
+    private String output = "";
+
+    @Parameter(names = { "-p", "--package" }, description = "Package name to be used in the generated source files")
+    private String apiPackage;
+
+    @Parameter(names = { "-h", "--help" }, hidden = true)
+    private boolean helpFlag;
+
+    @Parameter(names = "--debug", hidden = true)
+    private String debugPort;
+
+    @Override
+    public void execute() {
+        if (helpFlag) {
+            String commandUsageInfo = BLauncherCmd.getCommandUsageInfo(parentCmdParser, "swagger");
+            outStream.println(commandUsageInfo);
+            return;
+        }
+
+        if (argList == null || argList.size() < 2) {
+            throw LauncherUtils.createUsageException("Swagger action and a swagger file should be provided. "
+                    + "Ex: ballerina swagger connector swagger_file");
+        }
+        String action = argList.get(0).toUpperCase(Locale.ENGLISH);
+        StringBuilder msg = new StringBuilder("successfully generated ballerina ");
+
+        switch (action) {
+        case connector:
+            generateFromSwagger(connector);
+            msg.append("connector");
+            break;
+        case skeleton:
+            generateFromSwagger(skeleton);
+            msg.append("skeleton");
+            break;
+        case mock:
+            generateFromSwagger(mock);
+            msg.append("mock service");
+            break;
+        default:
+            throw LauncherUtils.createUsageException(
+                    "Only following actions(connector, skeleton, mock) are " + "supported in swagger command");
+        }
+        msg.append(" for swagger file - " + argList.get(1));
+        outStream.println(msg.toString());
+    }
+
+    @Override
+    public String getName() {
+        return "swagger";
+    }
+
+    @Override
+    public void printLongDesc(StringBuilder out) {
+        out.append("Generates ballerina connector, service skeleton and mock service" + System.lineSeparator());
+        out.append("for a given swagger definition" + System.lineSeparator());
+        out.append(System.lineSeparator());
+    }
+
+    @Override
+    public void printUsage(StringBuilder stringBuilder) {
+        stringBuilder.append("  ballerina swagger <connector | skeleton | mock> <swaggerFile> -p<package name> "
+                + "-d<output directory name>\n");
+        stringBuilder.append("\tconnector : generates a ballerina connector\n");
+        stringBuilder.append("\tskeleton  : generates a ballerina service skeleton\n");
+        stringBuilder.append("\tmock      : generates a ballerina mock service with sample responses\n");
+    }
+
+    private void generateFromSwagger(String targetLanguage) {
+        CodeGenerator generator = new CodeGenerator();
+        generator.setApiPackage(apiPackage);
+
+        try {
+            generator.generate(GenType.valueOf(targetLanguage), argList.get(1), output);
+        } catch (Exception e) {
+            String causeMessage = "";
+            Throwable rootCause = ExceptionUtils.getRootCause(e);
+
+            if (rootCause != null) {
+                causeMessage = rootCause.getMessage();
+            }
+            throw LauncherUtils.createUsageException(
+                    "Error occurred when generating " + targetLanguage + " for " + "swagger file at " + argList.get(1)
+                            + ". " + e.getMessage() + ". " + causeMessage);
+        }
+    }
+
+    @Override
+    public void setParentCmdParser(JCommander parentCmdParser) {
+        this.parentCmdParser = parentCmdParser;
+    }
+
+    @Override
+    public void setSelfCmdParser(JCommander selfCmdParser) {
+
+    }
+}

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/utils/GeneratorConstants.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/utils/GeneratorConstants.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballerinalang.swagger.utils;
+
+import java.io.File;
+
+/**
+ * Constants for swagger code generator.
+ */
+public class GeneratorConstants {
+
+    /**
+     * Enum to select the code generation mode.
+     * Ballerina service, mock and connector generation is available
+     */
+    public enum GenType {
+        SKELETON("skeleton"), MOCK("mock"), CONNECTOR("connector");
+
+        private String name;
+
+        GenType(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return this.name;
+        }
+    }
+
+    public static final String SKELETON_TEMPLATE_NAME = "skeleton";
+    public static final String CONNECTOR_TEMPLATE_NAME = "connector";
+    public static final String MOCK_TEMPLATE_NAME = "mock";
+
+    public static final String TEMPLATES_SUFFIX = ".mustache";
+    public static final String TEMPLATES_DIR_PATH_KEY = "templates.dir.path";
+    public static final String DEFAULT_TEMPLATE_DIR = File.separator + "templates";
+    public static final String DEFAULT_SKELETON_DIR = DEFAULT_TEMPLATE_DIR + File.separator + "skeleton";
+    public static final String DEFAULT_MOCK_DIR = DEFAULT_TEMPLATE_DIR + File.separator + "mock";
+    public static final String DEFAULT_CONNECTOR_DIR = DEFAULT_TEMPLATE_DIR + File.separator + "connector";
+
+}

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/utils/OpenApiWrapper.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/java/org/ballerinalang/swagger/utils/OpenApiWrapper.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballerinalang.swagger.utils;
+
+import io.swagger.oas.models.Components;
+import io.swagger.oas.models.ExternalDocumentation;
+import io.swagger.oas.models.OpenAPI;
+import io.swagger.oas.models.PathItem;
+import io.swagger.oas.models.info.Info;
+import io.swagger.oas.models.security.SecurityRequirement;
+import io.swagger.oas.models.servers.Server;
+import io.swagger.oas.models.tags.Tag;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Wrapper for <code>io.swagger.oas.models.OpenAPI</code>
+ * <p>This class can be used to push additional context variables for handlebars</p>
+ */
+public class OpenApiWrapper {
+    private String apiPackage;
+    private String openapi = "3.0.0";
+    private Info info = null;
+    private ExternalDocumentation externalDocs = null;
+    private List<Server> servers = null;
+    private List<SecurityRequirement> security = null;
+    private List<Tag> tags = null;
+    private Set<Map.Entry<String, PathItem>> paths = null;
+    private Components components = null;
+    private Map<String, Object> extensions = null;
+
+    public OpenApiWrapper buildFromOpenAPI(OpenAPI openAPI) {
+        this.openapi = openAPI.getOpenapi();
+        this.info = openAPI.getInfo();
+        this.externalDocs = openAPI.getExternalDocs();
+        this.servers = openAPI.getServers();
+        this.security = openAPI.getSecurity();
+        this.tags = openAPI.getTags();
+        this.components = openAPI.getComponents();
+        this.extensions = openAPI.getExtensions();
+        this.paths = openAPI.getPaths().entrySet();
+
+        return this;
+    }
+
+    public String getApiPackage() {
+        return apiPackage;
+    }
+
+    public OpenApiWrapper apiPackage(String apiPackage) {
+        this.apiPackage = apiPackage;
+        return this;
+    }
+
+    public String getOpenapi() {
+        return openapi;
+    }
+
+    public Info getInfo() {
+        return info;
+    }
+
+    public ExternalDocumentation getExternalDocs() {
+        return externalDocs;
+    }
+
+    public List<Server> getServers() {
+        return servers;
+    }
+
+    public List<SecurityRequirement> getSecurity() {
+        return security;
+    }
+
+    public List<Tag> getTags() {
+        return tags;
+    }
+
+    public Set<Map.Entry<String, PathItem>> getPaths() {
+        return paths;
+    }
+
+    public Components getComponents() {
+        return components;
+    }
+
+    public Map<String, Object> getExtensions() {
+        return extensions;
+    }
+}

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/META-INF/services/org.ballerinalang.launcher.BLauncherCmd
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/META-INF/services/org.ballerinalang.launcher.BLauncherCmd
@@ -1,0 +1,1 @@
+org.ballerinalang.swagger.cmd.SwaggerCmd

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/skeleton/pathParams.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/skeleton/pathParams.mustache
@@ -1,0 +1,1 @@
+{{#equals in "path"}}, string {{name}}{{/equals}}

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/skeleton/skeleton.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/skeleton/skeleton.mustache
@@ -1,7 +1,14 @@
 package {{apiPackage}};
 
 import ballerina.net.http;
-@http:configuration {basePath:"{{#each servers}}{{this.url}}{{/each}}"}
+
+{{#host}}
+@http:configuration {
+    host: "{{host}}",{{#port}}
+    port: {{port}},{{/port}}{{#httpsPort}}
+    httpsPort: {{httpsPort}},{{/httpsPort}}
+    basePath: "{{basePath}}"
+}{{/host}}
 service<http> {{cut info.title " "}} {
 {{#paths}}
 {{#value}}
@@ -10,127 +17,103 @@ service<http> {{cut info.title " "}} {
         methods:["GET"],
         path:"{{key}}"
     }
-    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
-        //stub code - fill as necessary
-        json payload;
-
-        resp.setHeader("Server", "Powered by Ballerina");
-        payload = {success:"true"};
-        resp.setJsonPayload(payload);
-
-        resp.send();
+    resource {{operationId}} (http:Connection conn, http:InRequest inReq{{#parameters}}{{>pathParams}}{{/parameters}}) {
+        //stub de - fill as necessary
+        http:OutResponse resp = {};
+        string payload = "Sample {{operationId}} Response";
+        resp.setStringPayload(payload);
+        _ = conn.respond(resp);
     }
 {{/get}}
 {{#post}}
     @http:resourceConfig {
-        methods:["GET"],
+        methods:["POST"],
         path:"{{key}}"
     }
-    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+    resource {{operationId}} (http:Connection conn, http:InRequest inReq{{#parameters}}{{>pathParams}}{{/parameters}}) {
         //stub code - fill as necessary
-        json payload;
-
-        resp.setHeader("Server", "Powered by Ballerina");
-        payload = {success:"true"};
-        resp.setJsonPayload(payload);
-
-        resp.send();
+        http:OutResponse resp = {};
+        string payload = "Sample {{operationId}} Response";
+        resp.setStringPayload(payload);
+        _ = conn.respond(resp);
     }
 {{/post}}
 {{#put}}
     @http:resourceConfig {
-        methods:["GET"],
+        methods:["PUT"],
         path:"{{key}}"
     }
-    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+    resource {{operationId}} (http:Connection conn, http:InRequest inReq{{#parameters}}{{>pathParams}}{{/parameters}}) {
         //stub code - fill as necessary
-        json payload;
-
-        resp.setHeader("Server", "Powered by Ballerina");
-        payload = {success:"true"};
-        resp.setJsonPayload(payload);
-
-        resp.send();
+        http:OutResponse resp = {};
+        string payload = "Sample {{operationId}} Response";
+        resp.setStringPayload(payload);
+        _ = conn.respond(resp);
     }
 {{/put}}
 {{#delete}}
     @http:resourceConfig {
-        methods:["GET"],
+        methods:["DELETE"],
         path:"{{key}}"
     }
-    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+    resource {{operationId}} (http:Connection conn, http:InRequest inReq{{#parameters}}{{>pathParams}}{{/parameters}}) {
         //stub code - fill as necessary
-        json payload;
-
-        resp.setHeader("Server", "Powered by Ballerina");
-        payload = {success:"true"};
-        resp.setJsonPayload(payload);
-
-        resp.send();
+        http:OutResponse resp = {};
+        string payload = "Sample {{operationId}} Response";
+        resp.setStringPayload(payload);
+        _ = conn.respond(resp);
     }
 {{/delete}}
 {{#options}}
     @http:resourceConfig {
-        methods:["GET"],
+        methods:["OPTIONS"],
         path:"{{key}}"
     }
-    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+    resource {{operationId}} (http:Connection conn, http:InRequest inReq{{#parameters}}{{>pathParams}}{{/parameters}}) {
         //stub code - fill as necessary
-        json payload;
-
-        resp.setHeader("Server", "Powered by Ballerina");
-        payload = {success:"true"};
-        resp.setJsonPayload(payload);
-
-        resp.send();
+        http:OutResponse resp = {};
+        string payload = "Sample {{operationId}} Response";
+        resp.setStringPayload(payload);
+        _ = conn.respond(resp);
     }
 {{/options}}
 {{#head}}
     @http:resourceConfig {
-        methods:["GET"],
+        methods:["HEAD"],
         path:"{{key}}"
     }
-    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+    resource {{operationId}} (http:Connection conn, http:InRequest inReq{{#parameters}}{{>pathParams}}{{/parameters}}) {
         //stub code - fill as necessary
-        json payload;
-
-        resp.setHeader("Server", "Powered by Ballerina");
-        payload = {success:"true"};
-        resp.setJsonPayload(payload);
-
-        resp.send();
+        http:OutResponse resp = {};
+        string payload = "Sample {{operationId}} Response";
+        resp.setStringPayload(payload);
+        _ = conn.respond(resp);
     }
 {{/head}}
 {{#patch}}
     @http:resourceConfig {
-        methods:["GET"],
+        methods:["PATCH"],
         path:"{{key}}"
     }
-    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+    resource {{operationId}} (http:Connection conn, http:InRequest inReq{{#parameters}}{{>pathParams}}{{/parameters}}) {
         //stub code - fill as necessary
-        json payload;
-
-        resp.setHeader("Server", "Powered by Ballerina");
-        payload = {success:"true"};
-        resp.setJsonPayload(payload);
-
-        resp.send();
+        http:OutResponse resp = {};
+        string payload = "Sample {{operationId}} Response";
+        resp.setStringPayload(payload);
+        _ = conn.respond(resp);
     }
 {{/patch}}
 {{#trace}}
     @http:resourceConfig {
-        methods:["GET"],
+        methods:["TRACE"],
         path:"{{key}}"
     }
-    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+    resource {{operationId}} (http:Connection conn, http:InRequest inReq{{#parameters}}{{>pathParams}}{{/parameters}}) {
         //stub code - fill as necessary
-        json payload;
-
-        resp.setHeader("Server", "Powered by Ballerina");
-        payload = {success:"true"};
-        resp.setJsonPayload(payload);
-
-        resp.send();
+        http:OutResponse resp = {};
+        string payload = "Sample {{operationId}} Response";
+        resp.setStringPayload(payload);
+        _ = conn.respond(resp);
     }
 {{/trace}}
 {{/value}}

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/skeleton/skeleton.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/skeleton/skeleton.mustache
@@ -1,0 +1,139 @@
+package {{apiPackage}};
+
+import ballerina.net.http;
+@http:configuration {basePath:"{{#each servers}}{{this.url}}{{/each}}"}
+service<http> {{cut info.title " "}} {
+{{#paths}}
+{{#value}}
+{{#get}}
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"{{key}}"
+    }
+    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+        //stub code - fill as necessary
+        json payload;
+
+        resp.setHeader("Server", "Powered by Ballerina");
+        payload = {success:"true"};
+        resp.setJsonPayload(payload);
+
+        resp.send();
+    }
+{{/get}}
+{{#post}}
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"{{key}}"
+    }
+    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+        //stub code - fill as necessary
+        json payload;
+
+        resp.setHeader("Server", "Powered by Ballerina");
+        payload = {success:"true"};
+        resp.setJsonPayload(payload);
+
+        resp.send();
+    }
+{{/post}}
+{{#put}}
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"{{key}}"
+    }
+    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+        //stub code - fill as necessary
+        json payload;
+
+        resp.setHeader("Server", "Powered by Ballerina");
+        payload = {success:"true"};
+        resp.setJsonPayload(payload);
+
+        resp.send();
+    }
+{{/put}}
+{{#delete}}
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"{{key}}"
+    }
+    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+        //stub code - fill as necessary
+        json payload;
+
+        resp.setHeader("Server", "Powered by Ballerina");
+        payload = {success:"true"};
+        resp.setJsonPayload(payload);
+
+        resp.send();
+    }
+{{/delete}}
+{{#options}}
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"{{key}}"
+    }
+    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+        //stub code - fill as necessary
+        json payload;
+
+        resp.setHeader("Server", "Powered by Ballerina");
+        payload = {success:"true"};
+        resp.setJsonPayload(payload);
+
+        resp.send();
+    }
+{{/options}}
+{{#head}}
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"{{key}}"
+    }
+    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+        //stub code - fill as necessary
+        json payload;
+
+        resp.setHeader("Server", "Powered by Ballerina");
+        payload = {success:"true"};
+        resp.setJsonPayload(payload);
+
+        resp.send();
+    }
+{{/head}}
+{{#patch}}
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"{{key}}"
+    }
+    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+        //stub code - fill as necessary
+        json payload;
+
+        resp.setHeader("Server", "Powered by Ballerina");
+        payload = {success:"true"};
+        resp.setJsonPayload(payload);
+
+        resp.send();
+    }
+{{/patch}}
+{{#trace}}
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"{{key}}"
+    }
+    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+        //stub code - fill as necessary
+        json payload;
+
+        resp.setHeader("Server", "Powered by Ballerina");
+        payload = {success:"true"};
+        resp.setJsonPayload(payload);
+
+        resp.send();
+    }
+{{/trace}}
+{{/value}}
+{{/paths}}
+}
+

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/test/java/CodeGeneratorTest.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/test/java/CodeGeneratorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.ballerinalang.swagger.CodeGenerator;
+import org.ballerinalang.swagger.utils.GeneratorConstants.GenType;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Unit tests for {@link org.ballerinalang.swagger.CodeGenerator}
+ */
+public class CodeGeneratorTest {
+    private String testResourceRoot;
+
+    @BeforeClass()
+    public void setup() {
+        testResourceRoot = CodeGeneratorTest.class.getProtectionDomain().getCodeSource().getLocation().getPath();
+    }
+
+    @Test(description = "Test Ballerina skeleton generation when destination path is provided")
+    public void generateSkeletonWithDestination() {
+        String outPath = testResourceRoot + File.separator + "service.bal";
+        String definitionPath = testResourceRoot + File.separator + "petstore.yaml";
+        CodeGenerator generator = new CodeGenerator();
+        try {
+            generator.generate(GenType.SKELETON, definitionPath, outPath);
+            File genFile = new File(outPath);
+            Assert.assertTrue(genFile.exists());
+        } catch (IOException e) {
+            Assert.fail();
+        }
+    }
+
+    @Test(description = "Test Ballerina skeleton generation when destination path is not provided")
+    public void generateSkeletonWithoutDestination() {
+        String definitionPath = testResourceRoot + File.separator + "petstore.yaml";
+        CodeGenerator generator = new CodeGenerator();
+        try {
+            generator.generate(GenType.SKELETON, definitionPath, null);
+        } catch (IOException e) {
+            Assert.fail();
+        }
+    }
+}

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/test/java/CodeGeneratorTest.java
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/test/java/CodeGeneratorTest.java
@@ -22,6 +22,8 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 /**
  * Unit tests for {@link org.ballerinalang.swagger.CodeGenerator}
@@ -39,12 +41,19 @@ public class CodeGeneratorTest {
         String outPath = testResourceRoot + File.separator + "service.bal";
         String definitionPath = testResourceRoot + File.separator + "petstore.yaml";
         CodeGenerator generator = new CodeGenerator();
+
         try {
             generator.generate(GenType.SKELETON, definitionPath, outPath);
             File genFile = new File(outPath);
-            Assert.assertTrue(genFile.exists());
+
+            if (genFile.exists()) {
+                String result = new String(Files.readAllBytes(Paths.get(genFile.getPath())));
+                Assert.assertTrue(result != null && result.contains("SwaggerPetstore"));
+            } else {
+                Assert.fail("Service was not generated");
+            }
         } catch (IOException e) {
-            Assert.fail();
+            Assert.fail("Error while generating the service");
         }
     }
 
@@ -52,10 +61,11 @@ public class CodeGeneratorTest {
     public void generateSkeletonWithoutDestination() {
         String definitionPath = testResourceRoot + File.separator + "petstore.yaml";
         CodeGenerator generator = new CodeGenerator();
+
         try {
             generator.generate(GenType.SKELETON, definitionPath, null);
         } catch (IOException e) {
-            Assert.fail();
+            Assert.fail("Error while generating the service");
         }
     }
 }

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/test/resources/petstore.yaml
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/test/resources/petstore.yaml
@@ -1,0 +1,109 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore YAML
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: An paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:    
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/test/resources/templates/skeleton/pathParams.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/test/resources/templates/skeleton/pathParams.mustache
@@ -1,0 +1,1 @@
+{{#equals in "path"}}, string {{name}}{{/equals}}

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/test/resources/templates/skeleton/skeleton.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/test/resources/templates/skeleton/skeleton.mustache
@@ -1,0 +1,139 @@
+package {{apiPackage}};
+
+import ballerina.net.http;
+@http:configuration {basePath:"{{#each servers}}{{this.url}}{{/each}}"}
+service<http> {{cut info.title " "}} {
+{{#paths}}
+{{#value}}
+{{#get}}
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"{{key}}"
+    }
+    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+        //stub code - fill as necessary
+        json payload;
+
+        resp.setHeader("Server", "Powered by Ballerina");
+        payload = {success:"true"};
+        resp.setJsonPayload(payload);
+
+        resp.send();
+    }
+{{/get}}
+{{#post}}
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"{{key}}"
+    }
+    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+        //stub code - fill as necessary
+        json payload;
+
+        resp.setHeader("Server", "Powered by Ballerina");
+        payload = {success:"true"};
+        resp.setJsonPayload(payload);
+
+        resp.send();
+    }
+{{/post}}
+{{#put}}
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"{{key}}"
+    }
+    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+        //stub code - fill as necessary
+        json payload;
+
+        resp.setHeader("Server", "Powered by Ballerina");
+        payload = {success:"true"};
+        resp.setJsonPayload(payload);
+
+        resp.send();
+    }
+{{/put}}
+{{#delete}}
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"{{key}}"
+    }
+    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+        //stub code - fill as necessary
+        json payload;
+
+        resp.setHeader("Server", "Powered by Ballerina");
+        payload = {success:"true"};
+        resp.setJsonPayload(payload);
+
+        resp.send();
+    }
+{{/delete}}
+{{#options}}
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"{{key}}"
+    }
+    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+        //stub code - fill as necessary
+        json payload;
+
+        resp.setHeader("Server", "Powered by Ballerina");
+        payload = {success:"true"};
+        resp.setJsonPayload(payload);
+
+        resp.send();
+    }
+{{/options}}
+{{#head}}
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"{{key}}"
+    }
+    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+        //stub code - fill as necessary
+        json payload;
+
+        resp.setHeader("Server", "Powered by Ballerina");
+        payload = {success:"true"};
+        resp.setJsonPayload(payload);
+
+        resp.send();
+    }
+{{/head}}
+{{#patch}}
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"{{key}}"
+    }
+    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+        //stub code - fill as necessary
+        json payload;
+
+        resp.setHeader("Server", "Powered by Ballerina");
+        payload = {success:"true"};
+        resp.setJsonPayload(payload);
+
+        resp.send();
+    }
+{{/patch}}
+{{#trace}}
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"{{key}}"
+    }
+    resource {{operationId}} (http:Request req, http:Response resp{{#parameters}}{{>pathParams}}{{/parameters}}) {
+        //stub code - fill as necessary
+        json payload;
+
+        resp.setHeader("Server", "Powered by Ballerina");
+        payload = {success:"true"};
+        resp.setJsonPayload(payload);
+
+        resp.send();
+    }
+{{/trace}}
+{{/value}}
+{{/paths}}
+}
+

--- a/misc/swagger-ballerina/pom.xml
+++ b/misc/swagger-ballerina/pom.xml
@@ -37,8 +37,8 @@
     </properties>
 
     <modules>
-        <module>modules/swagger-ballerina-generator</module>
         <module>modules/ballerina-to-swagger-generator</module>
+        <module>modules/swagger-to-ballerina-generator</module>
     </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,11 @@
             </dependency>
             <dependency>
                 <groupId>org.ballerinalang</groupId>
+                <artifactId>swagger-to-ballerina-generator</artifactId>
+                <version>${ballerina.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ballerinalang</groupId>
                 <artifactId>ballerina-container-support</artifactId>
                 <version>${ballerina.version}</version>
             </dependency>


### PR DESCRIPTION
## Purpose
> Users should be allowed to generate ballerina code from swagger swagger definition. This PR implements the required core features to support code generation from OAS2 and OAS3 definitions

## Goals
> 
* Utilities for code gen implementation
* OAS => Ballerina service generation

## Automation tests
 - Unit tests 
> Yes

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> `ballerina swagger skeleton /home/foo/petstore.yaml` will generate a ballerina service skeleton in `/home/foo/`
