### PR TITLE
Fix issue #4715

### DIFF
--- a/docs/ballerina-by-example/examples/record-i-o/record-i-o.bal
+++ b/docs/ballerina-by-example/examples/record-i-o/record-i-o.bal
@@ -1,9 +1,9 @@
 import ballerina.file;
 import ballerina.io;
 
-@Description{value:"This function will return a TextRecordChannel from a given file location.The encoding is character represenation of the content in file i.e UTF-8 ASCCI. The rs is record seperator i.e newline etc. and fs is field seperator i.e comma etc."}
+@Description{value:"This function will return a DelimitedRecordChannel from a given file location.The encoding is character represenation of the content in file i.e UTF-8 ASCCI. The rs is record seperator i.e newline etc. and fs is field seperator i.e comma etc."}
 function getFileRecordChannel (string filePath, string permission, string encoding,
-                               string rs, string fs) (io:TextRecordChannel) {
+                               string rs, string fs) (io:DelimitedRecordChannel) {
     file:File src = {path:filePath};
     //First we get the ByteChannel representation of the file.
     io:ByteChannel channel = src.openChannel(permission);
@@ -11,14 +11,14 @@ function getFileRecordChannel (string filePath, string permission, string encodi
     io:CharacterChannel characterChannel = channel.toCharacterChannel(encoding);
     //Finally we convert the character channel to record channel
     //to read content as records.
-    io:TextRecordChannel textRecordChannel = characterChannel.
+    io:DelimitedRecordChannel delimitedRecordChannel = characterChannel.
                                                              toTextRecordChannel(rs, fs);
-    return textRecordChannel;
+    return delimitedRecordChannel;
 }
 
 @Description{value:"This function will process CSV file and write content back as text with '|' delimiter."}
-function process (io:TextRecordChannel srcRecordChannel,
-                  io:TextRecordChannel dstRecordChannel) {
+function process (io:DelimitedRecordChannel srcRecordChannel,
+                  io:DelimitedRecordChannel dstRecordChannel) {
     //We read all the records from the provided file until there're no records returned.
     while (srcRecordChannel.hasNextTextRecord()) {
         //Here's how we read records.
@@ -33,11 +33,11 @@ function main (string[] args) {
     string dstFileName = "./files/sampleResponse.txt";
     //Here we specify the location of the CSV file where the record separator is
     //new line and field separator is comma.
-    io:TextRecordChannel srcRecordChannel =
+    io:DelimitedRecordChannel srcRecordChannel =
     getFileRecordChannel(srcFileName, "r", "UTF-8", "\\r?\\n", ",");
     //Here we specify the location of the text file where the record separator
     //is new line and field separator is pipe.
-    io:TextRecordChannel dstRecordChannel =
+    io:DelimitedRecordChannel dstRecordChannel =
     getFileRecordChannel(dstFileName, "w", "UTF-8", "\n", "|");
     println("Start to process CSV file from " + srcFileName + " to text file in "
             + dstFileName);

--- a/docs/getting_started/csvFileProcessor/processFile.bal
+++ b/docs/getting_started/csvFileProcessor/processFile.bal
@@ -1,15 +1,15 @@
 import ballerina.file;
 import ballerina.io;
 
-function getFileRecordChannel (string filePath, string permission, string encoding, string rs, string fs) (io:TextRecordChannel) {
+function getFileRecordChannel (string filePath, string permission, string encoding, string rs, string fs) (io:DelimitedRecordChannel) {
     file:File src = {path:filePath};
     io:ByteChannel channel = src.openChannel(permission);
     io:CharacterChannel characterChannel = channel.toCharacterChannel(encoding);
-    io:TextRecordChannel textRecordChannel = characterChannel.toTextRecordChannel(rs, fs);
+    io:DelimitedRecordChannel textRecordChannel = characterChannel.toTextRecordChannel(rs, fs);
     return textRecordChannel;
 }
 
-function process (io:TextRecordChannel srcRecordChannel, io:TextRecordChannel dstRecordChannel) {
+function process (io:DelimitedRecordChannel srcRecordChannel, io:DelimitedRecordChannel dstRecordChannel) {
     while (srcRecordChannel.hasNextTextRecord()) {
         string[] records = srcRecordChannel.nextTextRecord();
         dstRecordChannel.writeTextRecord(records);
@@ -19,8 +19,8 @@ function process (io:TextRecordChannel srcRecordChannel, io:TextRecordChannel ds
 function main (string[] args) {
     string srcFileName = "../samples/csvFileProcessor/files/sample.csv";
     string dstFileName = "../samples/csvFileProcessor/files/sampleResponse.txt";
-    io:TextRecordChannel srcRecordChannel = getFileRecordChannel(srcFileName, "r", "UTF-8", "\\r?\\n", ",");
-    io:TextRecordChannel dstRecordChannel = getFileRecordChannel(dstFileName, "w", "UTF-8", "\n", "|");
+    io:DelimitedRecordChannel srcRecordChannel = getFileRecordChannel(srcFileName, "r", "UTF-8", "\\r?\\n", ",");
+    io:DelimitedRecordChannel dstRecordChannel = getFileRecordChannel(dstFileName, "w", "UTF-8", "\n", "|");
     process(srcRecordChannel, dstRecordChannel);
     srcRecordChannel.closeTextRecordChannel();
     dstRecordChannel.closeTextRecordChannel();

--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/io/natives.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/io/natives.bal
@@ -8,7 +8,7 @@ public struct ByteChannel{
 public struct CharacterChannel{
 }
 
-@Description {value:"Ballerina TextRecordChannel represents a channel which will allow to read/write text records"}
+@Description {value:"Ballerina DelimitedRecordChannel represents a channel which will allow to read/write text records"}
 public struct DelimitedRecordChannel {
 }
 
@@ -28,7 +28,7 @@ public native function <CharacterChannel channel> toTextRecordChannel(string rec
 (DelimitedRecordChannel);
 
 @Description {value:"Function to read text records"}
-@Param {value:"channel: The TextRecordChannel to read text records from"}
+@Param {value:"channel: The DelimitedRecordChannel to read text records from"}
 @Return {value:"Fields listed in the record"}
 public native function <DelimitedRecordChannel channel> nextTextRecord () (string[]);
 
@@ -38,7 +38,7 @@ public native function <DelimitedRecordChannel channel> nextTextRecord () (strin
 public native function <DelimitedRecordChannel channel> writeTextRecord (string[] records);
 
 @Description{value:"Function to close the text record channel"}
-@Param {value:"channel: The TextRecordChannel to be closed"}
+@Param {value:"channel: The DelimitedRecordChannel to be closed"}
 public native function <DelimitedRecordChannel channel> closeDelimitedRecordChannel();
 
 @Description {value:"Function to read characters"}
@@ -85,6 +85,6 @@ public native function <ByteChannel channel> writeBytes(blob content,int startOf
 public native function <ByteChannel channel> close();
 
 @Description {value:"Function to check whether next record is available or not"}
-@Param {value:"channel: The TextRecordChannel to read text records from"}
+@Param {value:"channel: The DelimitedRecordChannel to read text records from"}
 @Return {value:"True if the channel has more records; false otherwise"}
 public native function <DelimitedRecordChannel channel> hasNextTextRecord () (boolean);

--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/io/natives.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/io/natives.bal
@@ -9,7 +9,7 @@ public struct CharacterChannel{
 }
 
 @Description {value:"Ballerina TextRecordChannel represents a channel which will allow to read/write text records"}
-public struct TextRecordChannel{
+public struct DelimitedRecordChannel {
 }
 
 @Description { value:"Function to convert a ByteChannel to CharacterChannel"}
@@ -18,28 +18,28 @@ public struct TextRecordChannel{
 @Return {value:"CharacterChannel converted from ByteChannel"}
 public native function <ByteChannel channel> toCharacterChannel(string encoding)(CharacterChannel);
 
-@Description {value:"Function to convert a CharacterChannel to TextRecordChannel"}
+@Description {value:"Function to convert a CharacterChannel to DelimitedRecordChannel"}
 @Param {value:"channel: The CharacterChannel to be converted"}
 @Param {value:"recordSeparator: Terminating expression to distinguish between records"}
 @Param {value:"fieldSeparator: Terminating expression to distinguish between fields"}
-@Return {value:"TextRecordChannel converted from CharacterChannel"}
+@Return {value:"DelimitedRecordChannel converted from CharacterChannel"}
 public native function <CharacterChannel channel> toTextRecordChannel(string recordSeparator,
                                                                       string fieldSeparator)
-(TextRecordChannel);
+(DelimitedRecordChannel);
 
 @Description {value:"Function to read text records"}
 @Param {value:"channel: The TextRecordChannel to read text records from"}
 @Return {value:"Fields listed in the record"}
-public native function <TextRecordChannel channel> nextTextRecord()(string []);
+public native function <DelimitedRecordChannel channel> nextTextRecord () (string[]);
 
 @Description {value:"Function to write text records"}
-@Param {value:"channel: The TextRecordChannel to write text records to"}
+@Param {value:"channel: The DelimitedRecordChannel to write records"}
 @Param {value:"records: Fields which are included in the record"}
-public native function <TextRecordChannel channel> writeTextRecord(string [] records);
+public native function <DelimitedRecordChannel channel> writeTextRecord (string[] records);
 
 @Description{value:"Function to close the text record channel"}
 @Param {value:"channel: The TextRecordChannel to be closed"}
-public native function <TextRecordChannel channel> closeTextRecordChannel();
+public native function <DelimitedRecordChannel channel> closeDelimitedRecordChannel();
 
 @Description {value:"Function to read characters"}
 @Param {value:"channel: The CharacterChannel to read characters from"}
@@ -87,4 +87,4 @@ public native function <ByteChannel channel> close();
 @Description {value:"Function to check whether next record is available or not"}
 @Param {value:"channel: The TextRecordChannel to read text records from"}
 @Return {value:"True if the channel has more records; false otherwise"}
-public native function <TextRecordChannel channel> hasNextTextRecord () (boolean);
+public native function <DelimitedRecordChannel channel> hasNextTextRecord () (boolean);

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CloseDelimitedRecordChannel.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CloseDelimitedRecordChannel.java
@@ -43,7 +43,7 @@ import org.ballerinalang.util.exceptions.BallerinaException;
 public class CloseDelimitedRecordChannel extends AbstractNativeFunction {
 
     /**
-     * The index of the TextRecordChannel in ballerina.io#closeTextRecordChannel().
+     * The index of the DelimitedRecordChannel in ballerina.io#closeDelimitedRecordChannel().
      */
     private static final int RECORD_CHANNEL_INDEX = 0;
 

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CloseDelimitedRecordChannel.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CloseDelimitedRecordChannel.java
@@ -21,7 +21,7 @@ import org.ballerinalang.bre.Context;
 import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
-import org.ballerinalang.nativeimpl.io.channels.base.TextRecordChannel;
+import org.ballerinalang.nativeimpl.io.channels.base.DelimitedRecordChannel;
 import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
@@ -34,11 +34,13 @@ import org.ballerinalang.util.exceptions.BallerinaException;
  */
 @BallerinaFunction(
         packageName = "ballerina.io",
-        functionName = "closeTextRecordChannel",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = "TextRecordChannel", structPackage = "ballerina.io"),
+        functionName = "closeDelimitedRecordChannel",
+        receiver = @Receiver(type = TypeKind.STRUCT,
+                structType = "DelimitedRecordChannel",
+                structPackage = "ballerina.io"),
         isPublic = true
 )
-public class CloseTextRecordChannel extends AbstractNativeFunction {
+public class CloseDelimitedRecordChannel extends AbstractNativeFunction {
 
     /**
      * The index of the TextRecordChannel in ballerina.io#closeTextRecordChannel().
@@ -57,7 +59,7 @@ public class CloseTextRecordChannel extends AbstractNativeFunction {
         BStruct channel;
         try {
             channel = (BStruct) getRefArgument(context, RECORD_CHANNEL_INDEX);
-            TextRecordChannel charChannel = (TextRecordChannel)
+            DelimitedRecordChannel charChannel = (DelimitedRecordChannel)
                     channel.getNativeData(IOConstants.TXT_RECORD_CHANNEL_NAME);
             charChannel.close();
         } catch (Throwable e) {

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/HasNextTextRecord.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/HasNextTextRecord.java
@@ -23,7 +23,7 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
-import org.ballerinalang.nativeimpl.io.channels.base.TextRecordChannel;
+import org.ballerinalang.nativeimpl.io.channels.base.DelimitedRecordChannel;
 import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
@@ -38,7 +38,9 @@ import org.ballerinalang.util.exceptions.BallerinaException;
 @BallerinaFunction(
         packageName = "ballerina.io",
         functionName = "hasNextTextRecord",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = "TextRecordChannel", structPackage = "ballerina.io"),
+        receiver = @Receiver(type = TypeKind.STRUCT,
+                structType = "DelimitedRecordChannel",
+                structPackage = "ballerina.io"),
         returnType = {@ReturnType(type = TypeKind.BOOLEAN)},
         isPublic = true
 )
@@ -56,8 +58,8 @@ public class HasNextTextRecord extends AbstractNativeFunction {
         BBoolean hasNext;
         BStruct channel = (BStruct) getRefArgument(context, TXT_RECORD_CHANNEL_INDEX);
         if (channel.getNativeData(IOConstants.TXT_RECORD_CHANNEL_NAME) != null) {
-            TextRecordChannel textRecordChannel =
-                    (TextRecordChannel) channel.getNativeData(IOConstants.TXT_RECORD_CHANNEL_NAME);
+            DelimitedRecordChannel textRecordChannel =
+                    (DelimitedRecordChannel) channel.getNativeData(IOConstants.TXT_RECORD_CHANNEL_NAME);
             hasNext = new BBoolean(textRecordChannel.hasNext());
         } else {
             String message = "Error occurred while checking the next record availability: Null channel returned.";

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/NextTextRecord.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/NextTextRecord.java
@@ -22,7 +22,7 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BStringArray;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
-import org.ballerinalang.nativeimpl.io.channels.base.TextRecordChannel;
+import org.ballerinalang.nativeimpl.io.channels.base.DelimitedRecordChannel;
 import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
@@ -37,7 +37,9 @@ import org.ballerinalang.util.exceptions.BallerinaException;
 @BallerinaFunction(
         packageName = "ballerina.io",
         functionName = "nextTextRecord",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = "TextRecordChannel", structPackage = "ballerina.io"),
+        receiver = @Receiver(type = TypeKind.STRUCT,
+                structType = "DelimitedRecordChannel",
+                structPackage = "ballerina.io"),
         returnType = {@ReturnType(type = TypeKind.ARRAY, elementType = TypeKind.STRING)},
         isPublic = true
 )
@@ -57,9 +59,9 @@ public class NextTextRecord extends AbstractNativeFunction {
         try {
             channel = (BStruct) getRefArgument(context, TXT_RECORD_CHANNEL_INDEX);
 
-            TextRecordChannel textRecordChannel = (TextRecordChannel) channel.getNativeData(IOConstants
+            DelimitedRecordChannel delimitedRecordChannel = (DelimitedRecordChannel) channel.getNativeData(IOConstants
                     .TXT_RECORD_CHANNEL_NAME);
-            String[] recordValue = textRecordChannel.read();
+            String[] recordValue = delimitedRecordChannel.read();
             record = new BStringArray(recordValue);
         } catch (Throwable e) {
             String message = "Error occurred while reading text records:" + e.getMessage();

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/ToTextRecordChannel.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/ToTextRecordChannel.java
@@ -23,7 +23,7 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.nativeimpl.io.channels.base.CharacterChannel;
-import org.ballerinalang.nativeimpl.io.channels.base.TextRecordChannel;
+import org.ballerinalang.nativeimpl.io.channels.base.DelimitedRecordChannel;
 import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
@@ -45,7 +45,7 @@ import org.ballerinalang.util.exceptions.BallerinaException;
         args = {@Argument(name = "recordSeparator", type = TypeKind.STRING),
                 @Argument(name = "fieldSeparator", type = TypeKind.STRING)},
         returnType = {@ReturnType(type = TypeKind.STRUCT,
-                structType = "TextRecordChannel",
+                structType = "DelimitedRecordChannel",
                 structPackage = "ballerina.io")},
         isPublic = true
 )
@@ -54,7 +54,7 @@ public class ToTextRecordChannel extends AbstractNativeFunction {
     /**
      * The index od the text record channel in ballerina.io#toTextRecordChannel().
      */
-    private static final int TXT_RECORD_CHANNEL_INDEX = 0;
+    private static final int RECORD_CHANNEL_INDEX = 0;
     /**
      * The index of the record channel separator in ballerina.io#toTextRecordChannel().
      */
@@ -70,11 +70,11 @@ public class ToTextRecordChannel extends AbstractNativeFunction {
     /**
      * The package path of the byte channel.
      */
-    private static final String TXT_RECORD_CHANNEL_PACKAGE = "ballerina.io";
+    private static final String RECORD_CHANNEL_PACKAGE = "ballerina.io";
     /**
      * The type of the byte channel.
      */
-    private static final String STRUCT_TYPE = "TextRecordChannel";
+    private static final String STRUCT_TYPE = "DelimitedRecordChannel";
 
     /**
      * Gets the struct related to AbstractChannel.
@@ -85,7 +85,7 @@ public class ToTextRecordChannel extends AbstractNativeFunction {
     private StructInfo getCharacterChannelStructInfo(Context context) {
         StructInfo result = textRecordChannelStructInfo;
         if (result == null) {
-            PackageInfo timePackageInfo = context.getProgramFile().getPackageInfo(TXT_RECORD_CHANNEL_PACKAGE);
+            PackageInfo timePackageInfo = context.getProgramFile().getPackageInfo(RECORD_CHANNEL_PACKAGE);
             textRecordChannelStructInfo = timePackageInfo.getStructInfo(STRUCT_TYPE);
         }
         return textRecordChannelStructInfo;
@@ -103,7 +103,7 @@ public class ToTextRecordChannel extends AbstractNativeFunction {
         String fieldSeparator;
         try {
             //File which holds access to the channel information
-            textRecordChannelInfo = (BStruct) getRefArgument(context, TXT_RECORD_CHANNEL_INDEX);
+            textRecordChannelInfo = (BStruct) getRefArgument(context, RECORD_CHANNEL_INDEX);
             recordSeparator = getStringArgument(context, RECORD_SEPARATOR_INDEX);
             fieldSeparator = getStringArgument(context, FIELD_SEPARATOR_INDEX);
 
@@ -112,7 +112,7 @@ public class ToTextRecordChannel extends AbstractNativeFunction {
             //Will get the relevant byte channel and will create a character channel
             CharacterChannel characterChannel = (CharacterChannel) textRecordChannelInfo.getNativeData(IOConstants
                     .CHARACTER_CHANNEL_NAME);
-            TextRecordChannel bCharacterChannel = new TextRecordChannel(characterChannel, recordSeparator,
+            DelimitedRecordChannel bCharacterChannel = new DelimitedRecordChannel(characterChannel, recordSeparator,
                     fieldSeparator);
             textRecordChannel.addNativeData(IOConstants.TXT_RECORD_CHANNEL_NAME, bCharacterChannel);
             bValues = getBValues(textRecordChannel);

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/WriteTextRecord.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/WriteTextRecord.java
@@ -22,7 +22,7 @@ import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BStringArray;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
-import org.ballerinalang.nativeimpl.io.channels.base.TextRecordChannel;
+import org.ballerinalang.nativeimpl.io.channels.base.DelimitedRecordChannel;
 import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
@@ -37,7 +37,9 @@ import org.ballerinalang.util.exceptions.BallerinaException;
 @BallerinaFunction(
         packageName = "ballerina.io",
         functionName = "writeTextRecord",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = "TextRecordChannel", structPackage = "ballerina.io"),
+        receiver = @Receiver(type = TypeKind.STRUCT,
+                structType = "DelimitedRecordChannel",
+                structPackage = "ballerina.io"),
         args = {@Argument(name = "content", type = TypeKind.ARRAY, elementType = TypeKind.STRING)},
         isPublic = true
 )
@@ -65,9 +67,9 @@ public class WriteTextRecord extends AbstractNativeFunction {
         try {
             channel = (BStruct) getRefArgument(context, RECORD_CHANNEL_INDEX);
             content = (BStringArray) getRefArgument(context, CONTENT_INDEX);
-            TextRecordChannel textRecordChannel = (TextRecordChannel) channel.getNativeData(IOConstants
+            DelimitedRecordChannel delimitedRecordChannel = (DelimitedRecordChannel) channel.getNativeData(IOConstants
                     .TXT_RECORD_CHANNEL_NAME);
-            textRecordChannel.write(content);
+            delimitedRecordChannel.write(content);
         } catch (Throwable e) {
             String message = "Error occurred while writing text record:" + e.getMessage();
             throw new BallerinaException(message, context);

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/AbstractChannel.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/AbstractChannel.java
@@ -42,7 +42,7 @@ import java.nio.channels.WritableByteChannel;
  *
  * @see Channel
  * @see CharacterChannel
- * @see TextRecordChannel
+ * @see DelimitedRecordChannel
  */
 public abstract class AbstractChannel {
 

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/DelimitedRecordChannel.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/DelimitedRecordChannel.java
@@ -37,7 +37,7 @@ import java.util.Arrays;
  * synchronous.
  * </p>
  */
-public class TextRecordChannel {
+public class DelimitedRecordChannel {
 
     /**
      * Distinguishes the Record.
@@ -80,10 +80,10 @@ public class TextRecordChannel {
      */
     private int numberOfRecordsWrittenToChannel = 0;
 
-    private static final Logger log = LoggerFactory.getLogger(TextRecordChannel.class);
+    private static final Logger log = LoggerFactory.getLogger(DelimitedRecordChannel.class);
 
 
-    public TextRecordChannel(CharacterChannel channel, String recordSeparator, String fieldSeparator) {
+    public DelimitedRecordChannel(CharacterChannel channel, String recordSeparator, String fieldSeparator) {
         this.recordSeparator = recordSeparator;
         this.fieldSeparator = fieldSeparator;
         this.channel = channel;

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/records/RecordInputOutputTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/records/RecordInputOutputTest.java
@@ -20,7 +20,7 @@ package org.ballerinalang.test.nativeimpl.functions.io.records;
 import org.ballerinalang.model.values.BStringArray;
 import org.ballerinalang.nativeimpl.io.channels.base.Channel;
 import org.ballerinalang.nativeimpl.io.channels.base.CharacterChannel;
-import org.ballerinalang.nativeimpl.io.channels.base.TextRecordChannel;
+import org.ballerinalang.nativeimpl.io.channels.base.DelimitedRecordChannel;
 import org.ballerinalang.test.nativeimpl.functions.io.MockByteChannel;
 import org.ballerinalang.test.nativeimpl.functions.io.util.TestUtil;
 import org.testng.Assert;
@@ -53,7 +53,7 @@ public class RecordInputOutputTest {
         ByteChannel byteChannel = TestUtil.openForReading("datafiles/io/records/sample.csv");
         Channel channel = new MockByteChannel(byteChannel, 0);
         CharacterChannel characterChannel = new CharacterChannel(channel, StandardCharsets.UTF_8.name());
-        TextRecordChannel recordChannel = new TextRecordChannel(characterChannel, "\n", ",");
+        DelimitedRecordChannel recordChannel = new DelimitedRecordChannel(characterChannel, "\n", ",");
 
         String[] readRecord = recordChannel.read();
         Assert.assertEquals(readRecord.length, expectedFieldCount);
@@ -77,7 +77,7 @@ public class RecordInputOutputTest {
         ByteChannel byteChannel = TestUtil.openForReading("datafiles/io/records/sample4.csv");
         Channel channel = new MockByteChannel(byteChannel, 0);
         CharacterChannel characterChannel = new CharacterChannel(channel, StandardCharsets.UTF_8.name());
-        TextRecordChannel recordChannel = new TextRecordChannel(characterChannel, "\n", ",");
+        DelimitedRecordChannel recordChannel = new DelimitedRecordChannel(characterChannel, "\n", ",");
 
         String[] readRecord = recordChannel.read();
         Assert.assertEquals(readRecord.length, expectedFieldCount);
@@ -92,7 +92,7 @@ public class RecordInputOutputTest {
         ByteChannel byteChannel = TestUtil.openForReading("datafiles/io/records/sample2.csv");
         Channel channel = new MockByteChannel(byteChannel, 0);
         CharacterChannel characterChannel = new CharacterChannel(channel, StandardCharsets.UTF_8.name());
-        TextRecordChannel recordChannel = new TextRecordChannel(characterChannel, "\n", ",");
+        DelimitedRecordChannel recordChannel = new DelimitedRecordChannel(characterChannel, "\n", ",");
 
         String[] readRecord = recordChannel.read();
         Assert.assertEquals(readRecord.length, 9);
@@ -117,7 +117,7 @@ public class RecordInputOutputTest {
         ByteChannel byteChannel = TestUtil.openForWriting(currentDirectoryPath + "records.csv");
         Channel channel = new MockByteChannel(byteChannel, 0);
         CharacterChannel characterChannel = new CharacterChannel(channel, StandardCharsets.UTF_8.name());
-        TextRecordChannel recordChannel = new TextRecordChannel(characterChannel, "\n", ",");
+        DelimitedRecordChannel recordChannel = new DelimitedRecordChannel(characterChannel, "\n", ",");
 
         String[] recordOne = {"Foo", "Bar", "911"};
         BStringArray recordOneArr = new BStringArray(recordOne);

--- a/tests/ballerina-test/src/test/resources/test-src/io/recordio.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/recordio.bal
@@ -1,28 +1,28 @@
 import ballerina.file;
 import ballerina.io;
 
-io:TextRecordChannel textRecordChannel;
+io:DelimitedRecordChannel delimitedRecordChannel;
 
 function initFileChannel(string filePath,string permission,string encoding,string rs,string fs){
     file:File src = {path:filePath};
     io:ByteChannel channel = src.openChannel(permission);
     io:CharacterChannel  characterChannel = channel.toCharacterChannel(encoding);
-    textRecordChannel = characterChannel.toTextRecordChannel(rs,fs);
+    delimitedRecordChannel = characterChannel.toTextRecordChannel(rs, fs);
 }
 
 function nextRecord () (string[]) {
-    string[] fields = textRecordChannel.nextTextRecord();
+    string[] fields = delimitedRecordChannel.nextTextRecord();
     return fields;
 }
 
 function writeRecord (string[] fields) {
-    textRecordChannel.writeTextRecord(fields);
+    delimitedRecordChannel.writeTextRecord(fields);
 }
 
 function close(){
-    textRecordChannel.closeTextRecordChannel();
+    delimitedRecordChannel.closeDelimitedRecordChannel();
 }
 
 function hasNextRecord () (boolean) {
-    return textRecordChannel.hasNextTextRecord();
+    return delimitedRecordChannel.hasNextTextRecord();
 }


### PR DESCRIPTION
## Purpose
Fixes the issue described in #4715. TextRecordChannel conveys a generic meaning, there will be other channels i.e CSVProcessingChannel which will also be processing content as text. Hence the name will be changed to bring out a better meaning.  

## Goals
- Rename, the existing TextRecordChannel to DelimitedRecordChannel.
- Changed the relevant test cases
- Changed the relevant samples

## Approach

Introduced the following native function,

```
public native function <DelimitedRecordChannel channel> nextTextRecord () (string[]);

public native function <DelimitedRecordChannel channel> writeTextRecord (string[] records);

public native function <DelimitedRecordChannel channel> closeDelimitedRecordChannel();
```

## User stories
N/A

## Release note
Changes the TextRecordChannel to DelimitedRecordChannel

## Documentation
https://ballerinalang.org/docs/api/0.961.0/ballerina.io.html#TextRecordChannel
The function will be renamed to DelimitedRecordChannel

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
The relevant test cases which were there previously were changed to use DelimitedRecordChannel  

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
The relevant samples which used the TextRecordChannel were changed to use DelimitedRecordChannel 

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK 1.8
 
## Learning
N/A