### PR TITLE
Avoid overriding accept-encoding header

### DIFF
--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/AbstractHTTPAction.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/AbstractHTTPAction.java
@@ -89,7 +89,9 @@ public abstract class AbstractHTTPAction extends AbstractNativeAction {
         HttpUtil.checkEntityAvailability(context, requestStruct);
         HttpUtil.enrichOutboundMessage(requestMsg, requestStruct);
         prepareOutboundRequest(bConnector, path, requestMsg);
-        requestMsg.setHeader(ACCEPT_ENCODING, ENCODING_DEFLATE + ", " + ENCODING_GZIP);
+        if (requestMsg.getHeader(ACCEPT_ENCODING) == null) {
+            requestMsg.setHeader(ACCEPT_ENCODING, ENCODING_DEFLATE + ", " + ENCODING_GZIP);
+        }
         return requestMsg;
     }
 

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Execute.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Execute.java
@@ -98,7 +98,9 @@ public class Execute extends AbstractHTTPAction {
             httpVerb = (String) outboundRequestMsg.getProperty(HttpConstants.HTTP_METHOD);
         }
         outboundRequestMsg.setProperty(HttpConstants.HTTP_METHOD, httpVerb.trim().toUpperCase(Locale.getDefault()));
-        outboundRequestMsg.setHeader(ACCEPT_ENCODING, ENCODING_DEFLATE + ", " + ENCODING_GZIP);
+        if (outboundRequestMsg.getHeader(ACCEPT_ENCODING) == null) {
+            outboundRequestMsg.setHeader(ACCEPT_ENCODING, ENCODING_DEFLATE + ", " + ENCODING_GZIP);
+        }
         return outboundRequestMsg;
     }
 }


### PR DESCRIPTION
## Purpose
> Resolve https://github.com/ballerina-lang/ballerina/issues/4706
## Goals
> Make sure that if the accept-encoding header is already present in the incoming request it is not overridden.

## Approach
> Add a null check to see if the header is already present.

## Related PRs
> https://github.com/ballerina-lang/ballerina/pull/4709
>https://github.com/wso2/transport-http/pull/52

## Test environment
> JDK 8 | Ubuntu 17.10
 