### PR TITLE
References feature

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
@@ -60,6 +60,7 @@ public class BallerinaLanguageServer implements LanguageServer, LanguageClientAw
         res.getCapabilities().setHoverProvider(true);
         res.getCapabilities().setDocumentSymbolProvider(true);
         res.getCapabilities().setDefinitionProvider(true);
+        res.getCapabilities().setReferencesProvider(true);
 
         return CompletableFuture.supplyAsync(() -> res);
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -212,7 +212,6 @@ public class BallerinaTextDocumentService implements TextDocumentService {
     @Override
     public CompletableFuture<List<? extends Location>> references(ReferenceParams params) {
         return CompletableFuture.supplyAsync(() -> {
-            ReferenceParams ref = params;
             TextDocumentServiceContext referenceContext = new TextDocumentServiceContext();
             referenceContext.put(DocumentServiceKeys.FILE_URI_KEY, params.getTextDocument().getUri());
             referenceContext.put(DocumentServiceKeys.POSITION_KEY, params);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -228,7 +228,7 @@ public class BallerinaTextDocumentService implements TextDocumentService {
                 currentBLangPackage.accept(positionTreeVisitor);
                 contents = ReferenceUtil.getReferences(referenceContext, bLangPackageContext);
             } catch (Exception e) {
-                contents = new ArrayList<>();
+                // Ignore
             }
 
             return contents;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.langserver;
 
+import org.ballerinalang.langserver.common.constants.NodeContextKeys;
 import org.ballerinalang.langserver.common.position.PositionTreeVisitor;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.TreeVisitor;
@@ -22,6 +23,7 @@ import org.ballerinalang.langserver.completions.resolvers.TopLevelResolver;
 import org.ballerinalang.langserver.completions.util.CompletionItemResolver;
 import org.ballerinalang.langserver.definition.util.DefinitionUtil;
 import org.ballerinalang.langserver.hover.util.HoverUtil;
+import org.ballerinalang.langserver.references.util.ReferenceUtil;
 import org.ballerinalang.langserver.signature.SignatureHelpUtil;
 import org.ballerinalang.langserver.signature.SignatureTreeVisitor;
 import org.ballerinalang.langserver.symbols.SymbolFindingVisitor;
@@ -209,7 +211,28 @@ public class BallerinaTextDocumentService implements TextDocumentService {
 
     @Override
     public CompletableFuture<List<? extends Location>> references(ReferenceParams params) {
-        return CompletableFuture.supplyAsync(() -> null);
+        return CompletableFuture.supplyAsync(() -> {
+            ReferenceParams ref = params;
+            TextDocumentServiceContext referenceContext = new TextDocumentServiceContext();
+            referenceContext.put(DocumentServiceKeys.FILE_URI_KEY, params.getTextDocument().getUri());
+            referenceContext.put(DocumentServiceKeys.POSITION_KEY, params);
+
+            BLangPackage currentBLangPackage =
+                    TextDocumentServiceUtil.getBLangPackage(referenceContext, documentManager);
+            bLangPackageContext.addPackage(currentBLangPackage);
+
+            List<Location> contents = new ArrayList<>();
+            referenceContext.put(NodeContextKeys.REFERENCE_NODES_KEY, contents);
+            try {
+                PositionTreeVisitor positionTreeVisitor = new PositionTreeVisitor(referenceContext);
+                currentBLangPackage.accept(positionTreeVisitor);
+                contents = ReferenceUtil.getReferences(referenceContext, bLangPackageContext);
+            } catch (Exception e) {
+                contents = new ArrayList<>();
+            }
+
+            return contents;
+        });
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/NodeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/NodeVisitor.java
@@ -1,3 +1,20 @@
+/*
+*  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
 package org.ballerinalang.langserver.common;
 
 import org.wso2.ballerinalang.compiler.tree.BLangAction;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/NodeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/NodeVisitor.java
@@ -1,0 +1,572 @@
+package org.ballerinalang.langserver.common;
+
+import org.wso2.ballerinalang.compiler.tree.BLangAction;
+import org.wso2.ballerinalang.compiler.tree.BLangAnnotAttribute;
+import org.wso2.ballerinalang.compiler.tree.BLangAnnotation;
+import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
+import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
+import org.wso2.ballerinalang.compiler.tree.BLangConnector;
+import org.wso2.ballerinalang.compiler.tree.BLangEnum;
+import org.wso2.ballerinalang.compiler.tree.BLangFunction;
+import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
+import org.wso2.ballerinalang.compiler.tree.BLangImportPackage;
+import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
+import org.wso2.ballerinalang.compiler.tree.BLangPackage;
+import org.wso2.ballerinalang.compiler.tree.BLangPackageDeclaration;
+import org.wso2.ballerinalang.compiler.tree.BLangResource;
+import org.wso2.ballerinalang.compiler.tree.BLangService;
+import org.wso2.ballerinalang.compiler.tree.BLangStruct;
+import org.wso2.ballerinalang.compiler.tree.BLangTransformer;
+import org.wso2.ballerinalang.compiler.tree.BLangVariable;
+import org.wso2.ballerinalang.compiler.tree.BLangWorker;
+import org.wso2.ballerinalang.compiler.tree.BLangXMLNS;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangAnnotAttachmentAttribute;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangAnnotAttachmentAttributeValue;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangArrayLiteral;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangBinaryExpr;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangConnectorInit;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangIntRangeExpression;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangSimpleVarRef;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangStringTemplateLiteral;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangTernaryExpr;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeCastExpr;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeConversionExpr;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeofExpr;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangUnaryExpr;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLAttribute;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLAttributeAccess;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLCommentLiteral;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLElementLiteral;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLProcInsLiteral;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLQName;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLQuotedString;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLTextLiteral;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangAbort;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangAssignment;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangBind;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangBlockStmt;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangBreak;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangCatch;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangExpressionStmt;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangForeach;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangForkJoin;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangIf;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangLock;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangNext;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangReturn;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangThrow;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangTransaction;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangTryCatchFinally;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangVariableDef;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangWhile;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangWorkerReceive;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangWorkerSend;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangXMLNSStatement;
+import org.wso2.ballerinalang.compiler.tree.types.BLangArrayType;
+import org.wso2.ballerinalang.compiler.tree.types.BLangBuiltInRefTypeNode;
+import org.wso2.ballerinalang.compiler.tree.types.BLangConstrainedType;
+import org.wso2.ballerinalang.compiler.tree.types.BLangEndpointTypeNode;
+import org.wso2.ballerinalang.compiler.tree.types.BLangFunctionTypeNode;
+import org.wso2.ballerinalang.compiler.tree.types.BLangUserDefinedType;
+import org.wso2.ballerinalang.compiler.tree.types.BLangValueType;
+
+/**
+ * Common node visitor to override and remove assertion errors from BLangNodeVisitor methods.
+ */
+public class NodeVisitor extends BLangNodeVisitor {
+    @Override
+    public void visit(BLangPackage pkgNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangCompilationUnit compUnit) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangPackageDeclaration pkgDclNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangImportPackage importPkgNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangXMLNS xmlnsNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangFunction funcNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangService serviceNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangResource resourceNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangConnector connectorNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangAction actionNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangStruct structNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangEnum enumNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangEnum.BLangEnumerator enumeratorNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangVariable varNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangWorker workerNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangIdentifier identifierNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangAnnotation annotationNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangAnnotAttribute annotationAttribute) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangAnnotationAttachment annAttachmentNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangAnnotAttachmentAttributeValue annotAttributeValue) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangAnnotAttachmentAttribute annotAttachmentAttribute) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangTransformer transformerNode) {
+        // No implementation
+    }
+
+    // Statements
+
+    @Override
+    public void visit(BLangBlockStmt blockNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangVariableDef varDefNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangAssignment assignNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangBind bindNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangAbort abortNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangNext nextNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangBreak breakNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangReturn returnNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangReturn.BLangWorkerReturn returnNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangThrow throwNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangXMLNSStatement xmlnsStmtNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangExpressionStmt exprStmtNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangIf ifNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangForeach foreach) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangWhile whileNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangLock lockNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangTransaction transactionNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangTryCatchFinally tryNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangCatch catchNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangForkJoin forkJoin) {
+        // No implementation
+    }
+
+
+    // Expressions
+
+    @Override
+    public void visit(BLangLiteral literalExpr) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangArrayLiteral arrayLiteral) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangRecordLiteral recordLiteral) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangSimpleVarRef varRefExpr) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangFieldBasedAccess fieldAccessExpr) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangIndexBasedAccess indexAccessExpr) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangInvocation invocationExpr) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangConnectorInit connectorInitExpr) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangInvocation.BLangActionInvocation actionInvocationExpr) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangTernaryExpr ternaryExpr) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangBinaryExpr binaryExpr) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangUnaryExpr unaryExpr) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangTypeofExpr accessExpr) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangTypeCastExpr castExpr) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangTypeConversionExpr conversionExpr) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangXMLQName xmlQName) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangXMLAttribute xmlAttribute) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangXMLElementLiteral xmlElementLiteral) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangXMLTextLiteral xmlTextLiteral) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangXMLCommentLiteral xmlCommentLiteral) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangXMLProcInsLiteral xmlProcInsLiteral) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangXMLQuotedString xmlQuotedString) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangStringTemplateLiteral stringTemplateLiteral) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangWorkerSend workerSendNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangWorkerReceive workerReceiveNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangLambdaFunction bLangLambdaFunction) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangXMLAttributeAccess xmlAttributeAccessExpr) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangIntRangeExpression intRangeExpression) {
+        // No implementation
+    }
+
+    // Type nodes
+
+    @Override
+    public void visit(BLangValueType valueType) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangArrayType arrayType) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangBuiltInRefTypeNode builtInRefType) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangEndpointTypeNode endpointType) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangConstrainedType constrainedType) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangUserDefinedType userDefinedType) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangFunctionTypeNode functionTypeNode) {
+        // No implementation
+    }
+
+
+    // expressions that will used only from the Desugar phase
+
+    @Override
+    public void visit(BLangSimpleVarRef.BLangLocalVarRef localVarRef) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangSimpleVarRef.BLangFieldVarRef fieldVarRef) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangSimpleVarRef.BLangPackageVarRef packageVarRef) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangSimpleVarRef.BLangFunctionVarRef functionVarRef) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangFieldBasedAccess.BLangStructFieldAccessExpr fieldAccessExpr) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangIndexBasedAccess.BLangMapAccessExpr mapKeyAccessExpr) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangIndexBasedAccess.BLangArrayAccessExpr arrayIndexAccessExpr) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangIndexBasedAccess.BLangXMLAccessExpr xmlIndexAccessExpr) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangRecordLiteral.BLangJSONLiteral jsonLiteral) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangRecordLiteral.BLangMapLiteral mapLiteral) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangRecordLiteral.BLangStructLiteral structLiteral) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangInvocation.BFunctionPointerInvocation bFunctionPointerInvocation) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangInvocation.BLangAttachedFunctionInvocation iExpr) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangInvocation.BLangTransformerInvocation iExpr) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangArrayLiteral.BLangJSONArrayLiteral jsonArrayLiteral) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangIndexBasedAccess.BLangJSONAccessExpr jsonAccessExpr) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangXMLNS.BLangLocalXMLNS xmlnsNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangXMLNS.BLangPackageXMLNS xmlnsNode) {
+        // No implementation
+    }
+
+    @Override
+    public void visit(BLangFieldBasedAccess.BLangEnumeratorAccessExpr enumeratorAccessExpr) {
+        // No implementation
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/ContextConstants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/ContextConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/NodeContextKeys.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/NodeContextKeys.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,8 +17,10 @@ package org.ballerinalang.langserver.common.constants;
 
 import org.ballerinalang.langserver.LanguageServerContext;
 import org.ballerinalang.model.elements.PackageID;
+import org.eclipse.lsp4j.Location;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
 
+import java.util.List;
 import java.util.Stack;
 
 /**
@@ -44,5 +46,7 @@ public class NodeContextKeys {
     public static final LanguageServerContext.Key<String> SYMBOL_KIND_OF_NODE_KEY
             = new LanguageServerContext.Key<>();
     public static final LanguageServerContext.Key<String> VAR_NAME_OF_NODE_KEY
+            = new LanguageServerContext.Key<>();
+    public static final LanguageServerContext.Key<List<Location>> REFERENCE_NODES_KEY
             = new LanguageServerContext.Key<>();
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/position/PositionTreeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/position/PositionTreeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,7 @@ package org.ballerinalang.langserver.common.position;
 
 import org.ballerinalang.langserver.DocumentServiceKeys;
 import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.common.NodeVisitor;
 import org.ballerinalang.langserver.common.constants.ContextConstants;
 import org.ballerinalang.langserver.common.constants.NodeContextKeys;
 import org.ballerinalang.langserver.hover.util.HoverUtil;
@@ -30,88 +31,52 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BEndpointType;
 import org.wso2.ballerinalang.compiler.tree.BLangAction;
-import org.wso2.ballerinalang.compiler.tree.BLangAnnotAttribute;
-import org.wso2.ballerinalang.compiler.tree.BLangAnnotation;
-import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
-import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
 import org.wso2.ballerinalang.compiler.tree.BLangConnector;
-import org.wso2.ballerinalang.compiler.tree.BLangEnum;
 import org.wso2.ballerinalang.compiler.tree.BLangFunction;
-import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
 import org.wso2.ballerinalang.compiler.tree.BLangImportPackage;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
-import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
-import org.wso2.ballerinalang.compiler.tree.BLangPackageDeclaration;
 import org.wso2.ballerinalang.compiler.tree.BLangResource;
 import org.wso2.ballerinalang.compiler.tree.BLangService;
 import org.wso2.ballerinalang.compiler.tree.BLangStruct;
 import org.wso2.ballerinalang.compiler.tree.BLangTransformer;
 import org.wso2.ballerinalang.compiler.tree.BLangVariable;
 import org.wso2.ballerinalang.compiler.tree.BLangWorker;
-import org.wso2.ballerinalang.compiler.tree.BLangXMLNS;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangAnnotAttachmentAttribute;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangAnnotAttachmentAttributeValue;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangArrayLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangBinaryExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangConnectorInit;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangSimpleVarRef;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangStringTemplateLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangTernaryExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeCastExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeConversionExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeofExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangUnaryExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLAttribute;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLAttributeAccess;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLCommentLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLElementLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLProcInsLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLQName;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLQuotedString;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLTextLiteral;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangAbort;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangAssignment;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangBind;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangBlockStmt;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangBreak;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangCatch;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangExpressionStmt;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangForeach;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangForkJoin;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangIf;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangNext;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangReturn;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangThrow;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangTransaction;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangTryCatchFinally;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangVariableDef;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangWhile;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangWorkerReceive;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangWorkerSend;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangXMLNSStatement;
 import org.wso2.ballerinalang.compiler.tree.types.BLangArrayType;
-import org.wso2.ballerinalang.compiler.tree.types.BLangBuiltInRefTypeNode;
-import org.wso2.ballerinalang.compiler.tree.types.BLangConstrainedType;
 import org.wso2.ballerinalang.compiler.tree.types.BLangEndpointTypeNode;
-import org.wso2.ballerinalang.compiler.tree.types.BLangFunctionTypeNode;
 import org.wso2.ballerinalang.compiler.tree.types.BLangUserDefinedType;
-import org.wso2.ballerinalang.compiler.tree.types.BLangValueType;
 
 import java.util.List;
 import java.util.Stack;
 import java.util.stream.Collectors;
 
 /**
- * Tree visitor for the get the node at the given position.
+ * Tree visitor for finding the node at the given position.
  */
-public class PositionTreeVisitor extends BLangNodeVisitor {
+public class PositionTreeVisitor extends NodeVisitor {
 
     private String fileName;
     private Position position;
@@ -151,15 +116,22 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
         acceptNode(pkgEnv.node);
     }
 
-    public void visit(BLangXMLNS xmlnsNode) {
-        // No implementation
-    }
-
     public void visit(BLangFunction funcNode) {
         // Check for native functions
         BSymbol funcSymbol = funcNode.symbol;
         if (Symbols.isNative(funcSymbol)) {
             return;
+        }
+
+        if (funcNode.getPosition().sLine == this.position.getLine() && funcNode.getPosition().sCol == 1) {
+            this.context.put(NodeContextKeys.NODE_KEY, funcNode);
+            this.context.put(NodeContextKeys.PREVIOUSLY_VISITED_NODE_KEY, this.previousNode);
+            this.context.put(NodeContextKeys.NAME_OF_NODE_KEY, funcNode.name.getValue());
+            this.context.put(NodeContextKeys.PACKAGE_OF_NODE_KEY, funcNode.symbol.pkgID);
+            this.context.put(NodeContextKeys.SYMBOL_KIND_OF_NODE_PARENT_KEY, funcNode.symbol.kind.name());
+            this.context.put(NodeContextKeys.SYMBOL_KIND_OF_NODE_KEY, funcNode.symbol.kind.name());
+            this.context.put(NodeContextKeys.NODE_OWNER_KEY, funcNode.symbol.owner.name.getValue());
+            this.context.put(NodeContextKeys.NODE_OWNER_PACKAGE_KEY, funcNode.symbol.owner.pkgID);
         }
 
         previousNode = funcNode;
@@ -199,20 +171,9 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
             this.context.put(NodeContextKeys.SYMBOL_KIND_OF_NODE_PARENT_KEY, userDefinedType.type.tsymbol.kind.name());
             this.context.put(NodeContextKeys.SYMBOL_KIND_OF_NODE_KEY, userDefinedType.type.tsymbol.kind.name());
             this.context.put(NodeContextKeys.NODE_OWNER_KEY, userDefinedType.type.tsymbol.owner.name.getValue());
-            this.context.put(NodeContextKeys.NODE_OWNER_PACKAGE_KEY,
-                    userDefinedType.type.tsymbol.owner.pkgID);
+            this.context.put(NodeContextKeys.NODE_OWNER_PACKAGE_KEY, userDefinedType.type.tsymbol.owner.pkgID);
             terminateVisitor = true;
         }
-    }
-
-    @Override
-    public void visit(BLangEnum enumNode) {
-        // No implementation
-    }
-
-    @Override
-    public void visit(BLangAnnotation annotationNode) {
-        // No implementation
     }
 
     @Override
@@ -225,11 +186,6 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
         if (varNode.getTypeNode() != null) {
             this.acceptNode(varNode.getTypeNode());
         }
-    }
-
-    @Override
-    public void visit(BLangLiteral litNode) {
-        // No implementation
     }
 
     @Override
