### PR TITLE
[IO] Move channel open functionalities to IO package level

### DIFF
--- a/composer/modules/js-tests/src/test/resources/failing/natives-9.bal
+++ b/composer/modules/js-tests/src/test/resources/failing/natives-9.bal
@@ -12,10 +12,11 @@ public struct CharacterChannel{
 public struct TextRecordChannel{
 }
 
-@Description { value:"Function to convert ByteChannel to CharacterChannel"}
+@Description { value:"Function to create a CharacterChannel from ByteChannel"}
+@Param {value:"channel: The ByteChannel to be converted"}
 @Param {value:"encoding: the charset/encoding of the content (i.e UTF-8, ASCCI)"}
 @Return {value:"CharacterChannel converted from ByteChannel"}
-public native function <ByteChannel channel> toCharacterChannel(string encoding)(CharacterChannel);
+public native function createCharacterChannel (ByteChannel byteChannel, string encoding) (CharacterChannel);
 
 @Description {value:"Function to convert CharacterChannel to TextRecordChannel"}
 @Param {value:"recordSeparator: terminating expression to distingush between records"}

--- a/composer/modules/js-tests/src/test/resources/failing/natives-9.bal
+++ b/composer/modules/js-tests/src/test/resources/failing/natives-9.bal
@@ -4,70 +4,93 @@ package ballerina.io;
 public struct ByteChannel{
 }
 
-@Description {value:"Ballerina CharacterChannel reprsents a channel which will allow reading/writing characters"}
+@Description {value:"Ballerina CharacterChannel represents a channel which will allow to read/write characters"}
 public struct CharacterChannel{
 }
 
-@Description {value:"Ballerina TextRecordChannel represents a channel which will allow read/write text records"}
-public struct TextRecordChannel{
+@Description {value:"Ballerina DelimitedRecordChannel represents a channel which will allow to read/write text records"}
+public struct DelimitedRecordChannel {
 }
 
-@Description { value:"Function to create a CharacterChannel from ByteChannel"}
+@Description {value:"Function to create a CharacterChannel from ByteChannel"}
 @Param {value:"channel: The ByteChannel to be converted"}
-@Param {value:"encoding: the charset/encoding of the content (i.e UTF-8, ASCCI)"}
+@Param {value:"encoding: The charset/encoding of the content (i.e UTF-8, ASCII)"}
 @Return {value:"CharacterChannel converted from ByteChannel"}
 public native function createCharacterChannel (ByteChannel byteChannel, string encoding) (CharacterChannel);
 
-@Description {value:"Function to convert CharacterChannel to TextRecordChannel"}
-@Param {value:"recordSeparator: terminating expression to distingush between records"}
-@Param {value:"fieldSeparator: terminating expression to ditingish between feilds"}
-@Return {value:"TextRecordChannel converted from CharacterChannel"}
-public native function <CharacterChannel channel> toTextRecordChannel(string recordSeparator,
-                                                                      string fieldSeparator)
-                                                                      (TextRecordChannel);
+@Description {value:"Function to create a CharacterChannel to DelimitedRecordChannel"}
+@Param {value:"channel: The CharacterChannel to be converted"}
+@Param {value:"recordSeparator: Terminating expression to distinguish between records"}
+@Param {value:"fieldSeparator: Terminating expression to distinguish between fields"}
+@Return {value:"DelimitedRecordChannel converted from CharacterChannel"}
+public native function createDelimitedRecordChannel(CharacterChannel channel, string recordSeparator,
+                                                    string fieldSeparator)
+(DelimitedRecordChannel);
 
 @Description {value:"Function to read text records"}
+@Param {value:"channel: The DelimitedRecordChannel to read text records from"}
 @Return {value:"Fields listed in the record"}
-public native function <TextRecordChannel channel> readTextRecord()(string []);
+public native function <DelimitedRecordChannel channel> nextTextRecord () (string[]);
 
 @Description {value:"Function to write text records"}
-@Param {value:"records: feilds which are included in the record"}
-public native function <TextRecordChannel channel> writeTextRecord(string [] records);
+@Param {value:"channel: The DelimitedRecordChannel to write records"}
+@Param {value:"records: Fields which are included in the record"}
+public native function <DelimitedRecordChannel channel> writeTextRecord (string[] records);
 
 @Description{value:"Function to close the text record channel"}
-public native function <TextRecordChannel channel> closeTextRecordChannel();
+@Param {value:"channel: The DelimitedRecordChannel to be closed"}
+public native function <DelimitedRecordChannel channel> closeDelimitedRecordChannel();
 
 @Description {value:"Function to read characters"}
-@Param {value:"numberOfChars: number of characters which should be read"}
-@Return {value:"the characters which will be read"}
+@Param {value:"channel: The CharacterChannel to read characters from"}
+@Param {value:"numberOfChars: Number of characters which should be read"}
+@Return {value:"The character sequence which was read"}
 public native function <CharacterChannel channel> readCharacters(int numberOfChars)(string);
 
+@Description {value:"Function to read all characters in the give I/O source"}
+@Return {value:"all characters read"}
+public native function <CharacterChannel channel> readAllCharacters()(string);
+
 @Description {value:"Function to write characters"}
-@Param {value:"content: text content which should be written"}
-@Param {value:"startOffset: if the content needs to be written with an offset"}
-@Return {value:"int: number of characters written"}
+@Param {value:"channel: The CharacterChannel to write characters to"}
+@Param {value:"content: Text content which should be written"}
+@Param {value:"startOffset: If the content needs to be written with an offset, the value of that offset"}
+@Return { value:"Number of characters written"}
 public native function <CharacterChannel channel> writeCharacters(string content,int startOffset)(int);
 
-@Description {value:"Function to close character channel"}
+@Description {value:"Function to close a character channel"}
+@Param {value:"channel: The CharacterChannel to be closed"}
 public native function <CharacterChannel channel> closeCharacterChannel();
 
 @Description { value:"Function to read bytes"}
-@Param { value:"numberOfBytes: number of bytes which should be read" }
-@Return { value:"blob: the bytes which were read" }
-@Return {value:"int: number of bytes which were read"}
+@Param {value:"channel: The ByteChannel to read bytes from"}
+@Param { value:"numberOfBytes: Number of bytes which should be read" }
+@Return { value:"The bytes which were read" }
+@Return { value:"Number of bytes read"}
 public native function <ByteChannel channel> readBytes (int numberOfBytes) (blob, int);
 
+@Description {value:"Function to read all bytes in the given I/O source"}
+@Return {value:"all bytes read from the channel"}
+public native function <ByteChannel channel> readAllBytes()(blob,int);
+
 @Description { value:"Function to write bytes"}
-@Param { value:"content: bytes which should be written" }
-@Param { value:"content: whether the bytes should be writtne with an offset" }
-@Return {value:"int: number of bytes written"}
+@Param {value:"channel: The ByteChannel to write bytes to"}
+@Param { value:"content: Bytes which should be written" }
+@Param { value:"startOffset: If the bytes need to be written with an offset, the value of that offset" }
+@Return { value:"Number of bytes written"}
 public native function <ByteChannel channel> writeBytes(blob content,int startOffset) (int);
 
-@Description { value:"Function to close the byte channel"}
+@Description { value:"Function to close a byte channel"}
+@Param {value:"channel: The ByteChannel to be closed"}
 public native function <ByteChannel channel> close();
+
+@Description {value:"Function to check whether next record is available or not"}
+@Param {value:"channel: The DelimitedRecordChannel to read text records from"}
+@Return {value:"True if the channel has more records; false otherwise"}
+public native function <DelimitedRecordChannel channel> hasNextTextRecord () (boolean);
 
 @Description {value:"Function to return a ByteChannel related to the file. This ByteChannel can then be used to read/write from/to the file."}
 @Param {value:"path: The path of the file"}
 @Param {value:"accessMode: Specifies whether the file should be opened for reading or writing (r/w)"}
 @Return {value:"ByteChannel which will allow to perform I/O operations"}
-public native function openFile (string path, string accessMode) (io:ByteChannel);
+public native function openFile (string path, string accessMode) (ByteChannel);

--- a/composer/modules/js-tests/src/test/resources/failing/natives-9.bal
+++ b/composer/modules/js-tests/src/test/resources/failing/natives-9.bal
@@ -65,3 +65,9 @@ public native function <ByteChannel channel> writeBytes(blob content,int startOf
 
 @Description { value:"Function to close the byte channel"}
 public native function <ByteChannel channel> close();
+
+@Description {value:"Function to return a ByteChannel related to the file. This ByteChannel can then be used to read/write from/to the file."}
+@Param {value:"path: The path of the file"}
+@Param {value:"accessMode: Specifies whether the file should be opened for reading or writing (r/w)"}
+@Return {value:"ByteChannel which will allow to perform I/O operations"}
+public native function openFile (string path, string accessMode) (io:ByteChannel);

--- a/composer/modules/js-tests/src/test/resources/passing/byte-i-o.bal
+++ b/composer/modules/js-tests/src/test/resources/passing/byte-i-o.bal
@@ -1,12 +1,9 @@
-import ballerina.file;
 import ballerina.io;
 
 @Description{value:"This function will return a ByteChannel from a given file location according to the specified file permission whether the file should be opened for reading/writing."}
 function getFileChannel (string filePath, string permission) (io:ByteChannel) {
-    //Here's how the path of the file will be specified.
-    file:File src = {path:filePath};
     //Here's how the ByteChannel is retrieved from the file.
-    io:ByteChannel channel = src.openChannel(permission);
+    io:ByteChannel channel = io:openFile(filePath, permission);
     return channel;
 }
 

--- a/composer/modules/js-tests/src/test/resources/passing/bytesio.bal
+++ b/composer/modules/js-tests/src/test/resources/passing/bytesio.bal
@@ -1,11 +1,9 @@
-import ballerina.file;
 import ballerina.io;
 
 io:ByteChannel channel;
 
 function initFileChannel(string filePath, string permission){
-    file:File src = {path:filePath};
-    channel = src.openChannel(permission);
+    channel = io:openFile(filePath, permission);
 }
 
 function readBytes (int numberOfBytes) (blob) {

--- a/composer/modules/js-tests/src/test/resources/passing/character-i-o.bal
+++ b/composer/modules/js-tests/src/test/resources/passing/character-i-o.bal
@@ -7,8 +7,8 @@ function getFileCharacterChannel (string filePath, string permission, string enc
     file:File src = {path:filePath};
     //First we get the ByteChannel representation of the file.
     io:ByteChannel channel = src.openChannel(permission);
-    //Then we convert the byte channel to character channel to read content as text.
-    io:CharacterChannel characterChannel = channel.toCharacterChannel(encoding);
+    //Then we create a character channel from the byte channel to read content as text.
+    io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
     return characterChannel;
 }
 

--- a/composer/modules/js-tests/src/test/resources/passing/character-i-o.bal
+++ b/composer/modules/js-tests/src/test/resources/passing/character-i-o.bal
@@ -1,12 +1,10 @@
-import ballerina.file;
 import ballerina.io;
 
 @Description{value:"This function will return a CharacterChannel from a given file location accoring to the specified permissions and encoding."}
 function getFileCharacterChannel (string filePath, string permission, string encoding)
                                  (io:CharacterChannel) {
-    file:File src = {path:filePath};
     //First we get the ByteChannel representation of the file.
-    io:ByteChannel channel = src.openChannel(permission);
+    io:ByteChannel channel = io:openFile(filePath, permission);
     //Then we create a character channel from the byte channel to read content as text.
     io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
     return characterChannel;

--- a/composer/modules/js-tests/src/test/resources/passing/chario.bal
+++ b/composer/modules/js-tests/src/test/resources/passing/chario.bal
@@ -6,7 +6,7 @@ io:CharacterChannel characterChannel;
 function initFileChannel(string filePath,string permission,string encoding){
     file:File src = {path:filePath};
     io:ByteChannel channel = src.openChannel(permission);
-    characterChannel = channel.toCharacterChannel(encoding);
+    characterChannel = io:createCharacterChannel(channel, encoding);
 }
 
 function readCharacters (int numberOfCharacters) (string) {

--- a/composer/modules/js-tests/src/test/resources/passing/chario.bal
+++ b/composer/modules/js-tests/src/test/resources/passing/chario.bal
@@ -1,11 +1,9 @@
-import ballerina.file;
 import ballerina.io;
 
 io:CharacterChannel characterChannel;
 
 function initFileChannel(string filePath,string permission,string encoding){
-    file:File src = {path:filePath};
-    io:ByteChannel channel = src.openChannel(permission);
+    io:ByteChannel channel = io:openFile(filePath, permission);
     characterChannel = io:createCharacterChannel(channel, encoding);
 }
 

--- a/composer/modules/js-tests/src/test/resources/passing/processFile.bal
+++ b/composer/modules/js-tests/src/test/resources/passing/processFile.bal
@@ -1,9 +1,7 @@
-import ballerina.file;
 import ballerina.io;
 
 function getFileRecordChannel (string filePath, string permission, string encoding, string rs, string fs) (io:TextRecordChannel) {
-    file:File src = {path:filePath};
-    io:ByteChannel channel = src.openChannel(permission);
+    io:ByteChannel channel = io:openFile(filePath, permission);
     io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
     io:TextRecordChannel textRecordChannel = characterChannel.toTextRecordChannel(rs, fs);
     return textRecordChannel;

--- a/composer/modules/js-tests/src/test/resources/passing/processFile.bal
+++ b/composer/modules/js-tests/src/test/resources/passing/processFile.bal
@@ -3,7 +3,7 @@ import ballerina.io;
 function getFileRecordChannel (string filePath, string permission, string encoding, string rs, string fs) (io:TextRecordChannel) {
     io:ByteChannel channel = io:openFile(filePath, permission);
     io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
-    io:TextRecordChannel textRecordChannel = characterChannel.toTextRecordChannel(rs, fs);
+    io:TextRecordChannel textRecordChannel = io:createDelimitedRecordChannel(characterChannel, rs, fs);
     return textRecordChannel;
 }
 

--- a/composer/modules/js-tests/src/test/resources/passing/processFile.bal
+++ b/composer/modules/js-tests/src/test/resources/passing/processFile.bal
@@ -4,7 +4,7 @@ import ballerina.io;
 function getFileRecordChannel (string filePath, string permission, string encoding, string rs, string fs) (io:TextRecordChannel) {
     file:File src = {path:filePath};
     io:ByteChannel channel = src.openChannel(permission);
-    io:CharacterChannel characterChannel = channel.toCharacterChannel(encoding);
+    io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
     io:TextRecordChannel textRecordChannel = characterChannel.toTextRecordChannel(rs, fs);
     return textRecordChannel;
 }

--- a/composer/modules/js-tests/src/test/resources/passing/record-i-o.bal
+++ b/composer/modules/js-tests/src/test/resources/passing/record-i-o.bal
@@ -9,8 +9,7 @@ function getFileRecordChannel (string filePath, string permission, string encodi
     io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
     //Finally we convert the character channel to record channel
     //to read content as records.
-    io:TextRecordChannel textRecordChannel = characterChannel.
-                                             toTextRecordChannel(rs, fs);
+    io:TextRecordChannel textRecordChannel = io:createDelimitedRecordChannel(characterChannel, rs, fs);
     return textRecordChannel;
 }
 

--- a/composer/modules/js-tests/src/test/resources/passing/record-i-o.bal
+++ b/composer/modules/js-tests/src/test/resources/passing/record-i-o.bal
@@ -7,8 +7,8 @@ function getFileRecordChannel (string filePath, string permission, string encodi
     file:File src = {path:filePath};
     //First we get the ByteChannel representation of the file.
     io:ByteChannel channel = src.openChannel(permission);
-    //Then we convert the byte channel to character channel to read content as text.
-    io:CharacterChannel characterChannel = channel.toCharacterChannel(encoding);
+    //Then we create a character channel from the byte channel to read content as text.
+    io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
     //Finally we convert the character channel to record channel
     //to read content as records.
     io:TextRecordChannel textRecordChannel = characterChannel.

--- a/composer/modules/js-tests/src/test/resources/passing/record-i-o.bal
+++ b/composer/modules/js-tests/src/test/resources/passing/record-i-o.bal
@@ -1,12 +1,10 @@
-import ballerina.file;
 import ballerina.io;
 
 @Description{value:"This function will return a TextRecordChannel from a given file location.The encoding is character represenation of the content in file i.e UTF-8 ASCCI. The rs is record seperator i.e newline etc. and fs is field seperator i.e comma etc."}
 function getFileRecordChannel (string filePath, string permission, string encoding,
                                string rs, string fs) (io:TextRecordChannel) {
-    file:File src = {path:filePath};
     //First we get the ByteChannel representation of the file.
-    io:ByteChannel channel = src.openChannel(permission);
+    io:ByteChannel channel = io:openFile(filePath, permission);
     //Then we create a character channel from the byte channel to read content as text.
     io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
     //Finally we convert the character channel to record channel

--- a/composer/modules/js-tests/src/test/resources/passing/recordio.bal
+++ b/composer/modules/js-tests/src/test/resources/passing/recordio.bal
@@ -1,11 +1,9 @@
-import ballerina.file;
 import ballerina.io;
 
 io:TextRecordChannel textRecordChannel;
 
 function initFileChannel(string filePath,string permission,string encoding,string rs,string fs){
-    file:File src = {path:filePath};
-    io:ByteChannel channel = src.openChannel(permission);
+    io:ByteChannel channel = io:openFile(filePath, permission);
     io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
     textRecordChannel = characterChannel.toTextRecordChannel(rs,fs);
 }

--- a/composer/modules/js-tests/src/test/resources/passing/recordio.bal
+++ b/composer/modules/js-tests/src/test/resources/passing/recordio.bal
@@ -6,7 +6,7 @@ io:TextRecordChannel textRecordChannel;
 function initFileChannel(string filePath,string permission,string encoding,string rs,string fs){
     file:File src = {path:filePath};
     io:ByteChannel channel = src.openChannel(permission);
-    io:CharacterChannel  characterChannel = channel.toCharacterChannel(encoding);
+    io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
     textRecordChannel = characterChannel.toTextRecordChannel(rs,fs);
 }
 

--- a/composer/modules/js-tests/src/test/resources/passing/recordio.bal
+++ b/composer/modules/js-tests/src/test/resources/passing/recordio.bal
@@ -5,7 +5,7 @@ io:TextRecordChannel textRecordChannel;
 function initFileChannel(string filePath,string permission,string encoding,string rs,string fs){
     io:ByteChannel channel = io:openFile(filePath, permission);
     io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
-    textRecordChannel = characterChannel.toTextRecordChannel(rs,fs);
+    textRecordChannel = io:createDelimitedRecordChannel(characterChannel, rs, fs);
 }
 
 function readRecord () (string[]) {

--- a/docs/ballerina-by-example/examples/byte-i-o/byte-i-o.bal
+++ b/docs/ballerina-by-example/examples/byte-i-o/byte-i-o.bal
@@ -1,12 +1,9 @@
-import ballerina.file;
 import ballerina.io;
 
 @Description{value:"This function will return a ByteChannel from a given file location according to the specified file permission whether the file should be opened for reading/writing."}
 function getFileChannel (string filePath, string permission) (io:ByteChannel) {
-    //Here's how the path of the file will be specified.
-    file:File src = {path:filePath};
     //Here's how the ByteChannel is retrieved from the file.
-    io:ByteChannel channel = src.openChannel(permission);
+    io:ByteChannel channel = io:openFile(filePath, permission);
     return channel;
 }
 

--- a/docs/ballerina-by-example/examples/character-i-o/character-i-o.bal
+++ b/docs/ballerina-by-example/examples/character-i-o/character-i-o.bal
@@ -1,12 +1,10 @@
-import ballerina.file;
 import ballerina.io;
 
 @Description{value:"This function will return a CharacterChannel from a given file location according to the specified permissions and encoding."}
 function getFileCharacterChannel (string filePath, string permission, string encoding)
 (io:CharacterChannel) {
-    file:File src = {path:filePath};
     //First we get the ByteChannel representation of the file.
-    io:ByteChannel channel = src.openChannel(permission);
+    io:ByteChannel channel = io:openFile(filePath, permission);
     //Then we create a character channel from the byte channel to read content as text.
     io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
     return characterChannel;

--- a/docs/ballerina-by-example/examples/character-i-o/character-i-o.bal
+++ b/docs/ballerina-by-example/examples/character-i-o/character-i-o.bal
@@ -7,8 +7,8 @@ function getFileCharacterChannel (string filePath, string permission, string enc
     file:File src = {path:filePath};
     //First we get the ByteChannel representation of the file.
     io:ByteChannel channel = src.openChannel(permission);
-    //Then we convert the byte channel to character channel to read content as text.
-    io:CharacterChannel characterChannel = channel.toCharacterChannel(encoding);
+    //Then we create a character channel from the byte channel to read content as text.
+    io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
     return characterChannel;
 }
 

--- a/docs/ballerina-by-example/examples/inbound-request-with-multiparts/inbound-request-with-multiparts.bal
+++ b/docs/ballerina-by-example/examples/inbound-request-with-multiparts/inbound-request-with-multiparts.bal
@@ -1,7 +1,6 @@
-import ballerina.net.http;
-import ballerina.mime;
 import ballerina.io;
-import ballerina.file;
+import ballerina.mime;
+import ballerina.net.http;
 
 @http:configuration {basePath:"/foo"}
 service<http> echo {
@@ -57,7 +56,6 @@ function writeToFile(blob  readContent) {
 
 @Description {value:"Get a byte channel for the given file."}
 function getByteChannel (string filePath, string permission) (io:ByteChannel) {
-    file:File src = {path:filePath};
-    io:ByteChannel channel = src.openChannel(permission);
+    io:ByteChannel channel = io:openFile(filePath, permission);
     return channel;
 }

--- a/docs/ballerina-by-example/examples/record-i-o/record-i-o.bal
+++ b/docs/ballerina-by-example/examples/record-i-o/record-i-o.bal
@@ -9,8 +9,7 @@ function getFileRecordChannel (string filePath, string permission, string encodi
     io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
     //Finally we convert the character channel to record channel
     //to read content as records.
-    io:DelimitedRecordChannel delimitedRecordChannel = characterChannel.
-                                                             toTextRecordChannel(rs, fs);
+    io:DelimitedRecordChannel delimitedRecordChannel = io:createDelimitedRecordChannel(characterChannel, rs, fs);
     return delimitedRecordChannel;
 }
 

--- a/docs/ballerina-by-example/examples/record-i-o/record-i-o.bal
+++ b/docs/ballerina-by-example/examples/record-i-o/record-i-o.bal
@@ -7,8 +7,8 @@ function getFileRecordChannel (string filePath, string permission, string encodi
     file:File src = {path:filePath};
     //First we get the ByteChannel representation of the file.
     io:ByteChannel channel = src.openChannel(permission);
-    //Then we convert the byte channel to character channel to read content as text.
-    io:CharacterChannel characterChannel = channel.toCharacterChannel(encoding);
+    //Then we create a character channel from the byte channel to read content as text.
+    io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
     //Finally we convert the character channel to record channel
     //to read content as records.
     io:TextRecordChannel textRecordChannel = characterChannel.

--- a/docs/ballerina-by-example/examples/record-i-o/record-i-o.bal
+++ b/docs/ballerina-by-example/examples/record-i-o/record-i-o.bal
@@ -1,12 +1,10 @@
-import ballerina.file;
 import ballerina.io;
 
 @Description{value:"This function will return a TextRecordChannel from a given file location.The encoding is character represenation of the content in file i.e UTF-8 ASCCI. The rs is record seperator i.e newline etc. and fs is field seperator i.e comma etc."}
 function getFileRecordChannel (string filePath, string permission, string encoding,
                                string rs, string fs) (io:TextRecordChannel) {
-    file:File src = {path:filePath};
     //First we get the ByteChannel representation of the file.
-    io:ByteChannel channel = src.openChannel(permission);
+    io:ByteChannel channel = io:openFile(filePath, permission);
     //Then we create a character channel from the byte channel to read content as text.
     io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
     //Finally we convert the character channel to record channel

--- a/docs/getting_started/csvFileProcessor/processFile.bal
+++ b/docs/getting_started/csvFileProcessor/processFile.bal
@@ -1,9 +1,7 @@
-import ballerina.file;
 import ballerina.io;
 
 function getFileRecordChannel (string filePath, string permission, string encoding, string rs, string fs) (io:TextRecordChannel) {
-    file:File src = {path:filePath};
-    io:ByteChannel channel = src.openChannel(permission);
+    io:ByteChannel channel = io:openFile(filePath, permission);
     io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
     io:TextRecordChannel textRecordChannel = characterChannel.toTextRecordChannel(rs, fs);
     return textRecordChannel;

--- a/docs/getting_started/csvFileProcessor/processFile.bal
+++ b/docs/getting_started/csvFileProcessor/processFile.bal
@@ -4,7 +4,7 @@ import ballerina.io;
 function getFileRecordChannel (string filePath, string permission, string encoding, string rs, string fs) (io:TextRecordChannel) {
     file:File src = {path:filePath};
     io:ByteChannel channel = src.openChannel(permission);
-    io:CharacterChannel characterChannel = channel.toCharacterChannel(encoding);
+    io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
     io:TextRecordChannel textRecordChannel = characterChannel.toTextRecordChannel(rs, fs);
     return textRecordChannel;
 }

--- a/docs/getting_started/csvFileProcessor/processFile.bal
+++ b/docs/getting_started/csvFileProcessor/processFile.bal
@@ -3,7 +3,7 @@ import ballerina.io;
 function getFileRecordChannel (string filePath, string permission, string encoding, string rs, string fs) (io:DelimitedRecordChannel) {
     io:ByteChannel channel = io:openFile(filePath, permission);
     io:CharacterChannel characterChannel = channel.toCharacterChannel(encoding);
-    io:DelimitedRecordChannel textRecordChannel = characterChannel.toTextRecordChannel(rs, fs);
+    io:DelimitedRecordChannel textRecordChannel = io:createDelimitedRecordChannel(characterChannel, rs, fs);
     return textRecordChannel;
 }
 

--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/io/natives.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/io/natives.bal
@@ -88,3 +88,9 @@ public native function <ByteChannel channel> close();
 @Param {value:"channel: The TextRecordChannel to read text records from"}
 @Return {value:"True if the channel has more records; false otherwise"}
 public native function <TextRecordChannel channel> hasNextTextRecord () (boolean);
+
+@Description {value:"Function to return a ByteChannel related to the file. This ByteChannel can then be used to read/write from/to the file."}
+@Param {value:"path: The path of the file"}
+@Param {value:"accessMode: Specifies whether the file should be opened for reading or writing (r/w)"}
+@Return {value:"ByteChannel which will allow to perform I/O operations"}
+public native function openFile (string path, string accessMode) (ByteChannel);

--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/io/natives.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/io/natives.bal
@@ -12,11 +12,11 @@ public struct CharacterChannel{
 public struct TextRecordChannel{
 }
 
-@Description { value:"Function to convert a ByteChannel to CharacterChannel"}
+@Description {value:"Function to create a CharacterChannel from ByteChannel"}
 @Param {value:"channel: The ByteChannel to be converted"}
 @Param {value:"encoding: The charset/encoding of the content (i.e UTF-8, ASCII)"}
 @Return {value:"CharacterChannel converted from ByteChannel"}
-public native function <ByteChannel channel> toCharacterChannel(string encoding)(CharacterChannel);
+public native function createCharacterChannel (ByteChannel byteChannel, string encoding) (CharacterChannel);
 
 @Description {value:"Function to convert a CharacterChannel to TextRecordChannel"}
 @Param {value:"channel: The CharacterChannel to be converted"}

--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/io/natives.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/io/natives.bal
@@ -18,13 +18,13 @@ public struct DelimitedRecordChannel {
 @Return {value:"CharacterChannel converted from ByteChannel"}
 public native function createCharacterChannel (ByteChannel byteChannel, string encoding) (CharacterChannel);
 
-@Description {value:"Function to convert a CharacterChannel to DelimitedRecordChannel"}
+@Description {value:"Function to create a CharacterChannel to DelimitedRecordChannel"}
 @Param {value:"channel: The CharacterChannel to be converted"}
 @Param {value:"recordSeparator: Terminating expression to distinguish between records"}
 @Param {value:"fieldSeparator: Terminating expression to distinguish between fields"}
 @Return {value:"DelimitedRecordChannel converted from CharacterChannel"}
-public native function <CharacterChannel channel> toTextRecordChannel(string recordSeparator,
-                                                                      string fieldSeparator)
+public native function createDelimitedRecordChannel(CharacterChannel channel, string recordSeparator,
+                                                    string fieldSeparator)
 (DelimitedRecordChannel);
 
 @Description {value:"Function to read text records"}

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CreateCharacterChannel.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CreateCharacterChannel.java
@@ -1,16 +1,17 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
@@ -27,35 +28,35 @@ import org.ballerinalang.nativeimpl.io.channels.base.CharacterChannel;
 import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.util.codegen.PackageInfo;
 import org.ballerinalang.util.codegen.StructInfo;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
 /**
- * Native function ballerina.io#ToCharacterChannel.
+ * Native function ballerina.io#createCharacterChannel.
  *
  * @since 0.94
  */
 @BallerinaFunction(
         packageName = "ballerina.io",
-        functionName = "toCharacterChannel",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = "ByteChannel", structPackage = "ballerina.io"),
-        args = {@Argument(name = "encoding", type = TypeKind.STRING)},
+        functionName = "createCharacterChannel",
+        args = {@Argument(name = "byteChannel", type = TypeKind.STRUCT, structType = "ByteChannel",
+                    structPackage = "ballerina.io"),
+                @Argument(name = "encoding", type = TypeKind.STRING)},
         returnType = {@ReturnType(type = TypeKind.STRUCT,
                 structType = "CharacterChannel",
                 structPackage = "ballerina.io")},
         isPublic = true
 )
-public class ToCharacterChannel extends AbstractNativeFunction {
+public class CreateCharacterChannel extends AbstractNativeFunction {
     /**
-     * Specifies the index of the character channel in ballerina.io#toCharacterChannel.
+     * Specifies the index of the character channel in ballerina.io#createCharacterChannel.
      */
     private static final int CHAR_CHANNEL_INDEX = 0;
 
     /**
-     * Specifies the index of the encoding in ballerina.io#toCharacterChannel.
+     * Specifies the index of the encoding in ballerina.io#createCharacterChannel.
      */
     private static final int ENCODING_INDEX = 0;
     /**

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CreateDelimitedRecordChannel.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CreateDelimitedRecordChannel.java
@@ -27,40 +27,40 @@ import org.ballerinalang.nativeimpl.io.channels.base.DelimitedRecordChannel;
 import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.util.codegen.PackageInfo;
 import org.ballerinalang.util.codegen.StructInfo;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
 /**
- * Native function ballerina.io#toTextRecordChannel.
+ * Native function ballerina.io#createDelimitedRecordChannel.
  *
- * @since 0.94
+ * @since 0.963.0
  */
 @BallerinaFunction(
         packageName = "ballerina.io",
-        functionName = "toTextRecordChannel",
-        receiver = @Receiver(type = TypeKind.STRUCT, structType = "CharacterChannel", structPackage = "ballerina.io"),
-        args = {@Argument(name = "recordSeparator", type = TypeKind.STRING),
+        functionName = "createDelimitedRecordChannel",
+        args = {@Argument(name = "channel", type = TypeKind.STRUCT, structType = "DelimitedRecordChannel",
+                structPackage = "ballerina.io"),
+                @Argument(name = "recordSeparator", type = TypeKind.STRING),
                 @Argument(name = "fieldSeparator", type = TypeKind.STRING)},
         returnType = {@ReturnType(type = TypeKind.STRUCT,
                 structType = "DelimitedRecordChannel",
                 structPackage = "ballerina.io")},
         isPublic = true
 )
-public class ToTextRecordChannel extends AbstractNativeFunction {
+public class CreateDelimitedRecordChannel extends AbstractNativeFunction {
 
     /**
-     * The index od the text record channel in ballerina.io#toTextRecordChannel().
+     * The index od the text record channel in ballerina.io#createDelimitedRecordChannel().
      */
     private static final int RECORD_CHANNEL_INDEX = 0;
     /**
-     * The index of the record channel separator in ballerina.io#toTextRecordChannel().
+     * The index of the record channel separator in ballerina.io#createDelimitedRecordChannel().
      */
     private static final int RECORD_SEPARATOR_INDEX = 0;
     /**
-     * The index of the field separator in ballerina.io#toTextRecordChannel().
+     * The index of the field separator in ballerina.io#createDelimitedRecordChannel().
      */
     private static final int FIELD_SEPARATOR_INDEX = 1;
     /**

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/OpenFile.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/OpenFile.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.nativeimpl.io;
+
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.nativeimpl.io.channels.AbstractNativeChannel;
+import org.ballerinalang.nativeimpl.io.channels.FileIOChannel;
+import org.ballerinalang.nativeimpl.io.channels.base.AbstractChannel;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+import org.ballerinalang.util.exceptions.BallerinaException;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Native function to obtain channel from File.
+ *
+ * @since 0.963.0
+ */
+@BallerinaFunction(
+        packageName = "ballerina.io",
+        functionName = "openFile",
+        args = {@Argument(name = "path", type = TypeKind.STRING),
+                @Argument(name = "accessMode", type = TypeKind.STRING)},
+        returnType = {@ReturnType(type = TypeKind.STRUCT, structType = "ByteChannel", structPackage = "ballerina.io")},
+        isPublic = true
+)
+public class OpenFile extends AbstractNativeChannel {
+
+    private static final int PATH_FIELD_INDEX = 0;
+    private static final int FILE_ACCESS_MODE_INDEX = 1;
+
+    /**
+     * Creates a directory at the specified path.
+     *
+     * @param path the file location url
+     */
+    private void createDirs(Path path) {
+        Path parent = path.getParent();
+        if (parent != null && !Files.exists(parent)) {
+            try {
+                Files.createDirectories(parent);
+            } catch (IOException e) {
+                throw new BallerinaException("Error in writing file", e);
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AbstractChannel inFlow(Context context) throws BallerinaException {
+        String pathUrl = getStringArgument(context, PATH_FIELD_INDEX);
+        String accessMode = getStringArgument(context, FILE_ACCESS_MODE_INDEX);
+        Path path = null;
+        AbstractChannel channel;
+        try {
+            String accessLC = accessMode.toLowerCase(Locale.getDefault());
+            path = Paths.get(pathUrl);
+            Set<OpenOption> opts = new HashSet<>();
+            if (accessLC.contains("r")) {
+                if (!Files.exists(path)) {
+                    throw new BallerinaException("file not found: " + path);
+                }
+                if (!Files.isReadable(path)) {
+                    throw new BallerinaException("file is not readable: " + path);
+                }
+                opts.add(StandardOpenOption.READ);
+            }
+            boolean write = accessLC.contains("w");
+            boolean append = accessLC.contains("a");
+            if (write || append) {
+                if (Files.exists(path) && !Files.isWritable(path)) {
+                    throw new BallerinaException("file is not writable: " + path);
+                }
+                createDirs(path);
+                opts.add(StandardOpenOption.CREATE);
+                if (append) {
+                    opts.add(StandardOpenOption.APPEND);
+                } else {
+                    opts.add(StandardOpenOption.WRITE);
+                }
+            }
+            FileChannel byteChannel = FileChannel.open(path, opts);
+            channel = new FileIOChannel(byteChannel, IOConstants.CHANNEL_BUFFER_SIZE);
+        } catch (AccessDeniedException e) {
+            throw new BallerinaException("Do not have access to write file: " + path, e);
+        } catch (Throwable e) {
+            throw new BallerinaException("failed to open file: " + e.getMessage(), e);
+        }
+        return channel;
+    }
+}

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/AbstractNativeChannel.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/AbstractNativeChannel.java
@@ -36,7 +36,7 @@ import org.ballerinalang.util.exceptions.BallerinaException;
  * This will prepare the ByteChannel to perform I/O operations.
  * </p>
  *
- * @see org.ballerinalang.nativeimpl.file.OpenChannel
+ * @see org.ballerinalang.nativeimpl.io.OpenFile
  */
 public abstract class AbstractNativeChannel extends AbstractNativeFunction {
 

--- a/stdlib/ballerina-mime/src/main/ballerina/ballerina/mime/natives.bal
+++ b/stdlib/ballerina-mime/src/main/ballerina/ballerina/mime/natives.bal
@@ -71,7 +71,7 @@ public function getText (Entity entity) (string) {
         if (overFlowData != null) {
             string encoding = getEncoding(entity.contentType);
             io:ByteChannel channel = overFlowData.openChannel(READ_PERMISSION);
-            io:CharacterChannel characterChannel = channel.toCharacterChannel(encoding);
+            io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
             string characters = characterChannel.readAllCharacters();
             return characters;
         }

--- a/tests/ballerina-test/src/test/resources/test-src/io/bytesio.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/bytesio.bal
@@ -1,11 +1,9 @@
-import ballerina.file;
 import ballerina.io;
 
 io:ByteChannel channel;
 
 function initFileChannel(string filePath, string permission){
-    file:File src = {path:filePath};
-    channel = src.openChannel(permission);
+    channel = io:openFile(filePath, permission);
 }
 
 function readAll() (blob) {

--- a/tests/ballerina-test/src/test/resources/test-src/io/chario.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/chario.bal
@@ -6,7 +6,7 @@ io:CharacterChannel characterChannel;
 function initFileChannel(string filePath,string permission,string encoding){
     file:File src = {path:filePath};
     io:ByteChannel channel = src.openChannel(permission);
-    characterChannel = channel.toCharacterChannel(encoding);
+    characterChannel = io:createCharacterChannel(channel, encoding);
 }
 
 function readAll()(string){

--- a/tests/ballerina-test/src/test/resources/test-src/io/chario.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/chario.bal
@@ -1,11 +1,9 @@
-import ballerina.file;
 import ballerina.io;
 
 io:CharacterChannel characterChannel;
 
 function initFileChannel(string filePath,string permission,string encoding){
-    file:File src = {path:filePath};
-    io:ByteChannel channel = src.openChannel(permission);
+    io:ByteChannel channel = io:openFile(filePath, permission);
     characterChannel = io:createCharacterChannel(channel, encoding);
 }
 

--- a/tests/ballerina-test/src/test/resources/test-src/io/recordio.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/recordio.bal
@@ -4,8 +4,8 @@ io:DelimitedRecordChannel delimitedRecordChannel;
 
 function initFileChannel(string filePath,string permission,string encoding,string rs,string fs){
     io:ByteChannel channel = io:openFile(filePath, permission);
-    io:CharacterChannel  characterChannel = channel.toCharacterChannel(encoding);
-    delimitedRecordChannel = characterChannel.toTextRecordChannel(rs, fs);
+    io:CharacterChannel  characterChannel = io:createCharacterChannel(channel, encoding);
+    delimitedRecordChannel = io:createDelimitedRecordChannel(characterChannel, rs, fs);
 }
 
 function nextRecord () (string[]) {

--- a/tests/ballerina-test/src/test/resources/test-src/io/recordio.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/recordio.bal
@@ -1,11 +1,9 @@
-import ballerina.file;
 import ballerina.io;
 
 io:TextRecordChannel textRecordChannel;
 
 function initFileChannel(string filePath,string permission,string encoding,string rs,string fs){
-    file:File src = {path:filePath};
-    io:ByteChannel channel = src.openChannel(permission);
+    io:ByteChannel channel = io:openFile(filePath, permission);
     io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
     textRecordChannel = characterChannel.toTextRecordChannel(rs,fs);
 }

--- a/tests/ballerina-test/src/test/resources/test-src/io/recordio.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/recordio.bal
@@ -6,7 +6,7 @@ io:TextRecordChannel textRecordChannel;
 function initFileChannel(string filePath,string permission,string encoding,string rs,string fs){
     file:File src = {path:filePath};
     io:ByteChannel channel = src.openChannel(permission);
-    io:CharacterChannel  characterChannel = channel.toCharacterChannel(encoding);
+    io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
     textRecordChannel = characterChannel.toTextRecordChannel(rs,fs);
 }
 

--- a/tool-plugins/intellij/src/test/resources/testData/mockSdk-0.95.4/src/ballerina/io/natives.bal
+++ b/tool-plugins/intellij/src/test/resources/testData/mockSdk-0.95.4/src/ballerina/io/natives.bal
@@ -12,11 +12,11 @@ public struct CharacterChannel{
 public struct TextRecordChannel{
 }
 
-@Description { value:"Function to convert a ByteChannel to CharacterChannel"}
+@Description {value:"Function to create a CharacterChannel from ByteChannel "}
 @Param {value:"channel: The ByteChannel to be converted"}
 @Param {value:"encoding: The charset/encoding of the content (i.e UTF-8, ASCII)"}
 @Return {value:"CharacterChannel converted from ByteChannel"}
-public native function <ByteChannel channel> toCharacterChannel(string encoding)(CharacterChannel);
+public native function createCharacterChannel (ByteChannel byteChannel, string encoding) (CharacterChannel);
 
 @Description {value:"Function to convert a CharacterChannel to TextRecordChannel"}
 @Param {value:"channel: The CharacterChannel to be converted"}

--- a/tool-plugins/intellij/src/test/resources/testData/mockSdk-0.95.4/src/ballerina/io/natives.bal
+++ b/tool-plugins/intellij/src/test/resources/testData/mockSdk-0.95.4/src/ballerina/io/natives.bal
@@ -8,38 +8,38 @@ public struct ByteChannel{
 public struct CharacterChannel{
 }
 
-@Description {value:"Ballerina TextRecordChannel represents a channel which will allow to read/write text records"}
-public struct TextRecordChannel{
+@Description {value:"Ballerina DelimitedRecordChannel represents a channel which will allow to read/write text records"}
+public struct DelimitedRecordChannel {
 }
 
-@Description {value:"Function to create a CharacterChannel from ByteChannel "}
+@Description {value:"Function to create a CharacterChannel from ByteChannel"}
 @Param {value:"channel: The ByteChannel to be converted"}
 @Param {value:"encoding: The charset/encoding of the content (i.e UTF-8, ASCII)"}
 @Return {value:"CharacterChannel converted from ByteChannel"}
 public native function createCharacterChannel (ByteChannel byteChannel, string encoding) (CharacterChannel);
 
-@Description {value:"Function to convert a CharacterChannel to TextRecordChannel"}
+@Description {value:"Function to create a CharacterChannel to DelimitedRecordChannel"}
 @Param {value:"channel: The CharacterChannel to be converted"}
 @Param {value:"recordSeparator: Terminating expression to distinguish between records"}
 @Param {value:"fieldSeparator: Terminating expression to distinguish between fields"}
-@Return {value:"TextRecordChannel converted from CharacterChannel"}
-public native function <CharacterChannel channel> toTextRecordChannel(string recordSeparator,
-                                                                      string fieldSeparator)
-                                                                      (TextRecordChannel);
+@Return {value:"DelimitedRecordChannel converted from CharacterChannel"}
+public native function createDelimitedRecordChannel(CharacterChannel channel, string recordSeparator,
+                                                    string fieldSeparator)
+(DelimitedRecordChannel);
 
 @Description {value:"Function to read text records"}
-@Param {value:"channel: The TextRecordChannel to read text records from"}
+@Param {value:"channel: The DelimitedRecordChannel to read text records from"}
 @Return {value:"Fields listed in the record"}
-public native function <TextRecordChannel channel> readTextRecord()(string []);
+public native function <DelimitedRecordChannel channel> nextTextRecord () (string[]);
 
 @Description {value:"Function to write text records"}
-@Param {value:"channel: The TextRecordChannel to write text records to"}
+@Param {value:"channel: The DelimitedRecordChannel to write records"}
 @Param {value:"records: Fields which are included in the record"}
-public native function <TextRecordChannel channel> writeTextRecord(string [] records);
+public native function <DelimitedRecordChannel channel> writeTextRecord (string[] records);
 
 @Description{value:"Function to close the text record channel"}
-@Param {value:"channel: The TextRecordChannel to be closed"}
-public native function <TextRecordChannel channel> closeTextRecordChannel();
+@Param {value:"channel: The DelimitedRecordChannel to be closed"}
+public native function <DelimitedRecordChannel channel> closeDelimitedRecordChannel();
 
 @Description {value:"Function to read characters"}
 @Param {value:"channel: The CharacterChannel to read characters from"}
@@ -84,8 +84,13 @@ public native function <ByteChannel channel> writeBytes(blob content,int startOf
 @Param {value:"channel: The ByteChannel to be closed"}
 public native function <ByteChannel channel> close();
 
+@Description {value:"Function to check whether next record is available or not"}
+@Param {value:"channel: The DelimitedRecordChannel to read text records from"}
+@Return {value:"True if the channel has more records; false otherwise"}
+public native function <DelimitedRecordChannel channel> hasNextTextRecord () (boolean);
+
 @Description {value:"Function to return a ByteChannel related to the file. This ByteChannel can then be used to read/write from/to the file."}
 @Param {value:"path: The path of the file"}
 @Param {value:"accessMode: Specifies whether the file should be opened for reading or writing (r/w)"}
 @Return {value:"ByteChannel which will allow to perform I/O operations"}
-public native function openFile (string path, string accessMode) (io:ByteChannel);
+public native function openFile (string path, string accessMode) (ByteChannel);

--- a/tool-plugins/intellij/src/test/resources/testData/mockSdk-0.95.4/src/ballerina/io/natives.bal
+++ b/tool-plugins/intellij/src/test/resources/testData/mockSdk-0.95.4/src/ballerina/io/natives.bal
@@ -83,3 +83,9 @@ public native function <ByteChannel channel> writeBytes(blob content,int startOf
 @Description { value:"Function to close a byte channel"}
 @Param {value:"channel: The ByteChannel to be closed"}
 public native function <ByteChannel channel> close();
+
+@Description {value:"Function to return a ByteChannel related to the file. This ByteChannel can then be used to read/write from/to the file."}
+@Param {value:"path: The path of the file"}
+@Param {value:"accessMode: Specifies whether the file should be opened for reading or writing (r/w)"}
+@Return {value:"ByteChannel which will allow to perform I/O operations"}
+public native function openFile (string path, string accessMode) (io:ByteChannel);


### PR DESCRIPTION
## Purpose
Channel open functionalities are bound to structs. We should able to create a channel without initiating any structs.
Resolves https://github.com/ballerina-lang/ballerina/issues/4710

## Goals
Remove struct bound channel open operations.

## Approach
Move current struct bound functions to IO package level.

## User stories
N/A

## Release note
[IO] Move channel open functionalities to IO package level

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including produ