### PR TITLE
Add test grouping and data-driven test execution support

### DIFF
--- a/misc/testerina/README.md
+++ b/misc/testerina/README.md
@@ -46,6 +46,51 @@ If at least one assert fails, whole test function will be marked as failed.
 Detailed information is shown in the test result summary.  
 > One package may contain more than one ```*._test.bal``` file.
 
+#### Grouping Tests
+
+You can group the test functions and control the execution of tests by grouping them.
+
+e.g:
+```ballerina
+@test:config{
+    groups:["g2","g3"]
+}
+function testFunc () {
+test:assertFalse(false, "errorMessage");
+}
+```
+
+Inorder to execute tests belonging to a selected group. Run the below command.
+````
+ballerina test your_package --groups g2,g3
+````
+Note: You can also use `--disable-groups` flag to exclude groups from executing. Also un-grouped tests will be added to a group names default.
+
+#### Running Data-driven tests
+
+Data sets allows users to execute the same test case with different values sets. Testerina supports data driven tests natively.
+
+e.g:
+```ballerina
+@test:config{
+    valueSets:["val1,val2","val3, val4"]
+}
+function testFunc10 (string input, string output) {
+println("Input: " +input + " Output: " +output);
+test:assertFalse(false, "errorMessage");
+}
+```
+
+Executing the above will produce the following output.
+```
+Input: val3 Output: val4
+Input: val1 Output: val2
+
+============== TEST RESULT SUMMARY ==============
+result: 
+tests run: 2, passed: 2, failed: 0, skipped: 0
+````
+
 #### Tutorial
 
 1 Download [1] ```ballerina-tools-<release-version>.zip``` distribution and unzip.  

--- a/misc/testerina/modules/testerina-core/pom.xml
+++ b/misc/testerina/modules/testerina-core/pom.xml
@@ -176,6 +176,9 @@
                         <additionalClasspathElement>${basedir}/target/classes/org/wso2/ballerina/nativeimpl
                             /repository/BallerinaBuiltinPackageRepository.class</additionalClasspathElement>
                     </additionalClasspathElements>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
                 </configuration>
             </plugin>
         </plugins>

--- a/misc/testerina/modules/testerina-core/src/main/ballerina/ballerina/test/annotations.bal
+++ b/misc/testerina/modules/testerina-core/src/main/ballerina/ballerina/test/annotations.bal
@@ -1,0 +1,11 @@
+package ballerina.test;
+
+@Description { value:"Configuration set for test functions."}
+@Field {value:"disabled: Flag to disable test functions"}
+@Field {value:"groups: List of groups, the test function is included"}
+@Field {value:"valueSet: List of valueSets to be parsed for data-driven tests"}
+public annotation config attach function {
+    boolean disabled;
+    string[] groups;
+    string[] valueSets;
+}

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/AnnotationProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/AnnotationProcessor.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ * <p>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.testerina.core;
+
+import org.ballerinalang.testerina.core.entity.TesterinaAnnotation;
+import org.ballerinalang.util.codegen.AnnAttachmentInfo;
+import org.ballerinalang.util.codegen.FunctionInfo;
+import org.ballerinalang.util.codegen.attributes.AnnotationAttributeInfo;
+import org.ballerinalang.util.codegen.attributes.AttributeInfo;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * Process annotations added to a test function.
+ *
+ * @since 0.963.0
+ */
+public class AnnotationProcessor {
+
+    private static final String CONFIG_ANNOTATION_NAME = "config";
+    private static final String DEFAULT_TEST_GROUP_NAME = "default";
+
+    /**
+     * Takes @{@link FunctionInfo} as a input and process annotations attached to the function.
+     *
+     * @param functionInfo ballerina FunctionInfo object
+     * @return @{@link TesterinaAnnotation} object containing annotation information
+     */
+    public static TesterinaAnnotation processAnnotations(FunctionInfo functionInfo) {
+        TesterinaAnnotation testerinaAnnotation = new TesterinaAnnotation();
+
+        AnnotationAttributeInfo attributeInfo = (AnnotationAttributeInfo) functionInfo
+                .getAttributeInfo(AttributeInfo.Kind.ANNOTATIONS_ATTRIBUTE);
+
+        // If no annotations present set default group
+        if (attributeInfo.getAttachmentInfoEntries().length == 0) {
+            testerinaAnnotation.setGroups(Arrays.asList(DEFAULT_TEST_GROUP_NAME));
+        } else {
+            for (AnnAttachmentInfo attachmentInfo : attributeInfo.getAttachmentInfoEntries()) {
+                if (!attachmentInfo.getName().equals(CONFIG_ANNOTATION_NAME)) {
+                    continue;
+                }
+                // Check if disabled property is present in the annotation
+                if (attachmentInfo
+                            .getAttributeValue(TesterinaAnnotation.ConfigAnnotationProps.TEST_DISABLED.getName())
+                    != null) {
+                    testerinaAnnotation.setDisabled(attachmentInfo
+                            .getAttributeValue(TesterinaAnnotation.ConfigAnnotationProps.TEST_DISABLED.getName())
+                            .getBooleanValue());
+                }
+                // check if groups are present in the annotation
+                if (attachmentInfo.getAttributeValue(TesterinaAnnotation.ConfigAnnotationProps.TEST_GROUP.getName())
+                    != null) {
+                    testerinaAnnotation.setGroups(Arrays.stream(attachmentInfo
+                            .getAttributeValue(TesterinaAnnotation.ConfigAnnotationProps.TEST_GROUP.getName())
+                            .getAttributeValueArray()).map(f -> f.getStringValue()).collect(Collectors.toList()));
+                } else {
+                    // If groups are not present add it to a default group
+                    testerinaAnnotation.setGroups(Arrays.asList(DEFAULT_TEST_GROUP_NAME));
+                }
+                if (attachmentInfo
+                            .getAttributeValue(TesterinaAnnotation.ConfigAnnotationProps.TEST_VALUE_SET.getName())
+                    != null) {
+                    testerinaAnnotation.setValueSet(Arrays.stream(attachmentInfo
+                            .getAttributeValue(TesterinaAnnotation.ConfigAnnotationProps.TEST_VALUE_SET.getName())
+                            .getAttributeValueArray()).map(f -> f.getStringValue().split(","))
+                            .collect(Collectors.toList()));
+                }
+                break;
+            }
+        }
+        return testerinaAnnotation;
+    }
+}

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/BTestRunner.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/BTestRunner.java
@@ -15,10 +15,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.ballerinalang.testerina.core;
 
 import org.ballerinalang.compiler.CompilerPhase;
 import org.ballerinalang.launcher.LauncherUtils;
+import org.ballerinalang.model.values.BString;
 import org.ballerinalang.testerina.core.entity.TesterinaContext;
 import org.ballerinalang.testerina.core.entity.TesterinaFunction;
 import org.ballerinalang.testerina.core.entity.TesterinaReport;
@@ -34,6 +36,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.ballerinalang.compiler.CompilerOptionName.COMPILER_PHASE;
 import static org.ballerinalang.compiler.CompilerOptionName.PRESERVE_WHITESPACE;
@@ -46,20 +49,34 @@ public class BTestRunner {
 
     private static Path programDirPath = Paths.get(System.getProperty("user.dir"));
     private static PrintStream outStream = System.err;
-    private static TesterinaReport tReport = new TesterinaReport();
+    private TesterinaReport tReport = new TesterinaReport();
 
-    public static void runTest(Path[] sourceFilePaths) {
+    /**
+     * Executes a given set of ballerina program files.
+     *
+     * @param sourceFilePaths List of @{@link Path} of ballerina files
+     * @param groups          List of groups to be included
+     */
+    public void runTest(Path[] sourceFilePaths, List<String> groups) {
+        runTest(sourceFilePaths, groups, false);
+    }
+
+    /**
+     * Executes a given set of ballerina program files.
+     *
+     * @param sourceFilePaths List of @{@link Path} of ballerina files
+     * @param groups          List of groups to be included/excluded
+     * @param ignoreGroups    flag to specify whether to include or exclude provided groups
+     */
+    public void runTest(Path[] sourceFilePaths, List<String> groups, boolean ignoreGroups) {
         ProgramFile[] programFiles = Arrays.stream(sourceFilePaths).map(BTestRunner::buildTestModel)
                 .toArray(ProgramFile[]::new);
         Arrays.stream(programFiles).forEachOrdered(programFile -> {
             TesterinaRegistry.getInstance().addProgramFile(programFile);
         });
 
-    // TODO Implement debugging for Testerina
-
-        executeTestFunctions(programFiles);
+        executeTestFunctions(programFiles, groups, ignoreGroups);
         tReport.printTestSummary();
-        Runtime.getRuntime().exit(0);
     }
 
     private static ProgramFile buildTestModel(Path sourceFilePath) {
@@ -72,19 +89,17 @@ public class BTestRunner {
         // compile
         Compiler compiler = Compiler.getInstance(context);
         compiler.compile(sourceFilePath.toString());
-
         org.wso2.ballerinalang.programfile.ProgramFile programFile = compiler.getCompiledProgram();
 
         if (programFile == null) {
             throw new BallerinaException("compilation contains errors");
         }
-
         ProgramFile progFile = LauncherUtils.getExecutableProgram(programFile);
         progFile.setProgramFilePath(sourceFilePath);
         return progFile;
     }
 
-    private static void executeTestFunctions(ProgramFile[] programFiles) {
+    private void executeTestFunctions(ProgramFile[] programFiles, List<String> groups, boolean disableGroups) {
         TesterinaContext tFile = new TesterinaContext(programFiles);
         ArrayList<TesterinaFunction> testFunctions = tFile.getTestFunctions();
         ArrayList<TesterinaFunction> beforeTestFunctions = tFile.getBeforeTestFunctions();
@@ -108,20 +123,62 @@ public class BTestRunner {
         for (TesterinaFunction tFunction : testFunctions) {
             boolean isTestPassed = true;
             String errorMessage = null;
-            try {
-                tFunction.invoke();
-            } catch (BallerinaException e) {
-                isTestPassed = false;
-                errorMessage = e.getMessage();
-                outStream.println("test '" + tFunction.getName() + "' failed: " + errorMessage);
-            } catch (Exception e) {
-                isTestPassed = false;
-                errorMessage = e.getMessage();
-                outStream.println("test '" + tFunction.getName() + "' has an error: " + errorMessage);
+
+            // Check whether the test is disabled.
+            if (tFunction.getTesterinaAnnotation().isDisabled()) {
+                tReport.incrementSkipCount();
+                continue;
             }
-            // if there are no exception thrown, test is passed
-            TesterinaResult functionResult = new TesterinaResult(tFunction.getName(), isTestPassed, errorMessage);
-            tReport.addFunctionResult(functionResult);
+            // Filtering the test functions by group
+            if (groups != null) {
+                // If provided groups matches and the provided flag is to disable groups the function is skipped
+                if ((isGroupAvailable(groups, tFunction.getTesterinaAnnotation().getGroups()) && disableGroups) || (
+                        !isGroupAvailable(groups, tFunction.getTesterinaAnnotation().getGroups())
+                        && !disableGroups)) {
+                    tReport.incrementSkipCount();
+                    continue;
+                }
+            }
+
+            // Check whether valueSets are attached to the test function
+            List<String[]> valueSets = tFunction.getTesterinaAnnotation().getValueSet();
+            if (valueSets != null && valueSets.size() > 0) {
+                for (String[] valueSet : valueSets) {
+                    isTestPassed = true;
+                    try {
+                        // Parsing the args to invoke function
+                        tFunction.invoke(Arrays.stream(valueSet).map(s -> new BString(s)).toArray(BString[]::new));
+                    } catch (BallerinaException e) {
+                        isTestPassed = false;
+                        errorMessage = "valueSet: " + Arrays.toString(valueSet) + " " + e.getMessage();
+                        outStream.println("test '" + tFunction.getName() + "' failed: " + errorMessage);
+                    } catch (Exception e) {
+                        isTestPassed = false;
+                        errorMessage = "valueSet: " + Arrays.toString(valueSet) + " " + e.getMessage();
+                        outStream.println("test '" + tFunction.getName() + "' has an error: " + errorMessage);
+                    }
+                    // Adding results to the report
+                    TesterinaResult functionResult = new TesterinaResult(tFunction.getName(), isTestPassed,
+                            errorMessage);
+                    tReport.addFunctionResult(functionResult);
+                }
+            } else {
+                try {
+                    tFunction.invoke();
+                } catch (BallerinaException e) {
+                    isTestPassed = false;
+                    errorMessage = e.getMessage();
+                    outStream.println("test '" + tFunction.getName() + "' failed: " + errorMessage);
+                } catch (Exception e) {
+                    isTestPassed = false;
+                    errorMessage = e.getMessage();
+                    outStream.println("test '" + tFunction.getName() + "' has an error: " + errorMessage);
+                }
+                // if there are no exception thrown, test is passed
+                TesterinaResult functionResult = new TesterinaResult(tFunction.getName(), isTestPassed,
+                        errorMessage);
+                tReport.addFunctionResult(functionResult);
+            }
         }
 
         //after test
@@ -134,4 +191,30 @@ public class BTestRunner {
         }
     }
 
+    /**
+     * Return the Test report of program runner.
+     *
+     * @return @{@link TesterinaReport} object
+     */
+    public TesterinaReport getTesterinaReport() {
+        return tReport;
+    }
+
+    /**
+     * Check whether there is a common element in two Lists.
+     *
+     * @param inputGroups    String @{@link List} to match
+     * @param functionGroups String @{@link List} to match agains
+     * @return true if a match is found
+     */
+    private static boolean isGroupAvailable(List<String> inputGroups, List<String> functionGroups) {
+        for (String group : inputGroups) {
+            for (String funcGroup : functionGroups) {
+                if (group.equals(funcGroup)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 }

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/entity/TesterinaAnnotation.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/entity/TesterinaAnnotation.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ * <p>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.testerina.core.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Entity class to hold annotation information.
+ *
+ * @since 0.963.0
+ */
+public class TesterinaAnnotation {
+
+    private boolean disabled = false;
+    private List<String> groups = new ArrayList<>();
+    private List<String[]> valueSet = new ArrayList<>();
+
+    /**
+     * Testerina annotation types.
+     */
+    public enum Annotations {
+        TEST_CONFIG("config"),
+        BEFORE_TEST_CONFIG("beforeTest"),
+        AFTER_TEST_CONFIG("afterTest");
+
+        private final String annotationName;
+
+        Annotations(String annotationName) {
+            this.annotationName = annotationName;
+        }
+
+        public String getName() {
+            return annotationName;
+        }
+    }
+
+    /**
+     * Testerina config annotation properties.
+     */
+    public enum ConfigAnnotationProps {
+        TEST_GROUP("groups"),
+        TEST_VALUE_SET("valueSets"),
+        TEST_DISABLED("disabled");
+
+        String annotationName;
+
+        ConfigAnnotationProps(String annotationName) {
+            this.annotationName = annotationName;
+        }
+
+        public String getName() {
+            return annotationName;
+        }
+    }
+
+    public List<String> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(List<String> groups) {
+        this.groups = groups;
+    }
+
+    public List<String[]> getValueSet() {
+        return valueSet;
+    }
+
+    public void setValueSet(List<String[]> valueSet) {
+        this.valueSet = valueSet;
+    }
+
+    public boolean isDisabled() {
+        return disabled;
+    }
+
+    public void setDisabled(boolean disabled) {
+        this.disabled = disabled;
+    }
+}

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/entity/TesterinaContext.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/entity/TesterinaContext.java
@@ -17,6 +17,7 @@
  */
 package org.ballerinalang.testerina.core.entity;
 
+import org.ballerinalang.testerina.core.AnnotationProcessor;
 import org.ballerinalang.util.codegen.FunctionInfo;
 import org.ballerinalang.util.codegen.PackageInfo;
 import org.ballerinalang.util.codegen.ProgramFile;
@@ -73,30 +74,30 @@ public class TesterinaContext {
      * @param programFile {@link ProgramFile}.
      */
     private void extractTestFunctions(ProgramFile programFile) {
-        Arrays.stream(programFile.getPackageInfoEntries())
-                .map(PackageInfo::getFunctionInfoEntries)
-                .flatMap(Arrays::stream)
-                .forEachOrdered(f -> addTestFunctions(programFile, f));
+        Arrays.stream(programFile.getPackageInfoEntries()).map(PackageInfo::getFunctionInfoEntries)
+                .flatMap(Arrays::stream).forEachOrdered(f -> addTestFunctions(programFile, f));
     }
 
     private void addTestFunctions(ProgramFile programFile, FunctionInfo functionInfo) {
-            String nameUpperCase = functionInfo.getName().toUpperCase(Locale.ENGLISH);
-        if (nameUpperCase.startsWith(TesterinaFunction.PREFIX_TEST) &&
-                !nameUpperCase.endsWith(TesterinaFunction.INIT_SUFFIX)) {
-            TesterinaFunction tFunction = new TesterinaFunction(programFile, functionInfo, 
-                    TesterinaFunction.Type.TEST);
+        //TODO : We need exclude builtin packages in ballerina when searching for test functions
+        String nameUpperCase = functionInfo.getName().toUpperCase(Locale.ENGLISH);
+
+        if (nameUpperCase.startsWith(TesterinaFunction.PREFIX_TEST) && !nameUpperCase
+                .endsWith(TesterinaFunction.INIT_SUFFIX)) {
+
+            TesterinaFunction tFunction = new TesterinaFunction(programFile, functionInfo, TesterinaFunction.Type.TEST,
+                    AnnotationProcessor.processAnnotations(functionInfo));
             this.testFunctions.add(tFunction);
-        } else if (nameUpperCase.startsWith(TesterinaFunction.PREFIX_BEFORETEST) &&
-                !nameUpperCase.endsWith(TesterinaFunction.INIT_SUFFIX)) {
-            TesterinaFunction tFunction = new TesterinaFunction(programFile, functionInfo, 
-                    TesterinaFunction.Type.BEFORE_TEST);
+        } else if (nameUpperCase.startsWith(TesterinaFunction.PREFIX_BEFORETEST) && !nameUpperCase
+                .endsWith(TesterinaFunction.INIT_SUFFIX)) {
+            TesterinaFunction tFunction = new TesterinaFunction(programFile, functionInfo,
+                    TesterinaFunction.Type.BEFORE_TEST, null);
             this.beforeTestFunctions.add(tFunction);
-        } else if (nameUpperCase.startsWith(TesterinaFunction.PREFIX_AFTERTEST) &&
-                !nameUpperCase.endsWith(TesterinaFunction.INIT_SUFFIX)) {
-            TesterinaFunction tFunction = new TesterinaFunction(programFile, functionInfo, 
-                    TesterinaFunction.Type.AFTER_TEST);
+        } else if (nameUpperCase.startsWith(TesterinaFunction.PREFIX_AFTERTEST) && !nameUpperCase
+                .endsWith(TesterinaFunction.INIT_SUFFIX)) {
+            TesterinaFunction tFunction = new TesterinaFunction(programFile, functionInfo,
+                    TesterinaFunction.Type.AFTER_TEST, null);
             this.afterTestFunctions.add(tFunction);
         }
     }
-
 }

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/entity/TesterinaContext.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/entity/TesterinaContext.java
@@ -24,6 +24,7 @@ import org.ballerinalang.util.codegen.ProgramFile;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 
 /**
@@ -34,10 +35,12 @@ public class TesterinaContext {
     private ArrayList<TesterinaFunction> testFunctions = new ArrayList<>();
     private ArrayList<TesterinaFunction> beforeTestFunctions = new ArrayList<>();
     private ArrayList<TesterinaFunction> afterTestFunctions = new ArrayList<>();
+    private List<String> groups;
+    private boolean excludeGroups = false;
 
-    public static final String ASSERTION_EXCEPTION_CATEGORY = "assert-failure";
-
-    public TesterinaContext(ProgramFile[] programFiles) {
+    public TesterinaContext(ProgramFile[] programFiles, List<String> groups, boolean excludeGroups) {
+        this.groups = groups;
+        this.excludeGroups = excludeGroups;
         Arrays.stream(programFiles).forEach(this::extractTestFunctions);
     }
 
@@ -85,18 +88,19 @@ public class TesterinaContext {
         if (nameUpperCase.startsWith(TesterinaFunction.PREFIX_TEST) && !nameUpperCase
                 .endsWith(TesterinaFunction.INIT_SUFFIX)) {
 
-            TesterinaFunction tFunction = new TesterinaFunction(programFile, functionInfo, TesterinaFunction.Type.TEST,
-                    AnnotationProcessor.processAnnotations(functionInfo));
+            TesterinaFunction tFunction = AnnotationProcessor
+                    .processAnnotations(programFile, functionInfo, groups, excludeGroups);
+
             this.testFunctions.add(tFunction);
         } else if (nameUpperCase.startsWith(TesterinaFunction.PREFIX_BEFORETEST) && !nameUpperCase
                 .endsWith(TesterinaFunction.INIT_SUFFIX)) {
             TesterinaFunction tFunction = new TesterinaFunction(programFile, functionInfo,
-                    TesterinaFunction.Type.BEFORE_TEST, null);
+                    TesterinaFunction.Type.BEFORE_TEST);
             this.beforeTestFunctions.add(tFunction);
         } else if (nameUpperCase.startsWith(TesterinaFunction.PREFIX_AFTERTEST) && !nameUpperCase
                 .endsWith(TesterinaFunction.INIT_SUFFIX)) {
             TesterinaFunction tFunction = new TesterinaFunction(programFile, functionInfo,
-                    TesterinaFunction.Type.AFTER_TEST, null);
+                    TesterinaFunction.Type.AFTER_TEST);
             this.afterTestFunctions.add(tFunction);
         }
     }

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/entity/TesterinaFunction.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/entity/TesterinaFunction.java
@@ -35,6 +35,7 @@ public class TesterinaFunction {
     private Type type;
     private FunctionInfo bFunction;
     private ProgramFile programFile;
+    private TesterinaAnnotation testerinaAnnotation;
 
     private static final int WORKER_TIMEOUT = 10;
 
@@ -55,17 +56,39 @@ public class TesterinaFunction {
             this.prefix = prefix;
         }
 
-        @Override
-        public String toString() {
+        @Override public String toString() {
             return prefix;
         }
     }
 
-    TesterinaFunction(ProgramFile programFile, FunctionInfo bFunction, Type type) {
+    /**
+     * Testerina annotation names.
+     */
+    public enum Annotations {
+        TEST_FUNCTION("testFunction"),
+        BEFORE_TEST("beforeTest"),
+        AFTER_TEST("afterTest"),
+        TEST_GROUP("group"),
+        TEST_VALUE_SET("valueSet");
+
+        String annotationName;
+
+        Annotations(String annotationName) {
+            this.annotationName = annotationName;
+        }
+
+        @Override public String toString() {
+            return annotationName;
+        }
+    }
+
+    TesterinaFunction(ProgramFile programFile, FunctionInfo bFunction, Type type,
+                      TesterinaAnnotation testerinaAnnotation) {
         this.name = bFunction.getName();
         this.type = type;
         this.bFunction = bFunction;
         this.programFile = programFile;
+        this.testerinaAnnotation = testerinaAnnotation;
     }
 
     public BValue[] invoke() throws BallerinaException {
@@ -82,10 +105,9 @@ public class TesterinaFunction {
         Context ctx = new Context(programFile);
         Debugger debugger = new Debugger(programFile);
         initDebugger(ctx, debugger);
-        return BLangFunctions.invokeNew(programFile, bFunction.getPackageInfo().getPkgPath(), bFunction.getName(),
-                args, ctx);
+        return BLangFunctions
+                .invokeNew(programFile, bFunction.getPackageInfo().getPkgPath(), bFunction.getName(), args, ctx);
     }
-
 
     public String getName() {
         return name;
@@ -111,6 +133,14 @@ public class TesterinaFunction {
         this.bFunction = bFunction;
     }
 
+    public TesterinaAnnotation getTesterinaAnnotation() {
+        return testerinaAnnotation;
+    }
+
+    public void setTesterinaAnnotation(TesterinaAnnotation testerinaAnnotation) {
+        this.testerinaAnnotation = testerinaAnnotation;
+    }
+
     private static void initDebugger(Context bContext, Debugger debugger) {
         bContext.getProgramFile().setDebugger(debugger);
         if (debugger.isDebugEnabled()) {
@@ -120,5 +150,4 @@ public class TesterinaFunction {
             debugger.addDebugContextAndWait(debugContext);
         }
     }
-
 }

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/entity/TesterinaFunction.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/entity/TesterinaFunction.java
@@ -26,6 +26,9 @@ import org.ballerinalang.util.debugger.Debugger;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.ballerinalang.util.program.BLangFunctions;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * TesterinaFunction entity class.
  */
@@ -35,14 +38,16 @@ public class TesterinaFunction {
     private Type type;
     private FunctionInfo bFunction;
     private ProgramFile programFile;
-    private TesterinaAnnotation testerinaAnnotation;
+    private boolean runTest = true;
 
-    private static final int WORKER_TIMEOUT = 10;
+    // Annotation info
+    private List<String> groups = new ArrayList<>();
+    private List<String[]> valueSet = new ArrayList<>();
 
-    public static final String PREFIX_TEST = "TEST";
-    public static final String PREFIX_BEFORETEST = "BEFORETEST";
-    public static final String PREFIX_AFTERTEST = "AFTERTEST";
-    public static final String INIT_SUFFIX = ".<INIT>";
+    static final String PREFIX_TEST = "TEST";
+    static final String PREFIX_BEFORETEST = "BEFORETEST";
+    static final String PREFIX_AFTERTEST = "AFTERTEST";
+    static final String INIT_SUFFIX = ".<INIT>";
 
     /**
      * Prefixes for the test function names.
@@ -61,51 +66,27 @@ public class TesterinaFunction {
         }
     }
 
-    /**
-     * Testerina annotation names.
-     */
-    public enum Annotations {
-        TEST_FUNCTION("testFunction"),
-        BEFORE_TEST("beforeTest"),
-        AFTER_TEST("afterTest"),
-        TEST_GROUP("group"),
-        TEST_VALUE_SET("valueSet");
-
-        String annotationName;
-
-        Annotations(String annotationName) {
-            this.annotationName = annotationName;
-        }
-
-        @Override public String toString() {
-            return annotationName;
-        }
-    }
-
-    TesterinaFunction(ProgramFile programFile, FunctionInfo bFunction, Type type,
-                      TesterinaAnnotation testerinaAnnotation) {
+    public TesterinaFunction(ProgramFile programFile, FunctionInfo bFunction, Type type) {
         this.name = bFunction.getName();
         this.type = type;
         this.bFunction = bFunction;
         this.programFile = programFile;
-        this.testerinaAnnotation = testerinaAnnotation;
     }
 
-    public BValue[] invoke() throws BallerinaException {
-        return invoke(new BValue[] {});
+    public void invoke() throws BallerinaException {
+        invoke(new BValue[] {});
     }
 
     /**
      * Invokes a ballerina test function, in blocking mode.
      *
      * @param args function arguments
-     * @return values returned by the ballerina function
      */
-    public BValue[] invoke(BValue[] args) {
+    public void invoke(BValue[] args) {
         Context ctx = new Context(programFile);
         Debugger debugger = new Debugger(programFile);
         initDebugger(ctx, debugger);
-        return BLangFunctions
+        BLangFunctions
                 .invokeNew(programFile, bFunction.getPackageInfo().getPkgPath(), bFunction.getName(), args, ctx);
     }
 
@@ -125,20 +106,28 @@ public class TesterinaFunction {
         this.type = type;
     }
 
-    public FunctionInfo getbFunction() {
-        return this.bFunction;
+    public List<String> getGroups() {
+        return groups;
     }
 
-    public void setbFunctionInfo(FunctionInfo bFunction) {
-        this.bFunction = bFunction;
+    public void setGroups(List<String> groups) {
+        this.groups = groups;
     }
 
-    public TesterinaAnnotation getTesterinaAnnotation() {
-        return testerinaAnnotation;
+    public List<String[]> getValueSet() {
+        return valueSet;
     }
 
-    public void setTesterinaAnnotation(TesterinaAnnotation testerinaAnnotation) {
-        this.testerinaAnnotation = testerinaAnnotation;
+    public void setValueSet(List<String[]> valueSet) {
+        this.valueSet = valueSet;
+    }
+
+    public boolean getRunTest() {
+        return runTest;
+    }
+
+    public void setRunTest() {
+        this.runTest = false;
     }
 
     private static void initDebugger(Context bContext, Debugger debugger) {

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/entity/TesterinaReport.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/entity/TesterinaReport.java
@@ -32,18 +32,20 @@ public class TesterinaReport {
 
     private List<TesterinaResult> passedTests = new ArrayList<>();
     private List<TesterinaResult> failedTests = new ArrayList<>();
+    private int skipedTestCount = 0;
 
     public void printTestSummary() {
-        if (!passedTests.isEmpty() || !failedTests.isEmpty()) {
-            int totalTests = passedTests.size() + failedTests.size();
-            outStream.println();
-            outStream.println("result: ");
-            outStream.print("tests run: " + totalTests);
-            outStream.print(", passed: " + passedTests.size());
-            outStream.println(", failed: " + failedTests.size());
-        }
+        int totalTests = passedTests.size() + failedTests.size();
+        outStream.println();
+        outStream.println("============== TEST RESULT SUMMARY ==============");
+        outStream.println("result: ");
+        outStream.print("tests run: " + totalTests);
+        outStream.print(", passed: " + passedTests.size());
+        outStream.print(", failed: " + failedTests.size());
+        outStream.println(", skipped: " + skipedTestCount);
 
         if (!failedTests.isEmpty()) {
+            outStream.println();
             outStream.println("failed tests:");
             for (TesterinaResult failedResult : failedTests) {
                 outStream.println(
@@ -64,8 +66,23 @@ public class TesterinaReport {
         return Collections.unmodifiableList(passedTests);
     }
 
+    public int getPassedTestCount() {
+        return Collections.unmodifiableList(passedTests).size();
+    }
+
+    public int getFailedTestCount() {
+        return Collections.unmodifiableList(failedTests).size();
+    }
+
+    public int getSkippedTestCount() {
+        return skipedTestCount;
+    }
+
     public List<TesterinaResult> getFailedTests() {
         return Collections.unmodifiableList(failedTests);
     }
 
+    public void incrementSkipCount() {
+        skipedTestCount++;
+    }
 }

--- a/misc/testerina/modules/testerina-core/src/test/java/org/ballerinalang/testerina/test/DataDrivenTests.java
+++ b/misc/testerina/modules/testerina-core/src/test/java/org/ballerinalang/testerina/test/DataDrivenTests.java
@@ -1,0 +1,82 @@
+/*
+ *   Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ */
+
+package org.ballerinalang.testerina.test;
+
+import org.ballerinalang.testerina.core.BTestRunner;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tests to cover data set based testing.
+ */
+public class DataDrivenTests {
+
+    private Path[] filePaths = { Paths.get("src/test/resources/annotations-test/data-driven-positive-test.bal") };
+    private Path[] filePathsGrouped = {
+            Paths.get("src/test/resources/annotations-test/data-driven-with-groups-test.bal") };
+
+    @Test
+    public void dataSetTest() {
+        BTestRunner testRunner = new BTestRunner();
+        testRunner.runTest(filePaths, null);
+        Assert.assertEquals(testRunner.getTesterinaReport().getPassedTestCount(), 2);
+        Assert.assertEquals(testRunner.getTesterinaReport().getFailedTestCount(), 2);
+        Assert.assertEquals(testRunner.getTesterinaReport().getSkippedTestCount(), 0);
+    }
+
+    @Test
+    public void dataSetWithGroupFilterTest() {
+        BTestRunner testRunner = new BTestRunner();
+        List<String> groupList = new ArrayList<>();
+        groupList.add("g1");
+        testRunner.runTest(filePathsGrouped, groupList);
+        Assert.assertEquals(testRunner.getTesterinaReport().getPassedTestCount(), 2);
+        Assert.assertEquals(testRunner.getTesterinaReport().getFailedTestCount(), 2);
+        Assert.assertEquals(testRunner.getTesterinaReport().getSkippedTestCount(), 0);
+    }
+
+    @Test
+    public void dataSetWithMultipleGroupFilterTest() {
+        BTestRunner testRunner = new BTestRunner();
+        List<String> groupList = new ArrayList<>();
+        groupList.add("g1");
+        groupList.add("g2");
+        groupList.add("default");
+        testRunner.runTest(filePathsGrouped, groupList);
+        Assert.assertEquals(testRunner.getTesterinaReport().getPassedTestCount(), 6);
+        Assert.assertEquals(testRunner.getTesterinaReport().getFailedTestCount(), 5);
+        Assert.assertEquals(testRunner.getTesterinaReport().getSkippedTestCount(), 1);
+    }
+
+    @Test
+    public void dataSetWithDefaultGroupFilterTest() {
+        BTestRunner testRunner = new BTestRunner();
+        List<String> groupList = new ArrayList<>();
+        groupList.add("default");
+        testRunner.runTest(filePathsGrouped, groupList);
+        Assert.assertEquals(testRunner.getTesterinaReport().getPassedTestCount(), 1);
+        Assert.assertEquals(testRunner.getTesterinaReport().getFailedTestCount(), 0);
+        Assert.assertEquals(testRunner.getTesterinaReport().getSkippedTestCount(), 4);
+    }
+}

--- a/misc/testerina/modules/testerina-core/src/test/java/org/ballerinalang/testerina/test/DataDrivenTests.java
+++ b/misc/testerina/modules/testerina-core/src/test/java/org/ballerinalang/testerina/test/DataDrivenTests.java
@@ -53,7 +53,7 @@ public class DataDrivenTests {
         testRunner.runTest(filePathsGrouped, groupList);
         Assert.assertEquals(testRunner.getTesterinaReport().getPassedTestCount(), 2);
         Assert.assertEquals(testRunner.getTesterinaReport().getFailedTestCount(), 2);
-        Assert.assertEquals(testRunner.getTesterinaReport().getSkippedTestCount(), 0);
+        Assert.assertEquals(testRunner.getTesterinaReport().getSkippedTestCount(), 4);
     }
 
     @Test

--- a/misc/testerina/modules/testerina-core/src/test/java/org/ballerinalang/testerina/test/DisableFunctionsTest.java
+++ b/misc/testerina/modules/testerina-core/src/test/java/org/ballerinalang/testerina/test/DisableFunctionsTest.java
@@ -1,0 +1,43 @@
+/*
+ *   Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ */
+
+package org.ballerinalang.testerina.test;
+
+import org.ballerinalang.testerina.core.BTestRunner;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Tests disabling of test functions.
+ */
+public class DisableFunctionsTest {
+
+    private Path[] filePaths = { Paths.get("src/test/resources/annotations-test/disable-test.bal") };
+
+    @Test
+    public void disableFunctionsTest() {
+        BTestRunner testRunner = new BTestRunner();
+        testRunner.runTest(filePaths, null);
+        Assert.assertEquals(testRunner.getTesterinaReport().getPassedTestCount(), 3);
+        Assert.assertEquals(testRunner.getTesterinaReport().getFailedTestCount(), 0);
+        Assert.assertEquals(testRunner.getTesterinaReport().getSkippedTestCount(), 2);
+    }
+}

--- a/misc/testerina/modules/testerina-core/src/test/java/org/ballerinalang/testerina/test/GroupFilterTest.java
+++ b/misc/testerina/modules/testerina-core/src/test/java/org/ballerinalang/testerina/test/GroupFilterTest.java
@@ -1,0 +1,172 @@
+/*
+ *   Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ */
+
+package org.ballerinalang.testerina.test;
+
+import org.ballerinalang.testerina.core.BTestRunner;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Test class to test grouping
+ */
+public class GroupFilterTest {
+
+    private Path[] filePaths = { Paths.get("src/test/resources/annotations-test/groups-test.bal") };
+
+    @Test
+    public void singleGroupFilterTest() {
+        BTestRunner testRunner = new BTestRunner();
+        List<String> groupList = new ArrayList<>();
+        groupList.add("g1");
+        testRunner.runTest(filePaths, groupList);
+        Assert.assertEquals(testRunner.getTesterinaReport().getPassedTestCount(), 3);
+        Assert.assertEquals(testRunner.getTesterinaReport().getFailedTestCount(), 0);
+        Assert.assertEquals(testRunner.getTesterinaReport().getSkippedTestCount(), 3);
+    }
+
+    @Test
+    public void multipleGroupFilterTest() {
+        BTestRunner testRunner = new BTestRunner();
+        List<String> groupList = new ArrayList<>();
+        groupList.add("g2");
+        groupList.add("g4");
+        testRunner.runTest(filePaths, groupList);
+        Assert.assertEquals(testRunner.getTesterinaReport().getPassedTestCount(), 3);
+        Assert.assertEquals(testRunner.getTesterinaReport().getFailedTestCount(), 0);
+        Assert.assertEquals(testRunner.getTesterinaReport().getSkippedTestCount(), 3);
+    }
+
+    @Test
+    public void multipleGroupFilterWithDefaultGroupTest() {
+        BTestRunner testRunner = new BTestRunner();
+        List<String> groupList = new ArrayList<>();
+        groupList.add("g2");
+        groupList.add("g3");
+        groupList.add("default");
+        testRunner.runTest(filePaths, groupList);
+        Assert.assertEquals(testRunner.getTesterinaReport().getPassedTestCount(), 5);
+        Assert.assertEquals(testRunner.getTesterinaReport().getFailedTestCount(), 0);
+        Assert.assertEquals(testRunner.getTesterinaReport().getSkippedTestCount(), 1);
+    }
+
+    @Test
+    public void defaultGroupFilterTest() {
+        BTestRunner testRunner = new BTestRunner();
+        List<String> groupList = new ArrayList<>();
+        groupList.add("default");
+        testRunner.runTest(filePaths, groupList);
+        Assert.assertEquals(testRunner.getTesterinaReport().getPassedTestCount(), 2);
+        Assert.assertEquals(testRunner.getTesterinaReport().getFailedTestCount(), 0);
+        Assert.assertEquals(testRunner.getTesterinaReport().getSkippedTestCount(), 4);
+    }
+
+    @Test
+    public void specifyNonExistingGroupTest() {
+        BTestRunner testRunner = new BTestRunner();
+        List<String> groupList = new ArrayList<>();
+        groupList.add("g10");
+        testRunner.runTest(filePaths, groupList);
+        Assert.assertEquals(testRunner.getTesterinaReport().getPassedTestCount(), 0);
+        Assert.assertEquals(testRunner.getTesterinaReport().getFailedTestCount(), 0);
+        Assert.assertEquals(testRunner.getTesterinaReport().getSkippedTestCount(), 6);
+    }
+
+    @Test
+    public void groupFilterWithFailuresTest() {
+        BTestRunner testRunner = new BTestRunner();
+        List<String> groupList = new ArrayList<>();
+        groupList.add("g5");
+        testRunner.runTest(filePaths, groupList);
+        Assert.assertEquals(testRunner.getTesterinaReport().getPassedTestCount(), 0);
+        Assert.assertEquals(testRunner.getTesterinaReport().getFailedTestCount(), 1);
+        Assert.assertEquals(testRunner.getTesterinaReport().getSkippedTestCount(), 5);
+    }
+
+    @Test
+    public void noGroupFiltersTest() {
+        BTestRunner testRunner = new BTestRunner();
+        testRunner.runTest(filePaths, null);
+        Assert.assertEquals(testRunner.getTesterinaReport().getPassedTestCount(), 5);
+        Assert.assertEquals(testRunner.getTesterinaReport().getFailedTestCount(), 1);
+        Assert.assertEquals(testRunner.getTesterinaReport().getSkippedTestCount(), 0);
+    }
+
+    // Tests group exclude filters
+    @Test
+    public void excludeSingleGroupTest() {
+        BTestRunner testRunner = new BTestRunner();
+        List<String> groupList = new ArrayList<>();
+        groupList.add("g5");
+        testRunner.runTest(filePaths, groupList, true);
+        Assert.assertEquals(testRunner.getTesterinaReport().getPassedTestCount(), 5);
+        Assert.assertEquals(testRunner.getTesterinaReport().getFailedTestCount(), 0);
+        Assert.assertEquals(testRunner.getTesterinaReport().getSkippedTestCount(), 1);
+    }
+
+    @Test
+    public void excludeMultipleGroupsTest() {
+        BTestRunner testRunner = new BTestRunner();
+        List<String> groupList = new ArrayList<>();
+        groupList.add("g4");
+        groupList.add("g5");
+        testRunner.runTest(filePaths, groupList, true);
+        Assert.assertEquals(testRunner.getTesterinaReport().getPassedTestCount(), 4);
+        Assert.assertEquals(testRunner.getTesterinaReport().getFailedTestCount(), 0);
+        Assert.assertEquals(testRunner.getTesterinaReport().getSkippedTestCount(), 2);
+    }
+
+    @Test
+    public void excludeDefaultGroupTest() {
+        BTestRunner testRunner = new BTestRunner();
+        List<String> groupList = new ArrayList<>();
+        groupList.add("default");
+        testRunner.runTest(filePaths, groupList, true);
+        Assert.assertEquals(testRunner.getTesterinaReport().getPassedTestCount(), 3);
+        Assert.assertEquals(testRunner.getTesterinaReport().getFailedTestCount(), 1);
+        Assert.assertEquals(testRunner.getTesterinaReport().getSkippedTestCount(), 2);
+    }
+
+    @Test
+    public void excludeDefaultAndUserDefinedGroupTest() {
+        BTestRunner testRunner = new BTestRunner();
+        List<String> groupList = new ArrayList<>();
+        groupList.add("default");
+        groupList.add("g1");
+        testRunner.runTest(filePaths, groupList, true);
+        Assert.assertEquals(testRunner.getTesterinaReport().getPassedTestCount(), 0);
+        Assert.assertEquals(testRunner.getTesterinaReport().getFailedTestCount(), 1);
+        Assert.assertEquals(testRunner.getTesterinaReport().getSkippedTestCount(), 5);
+    }
+
+    @Test
+    public void excludeNonExistingGroupTest() {
+        BTestRunner testRunner = new BTestRunner();
+        List<String> groupList = new ArrayList<>();
+        groupList.add("g10");
+        testRunner.runTest(filePaths, groupList, true);
+        Assert.assertEquals(testRunner.getTesterinaReport().getPassedTestCount(), 5);
+        Assert.assertEquals(testRunner.getTesterinaReport().getFailedTestCount(), 1);
+        Assert.assertEquals(testRunner.getTesterinaReport().getSkippedTestCount(), 0);
+    }
+}

--- a/misc/testerina/modules/testerina-core/src/test/java/org/ballerinalang/testerina/test/GroupFilterTest.java
+++ b/misc/testerina/modules/testerina-core/src/test/java/org/ballerinalang/testerina/test/GroupFilterTest.java
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Test class to test grouping
+ * Test class to test grouping.
  */
 public class GroupFilterTest {
 

--- a/misc/testerina/modules/testerina-core/src/test/java/org/ballerinalang/testerina/test/utils/CompileResult.java
+++ b/misc/testerina/modules/testerina-core/src/test/java/org/ballerinalang/testerina/test/utils/CompileResult.java
@@ -31,8 +31,8 @@ public class CompileResult {
 
     private List<Diagnostic> diagnostics;
     private ProgramFile progFile;
-    private int errorCount = 0;;
-    private int warnCount = 0;;
+    private int errorCount = 0;
+    private int warnCount = 0;
 
     public CompileResult() {
         diagnostics = new ArrayList<Diagnostic>();

--- a/misc/testerina/modules/testerina-core/src/test/resources/annotations-test/data-driven-positive-test.bal
+++ b/misc/testerina/modules/testerina-core/src/test/resources/annotations-test/data-driven-positive-test.bal
@@ -1,0 +1,13 @@
+import ballerina.test;
+
+@test:config{
+    valueSets:["1,2,3","4,4,8","1,5,7","4,4,5"]
+}
+function testFunc1 (string fValue, string sValue, string result) {
+
+    var value1, _ = <int>fValue;
+    var value2, _ = <int>sValue;
+    var result1, _ = <int>result;
+
+    test:assertIntEquals(value1 + value2, result1, "The sum is not correct");
+}

--- a/misc/testerina/modules/testerina-core/src/test/resources/annotations-test/data-driven-with-groups-test.bal
+++ b/misc/testerina/modules/testerina-core/src/test/resources/annotations-test/data-driven-with-groups-test.bal
@@ -1,0 +1,52 @@
+import ballerina.test;
+
+@test:config{
+    valueSets:["1,2,3","4,4,8","1,5,7","4,4,5"],
+    groups:["g1"]
+}
+function testFunc1 (string fValue, string sValue, string result) {
+
+    var value1, _ = <int>fValue;
+    var value2, _ = <int>sValue;
+    var result1, _ = <int>result;
+
+    test:assertIntEquals(value1 + value2, result1, "The sum is not correct");
+}
+
+@test:config{
+    valueSets:["1,2,3","4,4,8","1,5,7","4,4,5"],
+    groups:["g2"]
+}
+function testFunc2 (string fValue, string sValue, string result) {
+
+    var value1, _ = <int>fValue;
+    var value2, _ = <int>sValue;
+    var result1, _ = <int>result;
+
+    test:assertIntEquals(value1 + value2, result1, "The sum is not correct");
+}
+
+@test:config{
+    valueSets:["1,2,3","4,4,2"],
+    groups:["g2"]
+}
+function testFunc3 (string fValue, string sValue, string result) {
+
+    var value1, _ = <int>fValue;
+    var value2, _ = <int>sValue;
+    var result1, _ = <int>result;
+
+    test:assertIntEquals(value1 + value2, result1, "The sum is not correct");
+}
+
+@test:config{
+    groups:["g3"]
+}
+function testFunc4 () {
+    test:assertFalse(false, "Asset Failed.");
+}
+
+@test:config{}
+function testFunc5 () {
+    test:assertFalse(false, "Asset Failed.");
+}

--- a/misc/testerina/modules/testerina-core/src/test/resources/annotations-test/disable-test.bal
+++ b/misc/testerina/modules/testerina-core/src/test/resources/annotations-test/disable-test.bal
@@ -1,0 +1,32 @@
+import ballerina.test;
+
+@test:config{
+    disabled:true
+}
+function testFunc1 () {
+    test:assertFalse(false, "errorMessage");
+}
+
+@test:config{
+    disabled:false
+}
+function testFunc3 () {
+    test:assertFalse(false, "errorMessage");
+}
+
+@test:config{
+    disabled:true
+}
+function testFunc4 () {
+    test:assertFalse(true, "errorMessage");
+}
+
+@test:config{}
+function testFunc5 () {
+    test:assertFalse(false, "errorMessage");
+}
+
+//Function without annotations
+function testFunc6 () {
+    test:assertFalse(false, "errorMessage");
+}

--- a/misc/testerina/modules/testerina-core/src/test/resources/annotations-test/groups-test.bal
+++ b/misc/testerina/modules/testerina-core/src/test/resources/annotations-test/groups-test.bal
@@ -1,0 +1,39 @@
+import ballerina.test;
+
+@test:config{
+    groups:["g1","g2"]
+}
+function testFunc1 () {
+    test:assertFalse(false, "errorMessage");
+}
+
+@test:config{
+    groups:["g1","g2","g3"]
+}
+function testFunc2 () {
+    test:assertFalse(false, "errorMessage");
+}
+
+@test:config{
+    groups:["g1","g2","g3","g4"]
+}
+function testFunc3 () {
+    test:assertFalse(false, "errorMessage");
+}
+
+@test:config{
+    groups:["g5"]
+}
+function testFunc4 () {
+    test:assertFalse(true, "errorMessage");
+}
+
+@test:config{}
+function testFunc5 () {
+    test:assertFalse(false, "errorMessage");
+}
+
+//Function without annotations
+function testFunc6 () {
+    test:assertFalse(false, "errorMessage");
+}

--- a/misc/testerina/modules/testerina-core/src/test/resources/testng.xml
+++ b/misc/testerina/modules/testerina-core/src/test/resources/testng.xml
@@ -25,6 +25,9 @@ under the License.
     <test name="ballerina-test-functions-unit-tests" preserve-order="true" parallel="false">
         <classes>
             <class name="org.ballerinalang.testerina.test.AssertTest"/>
+            <class name="org.ballerinalang.testerina.test.GroupFilterTest"/>
+            <class name="org.ballerinalang.testerina.test.DataDrivenTests"/>
+            <class name="org.ballerinalang.testerina.test.DisableFunctionsTest"/>
         </classes>
     </test>
 


### PR DESCRIPTION
## Purpose

This PR introduces test grouping and data-driven test execution support. Resoves #4674 #4676 #4675 

## Goals
Allow the user to better control tests. 

## Approach
#### Grouping Tests

You can group the test functions and control the execution of tests by grouping them.

e.g:
```ballerina
@test:config{
    groups:["g2","g3"]
}
function testFunc () {
test:assertFalse(false, "errorMessage");
}
```

In order to execute tests belonging to a selected group. Run the below command.
````
ballerina test your_package --groups g2,g3
````
Note: You can also use `--disable-groups` flag to exclude groups from executing. Also un-grouped tests will be added to a group names default.

#### Running Data-driven tests

Data sets allows users to execute the same test case with different values sets. Testerina supports data driven tests natively.

e.g:
```ballerina
@test:config{
    valueSets:["val1,val2","val3, val4"]
}
function testFunc10 (string input, string output) {
println("Input: " +input + " Output: " +output);
test:assertFalse(false, "errorMessage");
}
```

Executing the above will produce the following output.
```
Input: val3 Output: val4
Input: val1 Output: val2

============== TEST RESULT SUMMARY ==============
result: 
tests run: 2, passed: 2, failed: 0, skipped: 0
````

## Documentation

ReadMe is updated accordingly. 

## Automation tests
 - Unit tests: Added Unit tests