@@ -266,14 +222,18 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
             this.context.put(NodeContextKeys.PACKAGE_OF_NODE_KEY, varRefExpr.type.tsymbol.pkgID);
             this.context.put(NodeContextKeys.SYMBOL_KIND_OF_NODE_PARENT_KEY, varRefExpr.type.tsymbol.kind.name());
             this.context.put(NodeContextKeys.SYMBOL_KIND_OF_NODE_KEY, ContextConstants.VARIABLE);
+            this.context.put(NodeContextKeys.VAR_NAME_OF_NODE_KEY, varRefExpr.variableName.getValue());
+
             if (varRefExpr.symbol != null) {
                 this.context.put(NodeContextKeys.NODE_OWNER_KEY, varRefExpr.symbol.owner.name.getValue());
                 this.context.put(NodeContextKeys.NODE_OWNER_PACKAGE_KEY,
                         varRefExpr.symbol.owner.pkgID);
-                this.context.put(NodeContextKeys.VAR_NAME_OF_NODE_KEY, varRefExpr.variableName.getValue());
                 this.context.put(NodeContextKeys.SYMBOL_KIND_OF_NODE_KEY, ContextConstants.VARIABLE);
             } else {
                 this.context.put(NodeContextKeys.SYMBOL_KIND_OF_NODE_KEY, varRefExpr.type.tsymbol.kind.name());
+                this.context.put(NodeContextKeys.NODE_OWNER_KEY, varRefExpr.type.tsymbol.owner.name.getValue());
+                this.context.put(NodeContextKeys.NODE_OWNER_PACKAGE_KEY,
+                        varRefExpr.type.tsymbol.owner.pkgID);
             }
             terminateVisitor = true;
         } else if (varRefExpr.pkgSymbol != null
@@ -292,11 +252,6 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
             }
             terminateVisitor = true;
         }
