### PR TITLE
Add completion and suggestion support for Endpoint Definition

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/AbstractItemResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/AbstractItemResolver.java
@@ -84,7 +84,9 @@ public abstract class AbstractItemResolver {
     private CompletionItem populateBallerinaFunctionCompletionItem(SymbolInfo symbolInfo) {
         CompletionItem completionItem = new CompletionItem();
         BSymbol bSymbol = symbolInfo.getScopeEntry().symbol;
-        assert bSymbol instanceof BInvokableSymbol;
+        if (!(bSymbol instanceof BInvokableSymbol)) {
+            return null;
+        }
         BInvokableSymbol bInvokableSymbol = (BInvokableSymbol) bSymbol;
         if (bInvokableSymbol.getName().getValue().contains("<")
                 || bInvokableSymbol.getName().getValue().contains("<") ||

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/EndpointDefinitionContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/EndpointDefinitionContextResolver.java
@@ -1,0 +1,77 @@
+/*
+*  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.ballerinalang.langserver.completions.resolvers;
+
+import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.completions.CompletionKeys;
+import org.ballerinalang.langserver.completions.SymbolInfo;
+import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
+import org.ballerinalang.langserver.completions.util.Snippet;
+import org.ballerinalang.langserver.completions.util.sorters.EndpointDefContextItemSorter;
+import org.ballerinalang.langserver.completions.util.sorters.ItemSorters;
+import org.eclipse.lsp4j.CompletionItem;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BEndpointType;
+import org.wso2.ballerinalang.compiler.tree.BLangVariable;
+import org.wso2.ballerinalang.compiler.tree.types.BLangEndpointTypeNode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Item resolver for the endpoint definition context.
+ */
+public class EndpointDefinitionContextResolver extends AbstractItemResolver {
+    @Override
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+        BLangVariable bLangVariable = (BLangVariable) completionContext.get(CompletionKeys.SYMBOL_ENV_NODE_KEY);
+        if (!(bLangVariable.typeNode instanceof BLangEndpointTypeNode)) {
+            return null;
+        }
+
+        ArrayList<CompletionItem> completionItems = new ArrayList<>();
+        completionItems.add(getCreateKeyWordCompletionItem());
+        List<SymbolInfo> filteredSymbols =
+                filterEndpointContextItems(completionContext.get(CompletionKeys.VISIBLE_SYMBOLS_KEY));
+        this.populateCompletionItemList(filteredSymbols, completionItems);
+
+        ItemSorters.getSorterByClass(EndpointDefContextItemSorter.class).sortItems(completionContext, completionItems);
+                
+        return completionItems;
+    }
+    
+    private CompletionItem getCreateKeyWordCompletionItem() {
+        CompletionItem createItem = new CompletionItem();
+        createItem.setInsertText(Snippet.CREATE_KEYWORD_SNIPPET.toString());
+        createItem.setLabel(ItemResolverConstants.CREATE_KEYWORD);
+        createItem.setDetail(ItemResolverConstants.KEYWORD_TYPE);
+        return createItem;
+    }
+    
+    private List<SymbolInfo> filterEndpointContextItems(List<SymbolInfo> symbols) {
+        return symbols.stream().filter(symbolInfo -> {
+            BSymbol bSymbol = symbolInfo.getScopeEntry().symbol;
+            return (bSymbol instanceof BInvokableSymbol && ((BInvokableSymbol) bSymbol).receiverSymbol == null)
+                    || (!(bSymbol instanceof BInvokableSymbol)
+                    && bSymbol instanceof BVarSymbol && !(bSymbol.type instanceof BEndpointType));
+        }).collect(Collectors.toList());
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/CompletionItemResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/CompletionItemResolver.java
@@ -24,6 +24,7 @@ import org.ballerinalang.langserver.completions.resolvers.BLangStructContextReso
 import org.ballerinalang.langserver.completions.resolvers.BlockStatementContextResolver;
 import org.ballerinalang.langserver.completions.resolvers.ConnectorDefinitionContextResolver;
 import org.ballerinalang.langserver.completions.resolvers.DefaultResolver;
+import org.ballerinalang.langserver.completions.resolvers.EndpointDefinitionContextResolver;
 import org.ballerinalang.langserver.completions.resolvers.PackageNameContextResolver;
 import org.ballerinalang.langserver.completions.resolvers.ParameterContextResolver;
 import org.ballerinalang.langserver.completions.resolvers.ServiceContextResolver;
@@ -45,6 +46,7 @@ import org.wso2.ballerinalang.compiler.parser.antlr4.BallerinaParser;
 import org.wso2.ballerinalang.compiler.tree.BLangConnector;
 import org.wso2.ballerinalang.compiler.tree.BLangService;
 import org.wso2.ballerinalang.compiler.tree.BLangStruct;
+import org.wso2.ballerinalang.compiler.tree.BLangVariable;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangBlockStmt;
 
 import java.util.Collections;
@@ -80,6 +82,8 @@ public enum CompletionItemResolver {
             new ServiceContextResolver()),
     CONNECTOR_DEF_CONTEXT(BLangConnector.class,
             new ConnectorDefinitionContextResolver()),
+    ENDPOINT_DEF_CONTEXT(BLangVariable.class,
+            new EndpointDefinitionContextResolver()),
 
     PARSER_RULE_STATEMENT_CONTEXT(BallerinaParser.StatementContext.class,
             new ParserRuleStatementContextResolver()),

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/Priority.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/Priority.java
@@ -21,18 +21,18 @@ package org.ballerinalang.langserver.completions.util;
  * Completion Item Priority enum.
  */
 public enum  Priority {
-    PRIORITY10(10),
-    PRIORITY20(20),
-    PRIORITY30(30),
-    PRIORITY40(40),
-    PRIORITY50(50),
-    PRIORITY60(60),
-    PRIORITY70(70),
-    PRIORITY80(80),
-    PRIORITY90(90),
-    PRIORITY100(100),
     PRIORITY110(110),
-    PRIORITY120(120);
+    PRIORITY120(120),
+    PRIORITY130(130),
+    PRIORITY140(140),
+    PRIORITY150(150),
+    PRIORITY160(160),
+    PRIORITY170(170),
+    PRIORITY180(180),
+    PRIORITY190(190),
+    PRIORITY200(200),
+    PRIORITY210(210),
+    PRIORITY220(220);
 
     private int priority;
 
@@ -46,5 +46,15 @@ public enum  Priority {
     
     public String toString() {
         return Integer.toString(this.priority);
+    }
+
+    /**
+     * Shift the base priority from the base priority and get the shifted new priority value.
+     * @param basePriority  Base priority
+     * @param offset        Offset to shift the base priority to get the new value
+     * @return              {@link String} calculated new priority value
+     */
+    public static String shiftPriority(String basePriority, int offset) {
+        return String.valueOf(Integer.parseInt(basePriority) + offset);
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/CallableUnitBodyItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/CallableUnitBodyItemSorter.java
@@ -68,7 +68,7 @@ class CallableUnitBodyItemSorter extends CompletionItemSorter {
                 this.populateWhenCursorBeforeOrAfterEp(completionItems);
             } else {
                 CompletionItem workerItem = this.getWorkerSnippet();
-                workerItem.setSortText(Priority.PRIORITY60.toString());
+                workerItem.setSortText(Priority.PRIORITY160.toString());
                 completionItems.add(workerItem);
             }
         } else if (previousNode instanceof BLangWorker) {
@@ -82,8 +82,8 @@ class CallableUnitBodyItemSorter extends CompletionItemSorter {
         CompletionItem workerSnippet = this.getWorkerSnippet();
         this.setPriorities(completionItems);
 
-        epSnippet.setSortText(Priority.PRIORITY50.toString());
-        workerSnippet.setSortText(Priority.PRIORITY60.toString());
+        epSnippet.setSortText(Priority.PRIORITY150.toString());
+        workerSnippet.setSortText(Priority.PRIORITY160.toString());
         completionItems.add(epSnippet);
         completionItems.add(workerSnippet);
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/CompletionItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/CompletionItemSorter.java
@@ -60,40 +60,40 @@ public abstract class CompletionItemSorter {
         completionItems.forEach(completionItem -> {
             switch (completionItem.getDetail()) {
                 case ItemResolverConstants.NONE:
-                    completionItem.setSortText(Priority.PRIORITY120.toString());
+                    completionItem.setSortText(Priority.PRIORITY220.toString());
                     break;
                 case ItemResolverConstants.KEYWORD_TYPE:
-                    completionItem.setSortText(Priority.PRIORITY110.toString());
+                    completionItem.setSortText(Priority.PRIORITY210.toString());
                     break;
                 case ItemResolverConstants.STATEMENT_TYPE:
-                    completionItem.setSortText(Priority.PRIORITY100.toString());
+                    completionItem.setSortText(Priority.PRIORITY200.toString());
                     break;
                 case ItemResolverConstants.SNIPPET_TYPE:
-                    completionItem.setSortText(Priority.PRIORITY90.toString());
+                    completionItem.setSortText(Priority.PRIORITY190.toString());
                     break;
                 case ItemResolverConstants.FIELD_TYPE:
-                    completionItem.setSortText(Priority.PRIORITY80.toString());
+                    completionItem.setSortText(Priority.PRIORITY180.toString());
                     break;
                 case ItemResolverConstants.B_TYPE:
-                    completionItem.setSortText(Priority.PRIORITY70.toString());
+                    completionItem.setSortText(Priority.PRIORITY170.toString());
                     break;
                 case ItemResolverConstants.ENUM_TYPE:
-                    completionItem.setSortText(Priority.PRIORITY60.toString());
+                    completionItem.setSortText(Priority.PRIORITY160.toString());
                     break;
                 case ItemResolverConstants.STRUCT:
-                    completionItem.setSortText(Priority.PRIORITY50.toString());
+                    completionItem.setSortText(Priority.PRIORITY150.toString());
                     break;
                 case ItemResolverConstants.PACKAGE_TYPE:
-                    completionItem.setSortText(Priority.PRIORITY40.toString());
+                    completionItem.setSortText(Priority.PRIORITY140.toString());
                     break;
                 case ItemResolverConstants.ACTION_TYPE:
-                    completionItem.setSortText(Priority.PRIORITY30.toString());
+                    completionItem.setSortText(Priority.PRIORITY130.toString());
                     break;
                 case ItemResolverConstants.FUNCTION_TYPE:
-                    completionItem.setSortText(Priority.PRIORITY20.toString());
+                    completionItem.setSortText(Priority.PRIORITY120.toString());
                     break;
                 default:
-                    completionItem.setSortText(Priority.PRIORITY10.toString());
+                    completionItem.setSortText(Priority.PRIORITY110.toString());
                     break;
             }
         });

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/ConnectorContextItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/ConnectorContextItemSorter.java
@@ -58,7 +58,7 @@ class ConnectorContextItemSorter extends CompletionItemSorter {
             } else {
                 this.setPriorities(completionItems);
                 CompletionItem resItem = this.getActionSnippet();
-                resItem.setSortText(Priority.PRIORITY60.toString());
+                resItem.setSortText(Priority.PRIORITY160.toString());
                 completionItems.add(resItem);
             }
         } else if (previousNode instanceof BLangAction) {
@@ -72,8 +72,8 @@ class ConnectorContextItemSorter extends CompletionItemSorter {
         CompletionItem resSnippet = this.getActionSnippet();
         this.setPriorities(completionItems);
 
-        epSnippet.setSortText(Priority.PRIORITY50.toString());
-        resSnippet.setSortText(Priority.PRIORITY60.toString());
+        epSnippet.setSortText(Priority.PRIORITY150.toString());
+        resSnippet.setSortText(Priority.PRIORITY160.toString());
         completionItems.add(epSnippet);
         completionItems.add(resSnippet);
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/EndpointDefContextItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/EndpointDefContextItemSorter.java
@@ -1,0 +1,65 @@
+/*
+*  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.ballerinalang.langserver.completions.util.sorters;
+
+import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.completions.CompletionKeys;
+import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
+import org.ballerinalang.langserver.completions.util.Priority;
+import org.eclipse.lsp4j.CompletionItem;
+import org.wso2.ballerinalang.compiler.tree.BLangVariable;
+import org.wso2.ballerinalang.compiler.tree.types.BLangEndpointTypeNode;
+import org.wso2.ballerinalang.compiler.tree.types.BLangUserDefinedType;
+
+import java.util.List;
+
+/**
+ * Endpoint definition context item sorter.
+ */
+public class EndpointDefContextItemSorter extends CompletionItemSorter {
+    /**
+     * Sort Completion Items based on a particular criteria.
+     *
+     * @param ctx             Completion context
+     * @param completionItems List of initial completion items
+     */
+    @Override
+    public void sortItems(TextDocumentServiceContext ctx, List<CompletionItem> completionItems) {
+        this.setPriorities(completionItems);
+        BLangVariable bLangVariable = (BLangVariable) ctx.get(CompletionKeys.SYMBOL_ENV_NODE_KEY);
+        if (!(bLangVariable.typeNode instanceof BLangEndpointTypeNode)) {
+            return;
+        }
+        String constraintType = ((BLangUserDefinedType) ((BLangEndpointTypeNode) bLangVariable.typeNode).constraint)
+                .type.toString();
+        completionItems.forEach(completionItem -> {
+            if (completionItem.getDetail().equals(ItemResolverConstants.FUNCTION_TYPE)) {
+                String label = completionItem.getLabel();
+                String[] returnTypes = label.substring(label.lastIndexOf("(") + 1, label.lastIndexOf(")")).split(",");
+                if (returnTypes.length == 1 && returnTypes[0].equals(constraintType)) {
+                    String newPriority = Priority.shiftPriority(completionItem.getSortText(), -1);
+                    completionItem.setSortText(String.valueOf(newPriority));
+                }
+            } else if (completionItem.getDetail().equals(ItemResolverConstants.KEYWORD_TYPE)) {
+                completionItem.setSortText(Priority.shiftPriority(Priority.PRIORITY110.toString(), -1));
+            } else if (completionItem.getDetail().equals(constraintType)) {
+                completionItem.setSortText(Priority.shiftPriority(completionItem.getSortText(), -1));
+            }
+        });
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/ItemSorters.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/ItemSorters.java
@@ -43,6 +43,8 @@ public enum ItemSorters {
             new CallableUnitBodyItemSorter()),
     DEFAULT_ITEM_SORTER(DefaultItemSorter.class,
             new DefaultItemSorter()),
+    ENDPOINT_DEF_ITEM_SORTER(EndpointDefContextItemSorter.class,
+            new EndpointDefContextItemSorter()),
     RESOURCE_BODY_ITEM_SORTER(BLangAction.class,
             new CallableUnitBodyItemSorter()),
     SERVICE_BODY_ITEM_SORTER(BLangService.class,

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/ServiceContextItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/ServiceContextItemSorter.java
@@ -58,7 +58,7 @@ public class ServiceContextItemSorter extends CompletionItemSorter {
             } else {
                 this.setPriorities(completionItems);
                 CompletionItem resItem = this.getResourceSnippet();
-                resItem.setSortText(Priority.PRIORITY60.toString());
+                resItem.setSortText(Priority.PRIORITY160.toString());
                 completionItems.add(resItem);
             }
         } else if (previousNode instanceof BLangResource) {
@@ -72,8 +72,8 @@ public class ServiceContextItemSorter extends CompletionItemSorter {
         CompletionItem resSnippet = this.getResourceSnippet();
         this.setPriorities(completionItems);
 
-        epSnippet.setSortText(Priority.PRIORITY50.toString());
-        resSnippet.setSortText(Priority.PRIORITY60.toString());
+        epSnippet.setSortText(Priority.PRIORITY150.toString());
+        resSnippet.setSortText(Priority.PRIORITY160.toString());
         completionItems.add(epSnippet);
         completionItems.add(resSnippet);
     }


### PR DESCRIPTION
## Purpose
> Here we add the completion support for the endpoint definition context. With this initial implementation
basic completions of functions, variable definitions and the keyword (create) suggestions are implemented. Resolves #4725, Resolves #4724

## Goals
> Add the support for completion within the endpoint definition by implementing the context based item resolver for endpoint definition

## Approach
> 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/1329674/36423639-c476e780-1666-11e8-9274-063e36683c3a.gif)