-    }
-
-    @Override
-    public void visit(BLangRecordLiteral recordLiteral) {
-        // No implementation
     }
 
     @Override
@@ -464,6 +419,17 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
     }
 
     public void visit(BLangResource resourceNode) {
+        if (resourceNode.getPosition().sLine == this.position.getLine()) {
+            this.context.put(NodeContextKeys.NODE_KEY, resourceNode);
+            this.context.put(NodeContextKeys.PREVIOUSLY_VISITED_NODE_KEY, this.previousNode);
+            this.context.put(NodeContextKeys.NAME_OF_NODE_KEY, resourceNode.name.getValue());
+            this.context.put(NodeContextKeys.PACKAGE_OF_NODE_KEY, resourceNode.symbol.pkgID);
+            this.context.put(NodeContextKeys.SYMBOL_KIND_OF_NODE_PARENT_KEY, resourceNode.symbol.kind.name());
+            this.context.put(NodeContextKeys.SYMBOL_KIND_OF_NODE_KEY, resourceNode.symbol.kind.name());
+            this.context.put(NodeContextKeys.NODE_OWNER_KEY, resourceNode.symbol.owner.name.getValue());
+            this.context.put(NodeContextKeys.NODE_OWNER_PACKAGE_KEY, resourceNode.symbol.owner.pkgID);
+        }
+
         previousNode = resourceNode;
         this.addToNodeStack(resourceNode);
 
@@ -522,11 +488,6 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
         if (transactionNode.retryCount != null) {
             acceptNode(transactionNode.retryCount);
         }
-    }
-
-    @Override
-    public void visit(BLangAbort abortNode) {
-        // No implementation
     }
 
     @Override
@@ -602,10 +563,6 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
         }
     }
 
-    public void visit(BLangNext nextNode) {
-        // No implementation
-    }
-
     public void visit(BLangInvocation invocationExpr) {
         previousNode = invocationExpr;
         if (invocationExpr.expr != null) {
@@ -646,68 +603,11 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
         }
     }
 
-
-    public void visit(BLangCompilationUnit compUnit) {
-        // No implementation
-    }
-
-    public void visit(BLangPackageDeclaration pkgDclNode) {
-        // No implementation
-    }
-
-    public void visit(BLangEnum.BLangEnumerator enumeratorNode) {
-        // No implementation
-    }
-
-    public void visit(BLangIdentifier identifierNode) {
-        // No implementation
-    }
-
-    public void visit(BLangAnnotAttribute annotationAttribute) {
-        // No implementation
-    }
-
-    public void visit(BLangAnnotationAttachment annAttachmentNode) {
-        // No implementation
-    }
-
-    public void visit(BLangAnnotAttachmentAttributeValue annotAttributeValue) {
-        // No implementation
-    }
-
-    public void visit(BLangAnnotAttachmentAttribute annotAttachmentAttribute) {
-        // No implementation
-    }
-
-    public void visit(BLangBind bindNode) {
-        // No implementation
-    }
-
-    public void visit(BLangBreak breakNode) {
-        // No implementation
-    }
-
-    public void visit(BLangReturn.BLangWorkerReturn returnNode) {
-        // No implementation
-    }
-
-    public void visit(BLangThrow throwNode) {
-        // No implementation
-    }
-
-    public void visit(BLangXMLNSStatement xmlnsStmtNode) {
-        // No implementation
-    }
-
     public void visit(BLangArrayLiteral arrayLiteral) {
         previousNode = arrayLiteral;
         if (!arrayLiteral.exprs.isEmpty()) {
             arrayLiteral.exprs.forEach(this::acceptNode);
         }
-    }
-
-    public void visit(BLangIndexBasedAccess indexAccessExpr) {
-        // No implementation
     }
 
     public void visit(BLangConnectorInit connectorInitExpr) {
@@ -720,22 +620,6 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
         if (!connectorInitExpr.argsExpr.isEmpty()) {
             connectorInitExpr.argsExpr.forEach(this::acceptNode);
         }
-    }
-
-    public void visit(BLangInvocation.BLangActionInvocation actionInvocationExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangTernaryExpr ternaryExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangUnaryExpr unaryExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangTypeofExpr accessExpr) {
-        // No implementation
     }
 
     public void visit(BLangTypeCastExpr castExpr) {
@@ -765,52 +649,12 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
         }
     }
 
-    public void visit(BLangXMLQName xmlQName) {
-        // No implementation
-    }
-
-    public void visit(BLangXMLAttribute xmlAttribute) {
-        // No implementation
-    }
-
-    public void visit(BLangXMLElementLiteral xmlElementLiteral) {
-        // No implementation
-    }
-
-    public void visit(BLangXMLTextLiteral xmlTextLiteral) {
-        // No implementation
-    }
-
-    public void visit(BLangXMLCommentLiteral xmlCommentLiteral) {
-        // No implementation
-    }
-
-    public void visit(BLangXMLProcInsLiteral xmlProcInsLiteral) {
-        // No implementation
-    }
-
-    public void visit(BLangXMLQuotedString xmlQuotedString) {
-        // No implementation
-    }
-
     public void visit(BLangStringTemplateLiteral stringTemplateLiteral) {
         previousNode = stringTemplateLiteral;
 
         if (!stringTemplateLiteral.exprs.isEmpty()) {
             stringTemplateLiteral.exprs.forEach(this::acceptNode);
         }
-    }
-
-    public void visit(BLangLambdaFunction bLangLambdaFunction) {
-        // No implementation
-    }
-
-    public void visit(BLangXMLAttributeAccess xmlAttributeAccessExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangValueType valueType) {
-        // No implementation
     }
 
     public void visit(BLangArrayType arrayType) {
@@ -820,99 +664,11 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
         }
     }
 
-    public void visit(BLangBuiltInRefTypeNode builtInRefType) {
-        // No implementation
-    }
-
     public void visit(BLangEndpointTypeNode endpointType) {
         previousNode = endpointType;
         if (endpointType.constraint != null) {
             acceptNode(endpointType.constraint);
         }
-    }
-
-    public void visit(BLangConstrainedType constrainedType) {
-        // No implementation
-    }
-
-    public void visit(BLangFunctionTypeNode functionTypeNode) {
-        // No implementation
-    }
-
-    public void visit(BLangSimpleVarRef.BLangLocalVarRef localVarRef) {
-        // No implementation
-    }
-
-    public void visit(BLangSimpleVarRef.BLangFieldVarRef fieldVarRef) {
-        // No implementation
-    }
-
-    public void visit(BLangSimpleVarRef.BLangPackageVarRef packageVarRef) {
-        // No implementation
-    }
-
-    public void visit(BLangSimpleVarRef.BLangFunctionVarRef functionVarRef) {
-        // No implementation
-    }
-
-    public void visit(BLangFieldBasedAccess.BLangStructFieldAccessExpr fieldAccessExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangIndexBasedAccess.BLangMapAccessExpr mapKeyAccessExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangIndexBasedAccess.BLangArrayAccessExpr arrayIndexAccessExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangIndexBasedAccess.BLangXMLAccessExpr xmlIndexAccessExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangRecordLiteral.BLangJSONLiteral jsonLiteral) {
-        // No implementation
-    }
-
-    public void visit(BLangRecordLiteral.BLangMapLiteral mapLiteral) {
-        // No implementation
-    }
-
-    public void visit(BLangRecordLiteral.BLangStructLiteral structLiteral) {
-        // No implementation
-    }
-
-    public void visit(BLangInvocation.BFunctionPointerInvocation bFunctionPointerInvocation) {
-        // No implementation
-    }
-
-    public void visit(BLangInvocation.BLangAttachedFunctionInvocation iExpr) {
-
-    }
-
-    public void visit(BLangInvocation.BLangTransformerInvocation iExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangArrayLiteral.BLangJSONArrayLiteral jsonArrayLiteral) {
-        // No implementation
-    }
-
-    public void visit(BLangIndexBasedAccess.BLangJSONAccessExpr jsonAccessExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangXMLNS.BLangLocalXMLNS xmlnsNode) {
-        // No implementation
-    }
-
-    public void visit(BLangXMLNS.BLangPackageXMLNS xmlnsNode) {
-        // No implementation
-    }
-
-    public void visit(BLangFieldBasedAccess.BLangEnumeratorAccessExpr enumeratorAccessExpr) {
-        // No implementation
     }
 
     /**
@@ -931,7 +687,7 @@ public class PositionTreeVisitor extends BLangNodeVisitor {
      * Add node in to a stack to track the visited nodes.
      *
      * @param node BLangNode to be added to the stack
-     * */
+     */
     private void addToNodeStack(BLangNode node) {
         if (!terminateVisitor) {
             if (!this.nodeStack.empty()) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.common.utils;
+
+import org.wso2.ballerinalang.compiler.util.Name;
+
+import java.nio.file.Paths;
+import java.util.List;
+
+/**
+ * Common utils to be reuse in language server implementation.
+ * */
+public class CommonUtil {
+    /**
+     * Get the package URI to the given package name.
+     *
+     * @param pkgName        Name of the package that need the URI for
+     * @param currentPkgPath String URI of the current package
+     * @param currentPkgName Name of the current package
+     * @return String URI for the given path.
+     */
+    public static String getPackageURI(List<Name> pkgName, String currentPkgPath, List<Name> currentPkgName) {
+        String newPackagePath;
+        // If current package path is not null and current package is not default package continue,
+        // else new package path is same as the current package path.
+        if (currentPkgPath != null && !currentPkgName.get(0).getValue().equals(".")) {
+            int indexOfCurrentPkgName = currentPkgPath.indexOf(currentPkgName.get(0).getValue());
+            newPackagePath = currentPkgPath.substring(0, indexOfCurrentPkgName);
+            for (Name pkgDir : pkgName) {
+                newPackagePath = Paths.get(newPackagePath, pkgDir.getValue()).toString();
+            }
+        } else {
+            newPackagePath = currentPkgPath;
+        }
+        return newPackagePath;
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/definition/DefinitionTreeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/definition/DefinitionTreeVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,85 +18,32 @@ package org.ballerinalang.langserver.definition;
 
 import org.ballerinalang.langserver.DocumentServiceKeys;
 import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.common.NodeVisitor;
 import org.ballerinalang.langserver.common.constants.NodeContextKeys;
 import org.ballerinalang.model.tree.TopLevelNode;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.tree.BLangAction;
-import org.wso2.ballerinalang.compiler.tree.BLangAnnotAttribute;
-import org.wso2.ballerinalang.compiler.tree.BLangAnnotation;
-import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
-import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
 import org.wso2.ballerinalang.compiler.tree.BLangConnector;
-import org.wso2.ballerinalang.compiler.tree.BLangEnum;
 import org.wso2.ballerinalang.compiler.tree.BLangFunction;
-import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
-import org.wso2.ballerinalang.compiler.tree.BLangImportPackage;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
-import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
-import org.wso2.ballerinalang.compiler.tree.BLangPackageDeclaration;
 import org.wso2.ballerinalang.compiler.tree.BLangResource;
 import org.wso2.ballerinalang.compiler.tree.BLangService;
-import org.wso2.ballerinalang.compiler.tree.BLangStruct;
-import org.wso2.ballerinalang.compiler.tree.BLangTransformer;
 import org.wso2.ballerinalang.compiler.tree.BLangVariable;
 import org.wso2.ballerinalang.compiler.tree.BLangWorker;
-import org.wso2.ballerinalang.compiler.tree.BLangXMLNS;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangAnnotAttachmentAttribute;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangAnnotAttachmentAttributeValue;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangArrayLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangBinaryExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangConnectorInit;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangIntRangeExpression;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangSimpleVarRef;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangStringTemplateLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangTernaryExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeCastExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeConversionExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeofExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangUnaryExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLAttribute;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLAttributeAccess;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLCommentLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLElementLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLProcInsLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLQName;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLQuotedString;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLTextLiteral;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangAbort;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangAssignment;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangBind;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangBlockStmt;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangBreak;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangCatch;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangExpressionStmt;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangForeach;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangForkJoin;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangIf;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangNext;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangReturn;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangThrow;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangTransaction;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangTryCatchFinally;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangVariableDef;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangWhile;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangWorkerReceive;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangWorkerSend;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangXMLNSStatement;
-import org.wso2.ballerinalang.compiler.tree.types.BLangArrayType;
-import org.wso2.ballerinalang.compiler.tree.types.BLangBuiltInRefTypeNode;
-import org.wso2.ballerinalang.compiler.tree.types.BLangConstrainedType;
-import org.wso2.ballerinalang.compiler.tree.types.BLangEndpointTypeNode;
-import org.wso2.ballerinalang.compiler.tree.types.BLangFunctionTypeNode;
-import org.wso2.ballerinalang.compiler.tree.types.BLangUserDefinedType;
-import org.wso2.ballerinalang.compiler.tree.types.BLangValueType;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -104,7 +51,7 @@ import java.util.stream.Collectors;
 /**
  * Tree visitor to find the definition of variables.
  */
-public class DefinitionTreeVisitor extends BLangNodeVisitor {
+public class DefinitionTreeVisitor extends NodeVisitor {
 
     private boolean terminateVisitor = false;
     private TextDocumentServiceContext context;
@@ -128,22 +75,6 @@ public class DefinitionTreeVisitor extends BLangNodeVisitor {
         } else {
             topLevelNodes.forEach(topLevelNode -> acceptNode((BLangNode) topLevelNode));
         }
-    }
-
-    public void visit(BLangCompilationUnit compUnit) {
-        // No implementation
-    }
-
-    public void visit(BLangPackageDeclaration pkgDclNode) {
-        // No implementation
-    }
-
-    public void visit(BLangImportPackage importPkgNode) {
-        // No implementation
-    }
-
-    public void visit(BLangXMLNS xmlnsNode) {
-        // No implementation
     }
 
     public void visit(BLangFunction funcNode) {
@@ -240,18 +171,6 @@ public class DefinitionTreeVisitor extends BLangNodeVisitor {
         }
     }
 
-    public void visit(BLangStruct structNode) {
-        // No implementation
-    }
-
-    public void visit(BLangEnum enumNode) {
-        // No implementation
-    }
-
-    public void visit(BLangEnum.BLangEnumerator enumeratorNode) {
-        // No implementation
-    }
-
     public void visit(BLangVariable varNode) {
         if (varNode.name.getValue()
                 .equals(this.context.get(NodeContextKeys.VAR_NAME_OF_NODE_KEY))) {
@@ -270,34 +189,6 @@ public class DefinitionTreeVisitor extends BLangNodeVisitor {
         }
     }
 
-    public void visit(BLangIdentifier identifierNode) {
-        // No implementation
-    }
-
-    public void visit(BLangAnnotation annotationNode) {
-        // No implementation
-    }
-
-    public void visit(BLangAnnotAttribute annotationAttribute) {
-        // No implementation
-    }
-
-    public void visit(BLangAnnotationAttachment annAttachmentNode) {
-        // No implementation
-    }
-
-    public void visit(BLangAnnotAttachmentAttributeValue annotAttributeValue) {
-        // No implementation
-    }
-
-    public void visit(BLangAnnotAttachmentAttribute annotAttachmentAttribute) {
-        // No implementation
-    }
-
-    public void visit(BLangTransformer transformerNode) {
-        // No implementation
-    }
-
     public void visit(BLangBlockStmt blockNode) {
         if (!blockNode.stmts.isEmpty()) {
             blockNode.stmts.forEach(this::acceptNode);
@@ -314,42 +205,6 @@ public class DefinitionTreeVisitor extends BLangNodeVisitor {
         if (!assignNode.varRefs.isEmpty()) {
             assignNode.varRefs.forEach(this::acceptNode);
         }
-    }
-
-    public void visit(BLangBind bindNode) {
-        // No implementation
-    }
-
-    public void visit(BLangAbort abortNode) {
-        // No implementation
-    }
-
-    public void visit(BLangNext nextNode) {
-        // No implementation
-    }
-
-    public void visit(BLangBreak breakNode) {
-        // No implementation
-    }
-
-    public void visit(BLangReturn returnNode) {
-        // No implementation
-    }
-
-    public void visit(BLangReturn.BLangWorkerReturn returnNode) {
-        // No implementation
-    }
-
-    public void visit(BLangThrow throwNode) {
-        // No implementation
-    }
-
-    public void visit(BLangXMLNSStatement xmlnsStmtNode) {
-        // No implementation
-    }
-
-    public void visit(BLangExpressionStmt exprStmtNode) {
-        // No implementation
     }
 
     public void visit(BLangIf ifNode) {
@@ -422,18 +277,6 @@ public class DefinitionTreeVisitor extends BLangNodeVisitor {
         }
     }
 
-    public void visit(BLangLiteral literalExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangArrayLiteral arrayLiteral) {
-        // No implementation
-    }
-
-    public void visit(BLangRecordLiteral recordLiteral) {
-        // No implementation
-    }
-
     public void visit(BLangSimpleVarRef varRefExpr) {
         if (varRefExpr.variableName.getValue()
                 .equals(this.context.get(NodeContextKeys.VAR_NAME_OF_NODE_KEY))) {
@@ -442,206 +285,10 @@ public class DefinitionTreeVisitor extends BLangNodeVisitor {
         }
     }
 
-    public void visit(BLangFieldBasedAccess fieldAccessExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangIndexBasedAccess indexAccessExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangInvocation invocationExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangConnectorInit connectorInitExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangInvocation.BLangActionInvocation actionInvocationExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangTernaryExpr ternaryExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangBinaryExpr binaryExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangUnaryExpr unaryExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangTypeofExpr accessExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangTypeCastExpr castExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangTypeConversionExpr conversionExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangXMLQName xmlQName) {
-        // No implementation
-    }
-
-    public void visit(BLangXMLAttribute xmlAttribute) {
-        // No implementation
-    }
-
-    public void visit(BLangXMLElementLiteral xmlElementLiteral) {
-        // No implementation
-    }
-
-    public void visit(BLangXMLTextLiteral xmlTextLiteral) {
-        // No implementation
-    }
-
-    public void visit(BLangXMLCommentLiteral xmlCommentLiteral) {
-        // No implementation
-    }
-
-    public void visit(BLangXMLProcInsLiteral xmlProcInsLiteral) {
-        // No implementation
-    }
-
-    public void visit(BLangXMLQuotedString xmlQuotedString) {
-        // No implementation
-    }
-
-    public void visit(BLangStringTemplateLiteral stringTemplateLiteral) {
-        // No implementation
-    }
-
-    public void visit(BLangWorkerSend workerSendNode) {
-        // No implementation
-    }
-
-    public void visit(BLangWorkerReceive workerReceiveNode) {
-        // No implementation
-    }
-
     public void visit(BLangLambdaFunction bLangLambdaFunction) {
         if (bLangLambdaFunction.function != null) {
             this.acceptNode(bLangLambdaFunction.function);
         }
-    }
-
-    public void visit(BLangXMLAttributeAccess xmlAttributeAccessExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangIntRangeExpression intRangeExpression) {
-        // No implementation
-    }
-
-    public void visit(BLangValueType valueType) {
-        // No implementation
-    }
-
-    public void visit(BLangArrayType arrayType) {
-        // No implementation
-    }
-
-    public void visit(BLangBuiltInRefTypeNode builtInRefType) {
-        // No implementation
-    }
-
-    public void visit(BLangEndpointTypeNode endpointType) {
-        // No implementation
-    }
-
-    public void visit(BLangConstrainedType constrainedType) {
-        // No implementation
-    }
-
-    public void visit(BLangUserDefinedType userDefinedType) {
-        // No implementation
-    }
-
-    public void visit(BLangFunctionTypeNode functionTypeNode) {
-        // No implementation
-    }
-
-    public void visit(BLangSimpleVarRef.BLangLocalVarRef localVarRef) {
-        // No implementation
-    }
-
-    public void visit(BLangSimpleVarRef.BLangFieldVarRef fieldVarRef) {
-        // No implementation
-    }
-
-    public void visit(BLangSimpleVarRef.BLangPackageVarRef packageVarRef) {
-        // No implementation
-    }
-
-    public void visit(BLangSimpleVarRef.BLangFunctionVarRef functionVarRef) {
-        // No implementation
-    }
-
-    public void visit(BLangFieldBasedAccess.BLangStructFieldAccessExpr fieldAccessExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangIndexBasedAccess.BLangMapAccessExpr mapKeyAccessExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangIndexBasedAccess.BLangArrayAccessExpr arrayIndexAccessExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangIndexBasedAccess.BLangXMLAccessExpr xmlIndexAccessExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangRecordLiteral.BLangJSONLiteral jsonLiteral) {
-        // No implementation
-    }
-
-    public void visit(BLangRecordLiteral.BLangMapLiteral mapLiteral) {
-        // No implementation
-    }
-
-    public void visit(BLangRecordLiteral.BLangStructLiteral structLiteral) {
-        // No implementation
-    }
-
-    public void visit(BLangInvocation.BFunctionPointerInvocation bFunctionPointerInvocation) {
-        // No implementation
-    }
-
-    public void visit(BLangInvocation.BLangAttachedFunctionInvocation iExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangInvocation.BLangTransformerInvocation iExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangArrayLiteral.BLangJSONArrayLiteral jsonArrayLiteral) {
-        // No implementation
-    }
-
-    public void visit(BLangIndexBasedAccess.BLangJSONAccessExpr jsonAccessExpr) {
-        // No implementation
-    }
-
-    public void visit(BLangXMLNS.BLangLocalXMLNS xmlnsNode) {
-        // No implementation
-    }
-
-    public void visit(BLangXMLNS.BLangPackageXMLNS xmlnsNode) {
-        // No implementation
-    }
-
-    public void visit(BLangFieldBasedAccess.BLangEnumeratorAccessExpr enumeratorAccessExpr) {
-        // No implementation
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/definition/DefinitionTreeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/definition/DefinitionTreeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/definition/util/DefinitionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/definition/util/DefinitionUtil.java
@@ -22,6 +22,7 @@ import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.TextDocumentServiceUtil;
 import org.ballerinalang.langserver.common.constants.ContextConstants;
 import org.ballerinalang.langserver.common.constants.NodeContextKeys;
+import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.definition.DefinitionTreeVisitor;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
@@ -127,7 +128,7 @@ public class DefinitionUtil {
         if (parentPath != null) {
             String fileName = bLangNode.getPosition().getSource().getCompilationUnitName();
             Path filePath = Paths
-                    .get(getPackageURI(definitionContext.get(NodeContextKeys.PACKAGE_OF_NODE_KEY).nameComps,
+                    .get(CommonUtil.getPackageURI(definitionContext.get(NodeContextKeys.PACKAGE_OF_NODE_KEY).nameComps,
                             parentPath.toString(),
                             definitionContext.get(NodeContextKeys.PACKAGE_OF_NODE_KEY).nameComps),
                             fileName);
@@ -153,29 +154,5 @@ public class DefinitionUtil {
                                                      BLangPackageContext bLangPackageContext) {
         return bLangPackageContext
                 .getPackageByName(definitionContext.get(DocumentServiceKeys.COMPILER_CONTEXT_KEY), packageName);
-    }
-
-    /**
-     * Get the package URI to the given package name.
-     *
-     * @param pkgName        Name of the package that need the URI for
-     * @param currentPkgPath String URI of the current package
-     * @param currentPkgName Name of the current package
-     * @return String URI for the given path.
-     */
-    private static String getPackageURI(List<Name> pkgName, String currentPkgPath, List<Name> currentPkgName) {
-        String newPackagePath;
-        // If current package path is not null and current package is not default package continue,
-        // else new package path is same as the current package path.
-        if (currentPkgPath != null && !currentPkgName.get(0).getValue().equals(".")) {
-            int indexOfCurrentPkgName = currentPkgPath.indexOf(currentPkgName.get(0).getValue());
-            newPackagePath = currentPkgPath.substring(0, indexOfCurrentPkgName);
-            for (Name pkgDir : pkgName) {
-                newPackagePath = Paths.get(newPackagePath, pkgDir.getValue()).toString();
-            }
-        } else {
-            newPackagePath = currentPkgPath;
-        }
-        return newPackagePath;
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/definition/util/DefinitionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/definition/util/DefinitionUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/util/HoverUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/util/HoverUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/ReferencesTreeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/ReferencesTreeVisitor.java
@@ -1,0 +1,484 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.references;
+
+import org.ballerinalang.langserver.DocumentServiceKeys;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.TextDocumentServiceUtil;
+import org.ballerinalang.langserver.common.NodeVisitor;
+import org.ballerinalang.langserver.common.constants.NodeContextKeys;
+import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentPositionParams;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
+import org.wso2.ballerinalang.compiler.tree.BLangAction;
+import org.wso2.ballerinalang.compiler.tree.BLangConnector;
+import org.wso2.ballerinalang.compiler.tree.BLangEnum;
+import org.wso2.ballerinalang.compiler.tree.BLangFunction;
+import org.wso2.ballerinalang.compiler.tree.BLangNode;
+import org.wso2.ballerinalang.compiler.tree.BLangPackage;
+import org.wso2.ballerinalang.compiler.tree.BLangResource;
+import org.wso2.ballerinalang.compiler.tree.BLangService;
+import org.wso2.ballerinalang.compiler.tree.BLangVariable;
+import org.wso2.ballerinalang.compiler.tree.BLangWorker;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangSimpleVarRef;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangAssignment;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangBlockStmt;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangCatch;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangExpressionStmt;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangForeach;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangForkJoin;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangIf;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangReturn;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangTransaction;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangTryCatchFinally;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangVariableDef;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangWhile;
+import org.wso2.ballerinalang.compiler.tree.types.BLangUserDefinedType;
+import org.wso2.ballerinalang.compiler.util.Name;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+/**
+ * Tree visitor for finding the references of a statement.
+ */
+public class ReferencesTreeVisitor extends NodeVisitor {
+    private boolean terminateVisitor = false;
+    private TextDocumentServiceContext context;
+    private List<Location> locations;
+
+
+    public ReferencesTreeVisitor(TextDocumentServiceContext context) {
+        this.context = context;
+        this.locations = context.get(NodeContextKeys.REFERENCE_NODES_KEY);
+    }
+
+    @Override
+    public void visit(BLangPackage pkgNode) {
+        if (pkgNode.topLevelNodes.isEmpty()) {
+            terminateVisitor = true;
+            acceptNode(null);
+        } else {
+            pkgNode.topLevelNodes.forEach(topLevelNode -> acceptNode((BLangNode) topLevelNode));
+        }
+    }
+
+    @Override
+    public void visit(BLangFunction funcNode) {
+        // Check for native functions
+        BSymbol funcSymbol = funcNode.symbol;
+        if (Symbols.isNative(funcSymbol)) {
+            return;
+        }
+
+        if (this.context.get(NodeContextKeys.PACKAGE_OF_NODE_KEY).name.getValue()
+                .equals(funcNode.symbol.pkgID.name.getValue()) && this.context.get(NodeContextKeys.NAME_OF_NODE_KEY)
+                .equals(funcNode.name.getValue())) {
+            this.locations.add(getLocation(funcNode, funcNode.symbol.pkgID.nameComps, funcNode.symbol.pkgID.nameComps));
+        }
+        if (!funcNode.params.isEmpty()) {
+            funcNode.params.forEach(this::acceptNode);
+        }
+
+        if (!funcNode.retParams.isEmpty()) {
+            funcNode.retParams.forEach(this::acceptNode);
+        }
+
+        if (funcNode.body != null) {
+            this.acceptNode(funcNode.body);
+        }
+
+        if (!funcNode.workers.isEmpty()) {
+            funcNode.workers.forEach(this::acceptNode);
+        }
+    }
+
+    @Override
+    public void visit(BLangService serviceNode) {
+        if (serviceNode.symbol.pkgID.name.getValue()
+                .equals(this.context.get(NodeContextKeys.PACKAGE_OF_NODE_KEY).name.getValue()) &&
+                this.context.get(NodeContextKeys.NAME_OF_NODE_KEY).equals(serviceNode.name.getValue()) &&
+                this.context.get(NodeContextKeys.NODE_OWNER_KEY).equals(serviceNode.symbol.owner.name.getValue())) {
+            this.locations.add(getLocation(serviceNode, serviceNode.symbol.pkgID.nameComps,
+                    serviceNode.symbol.pkgID.nameComps));
+        }
+
+        if (!serviceNode.vars.isEmpty()) {
+            serviceNode.vars.forEach(this::acceptNode);
+        }
+
+        if (!serviceNode.resources.isEmpty()) {
+            serviceNode.resources.forEach(this::acceptNode);
+        }
+
+        if (serviceNode.initFunction != null) {
+            this.acceptNode(serviceNode.initFunction);
+        }
+    }
+
+    @Override
+    public void visit(BLangResource resourceNode) {
+        if (resourceNode.symbol.pkgID.name.getValue()
+                .equals(this.context.get(NodeContextKeys.PACKAGE_OF_NODE_KEY).name.getValue()) &&
+                this.context.get(NodeContextKeys.NAME_OF_NODE_KEY).equals(resourceNode.name.getValue()) &&
+                this.context.get(NodeContextKeys.NODE_OWNER_KEY).equals(resourceNode.symbol.owner.name.getValue())) {
+            this.locations.add(getLocation(resourceNode, resourceNode.symbol.pkgID.nameComps,
+                    resourceNode.symbol.pkgID.nameComps));
+        }
+
+        if (!resourceNode.params.isEmpty()) {
+            resourceNode.params.forEach(this::acceptNode);
+        }
+
+        if (!resourceNode.retParams.isEmpty()) {
+            resourceNode.retParams.forEach(this::acceptNode);
+        }
+
+        if (resourceNode.body != null) {
+            this.acceptNode(resourceNode.body);
+        }
+    }
+
+    @Override
+    public void visit(BLangConnector connectorNode) {
+        if (connectorNode.symbol.pkgID.name.getValue()
+                .equals(this.context.get(NodeContextKeys.PACKAGE_OF_NODE_KEY).name.getValue()) &&
+                this.context.get(NodeContextKeys.NAME_OF_NODE_KEY).equals(connectorNode.name.getValue()) &&
+                this.context.get(NodeContextKeys.NODE_OWNER_KEY).equals(connectorNode.symbol.owner.name.getValue())) {
+            this.locations.add(getLocation(connectorNode, connectorNode.symbol.pkgID.nameComps,
+                    connectorNode.symbol.pkgID.nameComps));
+        }
+
+        if (!connectorNode.params.isEmpty()) {
+            connectorNode.params.forEach(this::acceptNode);
+        }
+
+        if (!connectorNode.varDefs.isEmpty()) {
+            connectorNode.varDefs.forEach(this::acceptNode);
+        }
+
+        if (!connectorNode.actions.isEmpty()) {
+            connectorNode.actions.forEach(this::acceptNode);
+        }
+    }
+
+    @Override
+    public void visit(BLangAction actionNode) {
+        if (actionNode.symbol.pkgID.name.getValue()
+                .equals(this.context.get(NodeContextKeys.PACKAGE_OF_NODE_KEY).name.getValue()) &&
+                this.context.get(NodeContextKeys.NAME_OF_NODE_KEY).equals(actionNode.name.getValue())) {
+            this.locations.add(getLocation(actionNode, actionNode.symbol.pkgID.nameComps,
+                    actionNode.symbol.pkgID.nameComps));
+        }
+
+        if (!actionNode.params.isEmpty()) {
+            actionNode.params.forEach(this::acceptNode);
+        }
+
+        if (!actionNode.retParams.isEmpty()) {
+            actionNode.retParams.forEach(this::acceptNode);
+        }
+
+        if (actionNode.body != null) {
+            acceptNode(actionNode.body);
+        }
+
+        if (!actionNode.workers.isEmpty()) {
+            actionNode.workers.forEach(this::acceptNode);
+        }
+    }
+
+    @Override
+    public void visit(BLangVariable varNode) {
+        if ((this.context.get(NodeContextKeys.VAR_NAME_OF_NODE_KEY) != null &&
+                this.context.get(NodeContextKeys.VAR_NAME_OF_NODE_KEY).equals(varNode.name.getValue())) &&
+                varNode.symbol.owner.name.getValue().equals(this.context.get(NodeContextKeys.NODE_OWNER_KEY)) &&
+                varNode.symbol.owner.pkgID.getName().getValue()
+                        .equals(this.context.get(NodeContextKeys.NODE_OWNER_PACKAGE_KEY).name.getValue())) {
+
+            this.locations.add(getLocation(varNode, varNode.symbol.owner.pkgID.nameComps,
+                    varNode.pos.getSource().pkgID.nameComps));
+        }
+
+        if (varNode.typeNode != null) {
+            this.acceptNode(varNode.typeNode);
+        }
+
+        if (varNode.expr != null) {
+            this.acceptNode(varNode.expr);
+        }
+    }
+
+    @Override
+    public void visit(BLangWorker workerNode) {
+        if (workerNode.body != null) {
+            this.acceptNode(workerNode.body);
+        }
+
+        if (!workerNode.workers.isEmpty()) {
+            workerNode.workers.forEach(this::acceptNode);
+        }
+    }
+
+    @Override
+    public void visit(BLangBlockStmt blockNode) {
+        if (!blockNode.stmts.isEmpty()) {
+            blockNode.stmts.forEach(this::acceptNode);
+        }
+    }
+
+    @Override
+    public void visit(BLangVariableDef varDefNode) {
+        if (varDefNode.getVariable() != null) {
+            this.acceptNode(varDefNode.getVariable());
+        }
+    }
+
+    @Override
+    public void visit(BLangAssignment assignNode) {
+        if (!assignNode.varRefs.isEmpty()) {
+            assignNode.varRefs.forEach(this::acceptNode);
+        }
+
+        if (assignNode.expr != null) {
+            this.acceptNode(assignNode.expr);
+        }
+    }
+
+    @Override
+    public void visit(BLangIf ifNode) {
+        if (ifNode.body != null) {
+            this.acceptNode(ifNode.body);
+        }
+
+        if (ifNode.elseStmt != null) {
+            this.acceptNode(ifNode.elseStmt);
+        }
+    }
+
+    @Override
+    public void visit(BLangForeach foreach) {
+        if (!foreach.varRefs.isEmpty()) {
+            foreach.varRefs.forEach(this::acceptNode);
+        }
+
+        if (foreach.body != null) {
+            this.acceptNode(foreach.body);
+        }
+    }
+
+    @Override
+    public void visit(BLangWhile whileNode) {
+        if (whileNode.body != null) {
+            this.acceptNode(whileNode.body);
+        }
+    }
+
+    @Override
+    public void visit(BLangTransaction transactionNode) {
+        if (transactionNode.transactionBody != null) {
+            this.acceptNode(transactionNode.transactionBody);
+        }
+
+        if (transactionNode.failedBody != null) {
+            this.acceptNode(transactionNode.failedBody);
+        }
+    }
+
+    @Override
+    public void visit(BLangTryCatchFinally tryNode) {
+        if (tryNode.tryBody != null) {
+            this.acceptNode(tryNode.tryBody);
+        }
+
+        if (!tryNode.catchBlocks.isEmpty()) {
+            tryNode.catchBlocks.forEach(this::acceptNode);
+        }
+
+        if (tryNode.finallyBody != null) {
+            this.acceptNode(tryNode.finallyBody);
+        }
+    }
+
+    @Override
+    public void visit(BLangCatch catchNode) {
+        if (catchNode.body != null) {
+            this.acceptNode(catchNode.body);
+        }
+    }
+
+    @Override
+    public void visit(BLangForkJoin forkJoin) {
+        if (!forkJoin.getWorkers().isEmpty()) {
+            forkJoin.getWorkers().forEach(this::acceptNode);
+        }
+
+        if (forkJoin.joinedBody != null) {
+            this.acceptNode(forkJoin.joinedBody);
+        }
+
+        if (forkJoin.timeoutBody != null) {
+            this.acceptNode(forkJoin.timeoutBody);
+        }
+    }
+
+    @Override
+    public void visit(BLangSimpleVarRef varRefExpr) {
+        if (this.context.get(NodeContextKeys.VAR_NAME_OF_NODE_KEY) != null && varRefExpr.variableName.getValue()
+                .equals(this.context.get(NodeContextKeys.VAR_NAME_OF_NODE_KEY))) {
+
+            if (varRefExpr.symbol != null && varRefExpr.symbol.owner.name.getValue()
+                    .equals(this.context.get(NodeContextKeys.NODE_OWNER_KEY)) && varRefExpr.symbol.pkgID.name.getValue()
+                    .equals(this.context.get(NodeContextKeys.PACKAGE_OF_NODE_KEY).name.getValue())) {
+
+                this.locations.add(getLocation(varRefExpr, varRefExpr.symbol.owner.pkgID.nameComps,
+                        varRefExpr.pos.getSource().pkgID.nameComps));
+
+            } else if (varRefExpr.type.tsymbol.owner.name.getValue()
+                    .equals(this.context.get(NodeContextKeys.NODE_OWNER_KEY)) &&
+                    varRefExpr.type.tsymbol.pkgID.name.getValue()
+                            .equals(this.context.get(NodeContextKeys.PACKAGE_OF_NODE_KEY).name.getValue())) {
+                this.locations.add(getLocation(varRefExpr, varRefExpr.type.tsymbol.owner.pkgID.nameComps,
+                        varRefExpr.pos.getSource().pkgID.nameComps));
+            }
+        }
+    }
+
+    @Override
+    public void visit(BLangLambdaFunction bLangLambdaFunction) {
+        if (bLangLambdaFunction.function != null) {
+            this.acceptNode(bLangLambdaFunction.function);
+        }
+    }
+
+    @Override
+    public void visit(BLangInvocation invocationExpr) {
+        if (this.context.get(NodeContextKeys.NAME_OF_NODE_KEY).equals(invocationExpr.name.getValue()) &&
+                invocationExpr.symbol.owner.name.getValue()
+                        .equals(this.context.get(NodeContextKeys.NODE_OWNER_KEY))
+                && invocationExpr.symbol.owner.pkgID.getName().getValue()
+                .equals(this.context.get(NodeContextKeys.NODE_OWNER_PACKAGE_KEY).name.getValue())) {
+            this.locations.add(getLocation(invocationExpr, invocationExpr.symbol.owner.pkgID.nameComps,
+                    invocationExpr.pos.getSource().pkgID.nameComps));
+        }
+
+        if (invocationExpr.expr != null) {
+            this.acceptNode(invocationExpr.expr);
+        }
+
+        if (!invocationExpr.argExprs.isEmpty()) {
+            invocationExpr.argExprs.forEach(this::acceptNode);
+        }
+    }
+
+    @Override
+    public void visit(BLangExpressionStmt exprStmtNode) {
+        if (exprStmtNode.expr != null) {
+            this.acceptNode(exprStmtNode.expr);
+        }
+    }
+
+    @Override
+    public void visit(BLangReturn returnNode) {
+        if (!returnNode.exprs.isEmpty()) {
+            returnNode.exprs.forEach(this::acceptNode);
+        }
+    }
+
+    @Override
+    public void visit(BLangFieldBasedAccess fieldAccessExpr) {
+        if (fieldAccessExpr.expr != null) {
+            this.acceptNode(fieldAccessExpr.expr);
+        }
+    }
+
+    @Override
+    public void visit(BLangEnum enumNode) {
+        if (enumNode.symbol.owner.name.getValue().equals(this.context.get(NodeContextKeys.NODE_OWNER_KEY)) &&
+                enumNode.symbol.owner.pkgID.name.getValue()
+                        .equals(this.context.get(NodeContextKeys.NODE_OWNER_PACKAGE_KEY).name.getValue()) &&
+                enumNode.name.getValue().equals(this.context.get(NodeContextKeys.NAME_OF_NODE_KEY))) {
+            // Fixing the issue with enum end positions by
+            // replacing end line and end column with start line and column values
+            enumNode.getPosition().eLine = enumNode.getPosition().sLine;
+            enumNode.getPosition().eCol = enumNode.getPosition().sCol;
+            this.locations.add(getLocation(enumNode, enumNode.symbol.owner.pkgID.nameComps,
+                    enumNode.pos.getSource().pkgID.nameComps));
+        }
+    }
+
+    @Override
+    public void visit(BLangUserDefinedType userDefinedType) {
+        if (userDefinedType.typeName.getValue().equals(this.context.get(NodeContextKeys.NAME_OF_NODE_KEY)) &&
+                userDefinedType.type.tsymbol.owner.name.getValue()
+                        .equals(this.context.get(NodeContextKeys.NODE_OWNER_KEY)) &&
+                userDefinedType.type.tsymbol.owner.pkgID.name.getValue()
+                        .equals(this.context.get(NodeContextKeys.NODE_OWNER_PACKAGE_KEY).name.getValue())) {
+            this.locations.add(getLocation(userDefinedType, userDefinedType.type.tsymbol.owner.pkgID.nameComps,
+                    userDefinedType.pos.getSource().pkgID.nameComps));
+        }
+    }
+
+    /**
+     * Accept node to visit.
+     *
+     * @param node node to be accepted to visit.
+     */
+    private void acceptNode(BLangNode node) {
+        if (this.terminateVisitor) {
+            return;
+        }
+        node.accept(this);
+    }
+
+    /**
+     * Get the physical source location of the given package.
+     *
+     * @param bLangNode          ballerina language node references are requested for
+     * @param ownerPackageName   list of name compositions of the node's package name
+     * @param currentPackageName list of name compositions of the current package
+     * @return location of the package of the given node
+     */
+    private Location getLocation(BLangNode bLangNode, List<Name> ownerPackageName, List<Name> currentPackageName) {
+        Location l = new Location();
+        Range r = new Range();
+        TextDocumentPositionParams position = this.context.get(DocumentServiceKeys.POSITION_KEY);
+        Path parentPath = TextDocumentServiceUtil.getPath(position.getTextDocument().getUri()).getParent();
+        if (parentPath != null) {
+            String fileName = bLangNode.getPosition().getSource().getCompilationUnitName();
+            Path filePath = Paths.get(CommonUtil
+                    .getPackageURI(currentPackageName, parentPath.toString(), ownerPackageName), fileName);
+            l.setUri(filePath.toUri().toString());
+
+            // Subtract 1 to convert the token lines and char positions to zero based indexing
+            r.setStart(new Position(bLangNode.getPosition().getStartLine() - 1,
+                    bLangNode.getPosition().getStartColumn() - 1));
+            r.setEnd(new Position(bLangNode.getPosition().getEndLine() - 1,
+                    bLangNode.getPosition().getEndColumn() - 1));
+            l.setRange(r);
+        }
+
+        return l;
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/util/ReferenceUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/util/ReferenceUtil.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballerinalang.langserver.references.util;
+
+import org.ballerinalang.langserver.BLangPackageContext;
+import org.ballerinalang.langserver.BallerinaPackageLoader;
+import org.ballerinalang.langserver.DocumentServiceKeys;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.common.constants.NodeContextKeys;
+import org.ballerinalang.langserver.references.ReferencesTreeVisitor;
+import org.ballerinalang.model.elements.PackageID;
+import org.eclipse.lsp4j.Location;
+import org.wso2.ballerinalang.compiler.tree.BLangPackage;
+import org.wso2.ballerinalang.compiler.util.Name;
+
+import java.util.List;
+
+/**
+ * Utility class for find all references functionality in language server.
+ */
+public class ReferenceUtil {
+    /**
+     * Get definition position for the given definition context.
+     *
+     * @param referencesContext   context of the references.
+     * @param bLangPackageContext package context for language server.
+     * @return position
+     */
+    public static List<Location> getReferences(TextDocumentServiceContext referencesContext,
+                                               BLangPackageContext bLangPackageContext) {
+        ReferencesTreeVisitor referencesTreeVisitor = new ReferencesTreeVisitor(referencesContext);
+
+        for (Object o : BallerinaPackageLoader.getPackageList(referencesContext
+                .get(DocumentServiceKeys.COMPILER_CONTEXT_KEY), 15)) {
+            PackageID packageID = (PackageID) o;
+            BLangPackage bLangPackage = getPackageOfTheOwner(packageID.name, referencesContext, bLangPackageContext);
+            bLangPackage.accept(referencesTreeVisitor);
+        }
+
+        return referencesContext.get(NodeContextKeys.REFERENCE_NODES_KEY);
+    }
+
+    /**
+     * Get the package of the owner of given node.
+     *
+     * @param packageName         name of the package
+     * @param referencesContext   context for the references
+     * @param bLangPackageContext package context of language server
+     * @return ballerina language package
+     */
+    private static BLangPackage getPackageOfTheOwner(Name packageName, TextDocumentServiceContext referencesContext,
+                                                     BLangPackageContext bLangPackageContext) {
+        return bLangPackageContext
+                .getPackageByName(referencesContext.get(DocumentServiceKeys.COMPILER_CONTEXT_KEY), packageName);
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureTreeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureTreeVisitor.java
@@ -20,6 +20,7 @@ package org.ballerinalang.langserver.signature;
 import org.ballerinalang.langserver.DocumentServiceKeys;
 import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.TextDocumentServiceUtil;
+import org.ballerinalang.langserver.common.NodeVisitor;
 import org.ballerinalang.langserver.completions.SymbolInfo;
 import org.ballerinalang.model.tree.Node;
 import org.ballerinalang.model.tree.TopLevelNode;
@@ -36,80 +37,21 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.tree.BLangAction;
-import org.wso2.ballerinalang.compiler.tree.BLangAnnotAttribute;
-import org.wso2.ballerinalang.compiler.tree.BLangAnnotation;
-import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
 import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
 import org.wso2.ballerinalang.compiler.tree.BLangConnector;
-import org.wso2.ballerinalang.compiler.tree.BLangEnum;
 import org.wso2.ballerinalang.compiler.tree.BLangFunction;
-import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
-import org.wso2.ballerinalang.compiler.tree.BLangImportPackage;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
-import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
-import org.wso2.ballerinalang.compiler.tree.BLangPackageDeclaration;
 import org.wso2.ballerinalang.compiler.tree.BLangResource;
 import org.wso2.ballerinalang.compiler.tree.BLangService;
-import org.wso2.ballerinalang.compiler.tree.BLangStruct;
-import org.wso2.ballerinalang.compiler.tree.BLangTransformer;
-import org.wso2.ballerinalang.compiler.tree.BLangVariable;
-import org.wso2.ballerinalang.compiler.tree.BLangWorker;
-import org.wso2.ballerinalang.compiler.tree.BLangXMLNS;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangAnnotAttachmentAttribute;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangAnnotAttachmentAttributeValue;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangArrayLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangBinaryExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangConnectorInit;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangIntRangeExpression;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangSimpleVarRef;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangStringTemplateLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangTernaryExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeCastExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeConversionExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeofExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangUnaryExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLAttribute;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLAttributeAccess;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLCommentLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLElementLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLProcInsLiteral;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLQName;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLQuotedString;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLTextLiteral;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangAbort;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangAssignment;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangBind;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangBlockStmt;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangBreak;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangCatch;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangExpressionStmt;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangForeach;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangForkJoin;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangIf;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangNext;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangReturn;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangThrow;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangTransaction;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangTryCatchFinally;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangVariableDef;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangWhile;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangWorkerReceive;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangWorkerSend;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangXMLNSStatement;
-import org.wso2.ballerinalang.compiler.tree.types.BLangArrayType;
-import org.wso2.ballerinalang.compiler.tree.types.BLangBuiltInRefTypeNode;
-import org.wso2.ballerinalang.compiler.tree.types.BLangConstrainedType;
-import org.wso2.ballerinalang.compiler.tree.types.BLangEndpointTypeNode;
-import org.wso2.ballerinalang.compiler.tree.types.BLangFunctionTypeNode;
-import org.wso2.ballerinalang.compiler.tree.types.BLangUserDefinedType;
-import org.wso2.ballerinalang.compiler.tree.types.BLangValueType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
@@ -123,7 +65,7 @@ import java.util.stream.Collectors;
 /**
  * Tree visitor to traverse through the ballerina node tree and find the scope of a given cursor position.
  */
-public class SignatureTreeVisitor extends BLangNodeVisitor {
+public class SignatureTreeVisitor extends NodeVisitor {
     private SymbolEnv symbolEnv;
     private SymbolResolver symbolResolver;
     private boolean terminateVisitor = false;
@@ -165,21 +107,6 @@ public class SignatureTreeVisitor extends BLangNodeVisitor {
     @Override
     public void visit(BLangCompilationUnit compUnit) {
         super.visit(compUnit);
-    }
-
-    @Override
-    public void visit(BLangPackageDeclaration pkgDclNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangImportPackage importPkgNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangXMLNS xmlnsNode) {
-        // No Implementation
     }
 
     @Override
@@ -235,66 +162,6 @@ public class SignatureTreeVisitor extends BLangNodeVisitor {
     }
 
     @Override
-    public void visit(BLangStruct structNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangEnum enumNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangEnum.BLangEnumerator enumeratorNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangVariable varNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangWorker workerNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangIdentifier identifierNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangAnnotation annotationNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangAnnotAttribute annotationAttribute) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangAnnotationAttachment annAttachmentNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangAnnotAttachmentAttributeValue annotAttributeValue) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangAnnotAttachmentAttribute annotAttachmentAttribute) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangTransformer transformerNode) {
-        // No Implementation
-    }
-
-    @Override
     public void visit(BLangBlockStmt blockNode) {
         SymbolEnv blockEnv = SymbolEnv.createBlockEnv(blockNode, symbolEnv);
         blockNode.stmts.forEach(stmt -> this.acceptNode(stmt, blockEnv));
@@ -307,56 +174,6 @@ public class SignatureTreeVisitor extends BLangNodeVisitor {
     @Override
     public void visit(BLangVariableDef varDefNode) {
         this.acceptNode(varDefNode.var, symbolEnv);
-    }
-
-    @Override
-    public void visit(BLangAssignment assignNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangBind bindNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangAbort abortNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangNext nextNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangBreak breakNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangReturn returnNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangReturn.BLangWorkerReturn returnNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangThrow throwNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangXMLNSStatement xmlnsStmtNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangExpressionStmt exprStmtNode) {
-        // No Implementation
     }
 
     @Override
@@ -430,281 +247,6 @@ public class SignatureTreeVisitor extends BLangNodeVisitor {
         this.blockOwnerStack.push(catchNode);
         this.acceptNode(catchNode.body, catchBlockEnv);
         this.blockOwnerStack.pop();
-    }
-
-    @Override
-    public void visit(BLangForkJoin forkJoin) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangLiteral literalExpr) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangArrayLiteral arrayLiteral) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangRecordLiteral recordLiteral) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangSimpleVarRef varRefExpr) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangFieldBasedAccess fieldAccessExpr) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangIndexBasedAccess indexAccessExpr) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangInvocation invocationExpr) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangConnectorInit connectorInitExpr) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangInvocation.BLangActionInvocation actionInvocationExpr) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangTernaryExpr ternaryExpr) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangBinaryExpr binaryExpr) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangUnaryExpr unaryExpr) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangTypeofExpr accessExpr) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangTypeCastExpr castExpr) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangTypeConversionExpr conversionExpr) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangXMLQName xmlQName) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangXMLAttribute xmlAttribute) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangXMLElementLiteral xmlElementLiteral) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangXMLTextLiteral xmlTextLiteral) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangXMLCommentLiteral xmlCommentLiteral) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangXMLProcInsLiteral xmlProcInsLiteral) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangXMLQuotedString xmlQuotedString) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangStringTemplateLiteral stringTemplateLiteral) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangWorkerSend workerSendNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangWorkerReceive workerReceiveNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangLambdaFunction bLangLambdaFunction) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangXMLAttributeAccess xmlAttributeAccessExpr) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangIntRangeExpression intRangeExpression) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangValueType valueType) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangArrayType arrayType) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangBuiltInRefTypeNode builtInRefType) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangEndpointTypeNode endpointType) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangConstrainedType constrainedType) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangUserDefinedType userDefinedType) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangFunctionTypeNode functionTypeNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangSimpleVarRef.BLangLocalVarRef localVarRef) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangSimpleVarRef.BLangFieldVarRef fieldVarRef) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangSimpleVarRef.BLangPackageVarRef packageVarRef) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangSimpleVarRef.BLangFunctionVarRef functionVarRef) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangFieldBasedAccess.BLangStructFieldAccessExpr fieldAccessExpr) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangIndexBasedAccess.BLangMapAccessExpr mapKeyAccessExpr) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangIndexBasedAccess.BLangArrayAccessExpr arrayIndexAccessExpr) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangIndexBasedAccess.BLangXMLAccessExpr xmlIndexAccessExpr) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangRecordLiteral.BLangJSONLiteral jsonLiteral) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangRecordLiteral.BLangMapLiteral mapLiteral) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangRecordLiteral.BLangStructLiteral structLiteral) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangInvocation.BFunctionPointerInvocation bFunctionPointerInvocation) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangInvocation.BLangAttachedFunctionInvocation iExpr) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangInvocation.BLangTransformerInvocation iExpr) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangArrayLiteral.BLangJSONArrayLiteral jsonArrayLiteral) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangIndexBasedAccess.BLangJSONAccessExpr jsonAccessExpr) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangXMLNS.BLangLocalXMLNS xmlnsNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangXMLNS.BLangPackageXMLNS xmlnsNode) {
-        // No Implementation
-    }
-
-    @Override
-    public void visit(BLangFieldBasedAccess.BLangEnumeratorAccessExpr enumeratorAccessExpr) {
-        // No Implementation
     }
 
     // Private Methods


### PR DESCRIPTION
## Purpose
> Fix #4574

## Goals
This will introduce the initial implementation of "Find all references" [1] [2] language feature to the ballerina language server. For now this supports following constructs of the ballerina language.

- Functions 
- Connectors initial support
- Actions initial support
- Structs initial support
- Enum initial support
- Global and local variable initial support 

There are few scenarios which are still not supporting, like search inside if condition, while condition, endpoint creation. Support for these will be added soon with future releases. 

*Note: There is an issue with position calculation of nodes as some nodes (i.e. Enum) contains -1 as column values. So highlighting of some references will be wrong until fixing this issue.* 

## Approach

### Functions
![ezgif com-video-to-gif 15](https://user-images.githubusercontent.com/9109762/36378312-59ecac04-15a0-11e8-8f16-83b9ec1117a7.gif)

### Connectors
![ezgif com-video-to-gif 21](https://user-images.githubusercontent.com/9109762/36379043-1bd5844c-15a3-11e8-9016-f067680b8cb8.gif)

### Action
![ezgif com-video-to-gif 22](https://user-images.githubusercontent.com/9109762/36379011-049c4bc6-15a3-11e8-90db-0690b7d67488.gif)

### Structs
![ezgif com-video-to-gif 16](https://user-images.githubusercontent.com/9109762/36379072-3f05a988-15a3-11e8-9b9b-1e64e57469f3.gif)

### Enums
![ezgif com-video-to-gif 20](https://user-images.githubusercontent.com/9109762/36379119-6d7629b4-15a3-11e8-8194-8553b2df8c3b.gif)

### Local Variable
![ezgif com-video-to-gif 17](https://user-images.githubusercontent.com/9109762/36379130-7cdb1658-15a3-11e8-8175-a17a4180e01d.gif)

### Global Variable
![ezgif com-video-to-gif 18](https://user-images.githubusercontent.com/9109762/36379151-8abb52d8-15a3-11e8-89ef-9dc94d0c408c.gif)

