### PR TITLE
Use lower case headers consistently

### DIFF
--- a/composer/modules/server/services/ballerina-langserver/src/main/java/org/ballerinalang/composer/service/ballerina/langserver/service/WSRPCMessageConsumer.java
+++ b/composer/modules/server/services/ballerina-langserver/src/main/java/org/ballerinalang/composer/service/ballerina/langserver/service/WSRPCMessageConsumer.java
@@ -17,6 +17,7 @@
  */
 package org.ballerinalang.composer.service.ballerina.langserver.service;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
 import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
 import org.eclipse.lsp4j.jsonrpc.messages.Message;
@@ -53,9 +54,9 @@ public class WSRPCMessageConsumer implements MessageConsumer {
 
     protected String getHeader(int contentLength) {
         StringBuilder headerBuilder = new StringBuilder();
-        this.appendHeader(headerBuilder, "Content-Length", contentLength).append("\r\n");
+        this.appendHeader(headerBuilder, HttpHeaderNames.CONTENT_LENGTH.toString(), contentLength).append("\r\n");
         if (!StandardCharsets.UTF_8.name().equals(this.encoding)) {
-            this.appendHeader(headerBuilder, "Content-Type", "application/json");
+            this.appendHeader(headerBuilder, HttpHeaderNames.CONTENT_TYPE.toString(), "application/json");
             headerBuilder.append("; charset=").append(this.encoding).append("\r\n");
         }
 

--- a/composer/modules/server/services/ballerina-parser/src/main/java/org/ballerinalang/composer/service/ballerina/parser/service/BallerinaParserService.java
+++ b/composer/modules/server/services/ballerina-parser/src/main/java/org/ballerinalang/composer/service/ballerina/parser/service/BallerinaParserService.java
@@ -22,6 +22,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -97,10 +98,14 @@ public class BallerinaParserService implements ComposerService {
     @Produces(MediaType.APPLICATION_JSON)
     public Response getBuiltInPackages() {
         return Response.ok()
-                .header("Access-Control-Max-Age", "600 ")
-                .header("Access-Control-Allow-Origin", "*").header("Access-Control-Allow-Credentials",
-                        "true").header("Access-Control-Allow-Methods", "POST, GET, PUT, UPDATE, DELETE, OPTIONS, HEAD")
-                .header("Access-Control-Allow-Headers", "Content-Type, Accept, X-Requested-With").build();
+                .header(HttpHeaderNames.ACCESS_CONTROL_MAX_AGE.toString(), "600 ")
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), "*")
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString(), "true")
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString(),
+                        "POST, GET, PUT, UPDATE, DELETE, OPTIONS, HEAD")
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS.toString(),
+                        HttpHeaderNames.CONTENT_TYPE.toString() + ", " + HttpHeaderNames.ACCEPT.toString() +
+                                ", X-Requested-With").build();
     }
 
     @GET
@@ -126,10 +131,14 @@ public class BallerinaParserService implements ComposerService {
     @Produces(MediaType.APPLICATION_JSON)
     public Response getBuiltInTypesOptions() {
         return Response.ok()
-                .header("Access-Control-Max-Age", "600 ")
-                .header("Access-Control-Allow-Origin", "*").header("Access-Control-Allow-Credentials",
-                        "true").header("Access-Control-Allow-Methods", "POST, GET, PUT, UPDATE, DELETE, OPTIONS, HEAD")
-                .header("Access-Control-Allow-Headers", "Content-Type, Accept, X-Requested-With").build();
+                .header(HttpHeaderNames.ACCESS_CONTROL_MAX_AGE.toString(), "600 ")
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), "*")
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString(), "true")
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString(),
+                        "POST, GET, PUT, UPDATE, DELETE, OPTIONS, HEAD")
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS.toString(),
+                        HttpHeaderNames.CONTENT_TYPE.toString() + ", " + HttpHeaderNames.ACCEPT.toString() +
+                                ", X-Requested-With").build();
     }
 
     @GET
@@ -146,7 +155,8 @@ public class BallerinaParserService implements ComposerService {
         response.add("types", packagesArray);
         return Response.status(Response.Status.OK)
                 .entity(response)
-                .header("Access-Control-Allow-Origin", '*').type(MediaType.APPLICATION_JSON).build();
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), '*').type(MediaType.APPLICATION_JSON)
+                .build();
     }
 
     @POST
@@ -157,7 +167,8 @@ public class BallerinaParserService implements ComposerService {
             IllegalAccessException {
         return Response.status(Response.Status.OK)
                 .entity(validateAndParse(bFileRequest))
-                .header("Access-Control-Allow-Origin", '*').type(MediaType.APPLICATION_JSON).build();
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), '*').type(MediaType.APPLICATION_JSON)
+                .build();
     }
 
     @OPTIONS
@@ -167,9 +178,13 @@ public class BallerinaParserService implements ComposerService {
     public Response validateAndParseOptions() {
         return Response.ok()
                 .header("Access-Control-Max-Age", "600 ")
-                .header("Access-Control-Allow-Origin", "*").header("Access-Control-Allow-Credentials",
-                        "true").header("Access-Control-Allow-Methods", "POST, GET, PUT, UPDATE, DELETE, OPTIONS, HEAD")
-                .header("Access-Control-Allow-Headers", "Content-Type, Accept, X-Requested-With").build();
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), "*")
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString(), "true")
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString(),
+                        "POST, GET, PUT, UPDATE, DELETE, OPTIONS, HEAD")
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS.toString(),
+                        HttpHeaderNames.CONTENT_TYPE.toString() + ", " + HttpHeaderNames.ACCEPT.toString() +
+                                ", X-Requested-With").build();
     }
 
     @POST
@@ -178,7 +193,8 @@ public class BallerinaParserService implements ComposerService {
     @Produces(MediaType.APPLICATION_JSON)
     public Response getBallerinaJsonDataModelGivenFragment(BLangSourceFragment sourceFragment) throws IOException {
         String response = BLangFragmentParser.parseFragment(sourceFragment);
-        return Response.ok(response, MediaType.APPLICATION_JSON).header("Access-Control-Allow-Origin", '*').build();
+        return Response.ok(response, MediaType.APPLICATION_JSON).header(
+                HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), '*').build();
     }
 
     @OPTIONS
@@ -188,9 +204,12 @@ public class BallerinaParserService implements ComposerService {
     public Response optionsParseFragment() {
         return Response.ok()
                 .header("Access-Control-Max-Age", "600 ")
-                .header("Access-Control-Allow-Origin", "*").header("Access-Control-Allow-Credentials",
-                        "true").header("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
-                .header("Access-Control-Allow-Headers", "Content-Type, Accept, X-Requested-With").build();
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), "*")
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString(), "true")
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString(), "POST, GET, OPTIONS")
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS.toString(),
+                        HttpHeaderNames.CONTENT_TYPE.toString() + ", " + HttpHeaderNames.ACCEPT.toString() +
+                                ", X-Requested-With").build();
     }
 
     public static JsonElement generateJSON(Node node, Map<String, Node> anonStructs)

--- a/composer/modules/server/services/ballerina-to-swagger/src/main/java/org/ballerinalang/composer/service/ballerina/swagger/service/BallerinaToSwaggerService.java
+++ b/composer/modules/server/services/ballerina-to-swagger/src/main/java/org/ballerinalang/composer/service/ballerina/swagger/service/BallerinaToSwaggerService.java
@@ -16,6 +16,7 @@
 package org.ballerinalang.composer.service.ballerina.swagger.service;
 
 import com.google.gson.JsonObject;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.ballerina.swagger.convertor.service.SwaggerConverterUtils;
 import org.ballerinalang.composer.server.core.ServerConstants;
 import org.ballerinalang.composer.server.spi.ComposerService;
@@ -45,11 +46,14 @@ import javax.ws.rs.core.Response;
 public class BallerinaToSwaggerService implements ComposerService {
     private static final Logger logger = LoggerFactory.getLogger(BallerinaToSwaggerService.class);
 
-    private static final String ACCESS_CONTROL_ALLOW_ORIGIN_NAME = "Access-Control-Allow-Origin";
+    private static final String ACCESS_CONTROL_ALLOW_ORIGIN_NAME =
+            HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString();
     private static final String ACCESS_CONTROL_ALLOW_ORIGIN_VALUE = "*";
-    private static final String ACCESS_CONTROL_ALLOW_HEADERS_NAME = "Access-Control-Allow-Headers";
-    private static final String ACCESS_CONTROL_ALLOW_HEADERS_VALUE = "content-type";
-    private static final String ACCESS_CONTROL_ALLOW_METHODS_NAME = "Access-Control-Allow-Methods";
+    private static final String ACCESS_CONTROL_ALLOW_HEADERS_NAME =
+            HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS.toString();
+    private static final String ACCESS_CONTROL_ALLOW_HEADERS_VALUE = HttpHeaderNames.CONTENT_TYPE.toString();
+    private static final String ACCESS_CONTROL_ALLOW_METHODS_NAME =
+            HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString();
     private static final String ACCESS_CONTROL_ALLOW_METHODS_VALUE = "OPTIONS, POST";
 
     @POST
@@ -65,14 +69,14 @@ public class BallerinaToSwaggerService implements ComposerService {
             // Generate the swagger definitions using ballerina source.
             String swaggerDefinition = SwaggerConverterUtils.generateSwaggerDefinitions(ballerinaSource, serviceName);
             swaggerServiceContainer.setSwaggerDefinition(swaggerDefinition);
-            return Response.ok().entity(swaggerServiceContainer).header("Access-Control-Allow-Origin", '*').build();
+            return Response.ok().entity(swaggerServiceContainer).header(ACCESS_CONTROL_ALLOW_ORIGIN_NAME, '*').build();
         } catch (Exception ex) {
             logger.error("error: while processing service definition at converter service: " + ex.getMessage(), ex);
             JsonObject entity = new JsonObject();
             entity.addProperty("Error", ex.toString());
             return Response.status(Response.Status.BAD_REQUEST)
                     .entity(entity)
-                    .header("Access-Control-Allow-Origin", '*')
+                    .header(ACCESS_CONTROL_ALLOW_ORIGIN_NAME, '*')
                     .type(MediaType.APPLICATION_JSON).build();
         }
     }

--- a/composer/modules/server/services/ballerina-tryit/src/main/java/org/ballerinalang/composer/service/tryit/service/TryItService.java
+++ b/composer/modules/server/services/ballerina-tryit/src/main/java/org/ballerinalang/composer/service/tryit/service/TryItService.java
@@ -17,6 +17,7 @@
 package org.ballerinalang.composer.service.tryit.service;
 
 import com.google.gson.JsonObject;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.composer.server.core.ServerConfig;
 import org.ballerinalang.composer.server.core.ServerConstants;
 import org.ballerinalang.composer.server.spi.ComposerService;
@@ -135,11 +136,14 @@ public class TryItService implements ComposerService {
     @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.APPLICATION_JSON)
     public Response options() {
-        return Response.ok().header("Access-Control-Allow-Origin", "*")
-                .header("Access-Control-Allow-Credentials", "true")
-                .header("Access-Control-Allow-Methods", "POST, GET, PUT, UPDATE, DELETE, OPTIONS, HEAD")
-                .header("Access-Control-Allow-Headers", "Content-Type, Accept, X-Requested-With")
-                .build();
+        return Response.ok().header("Access-Control-Max-Age", "600 ")
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), "*")
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString(), "true")
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString(),
+                        "POST, GET, PUT, UPDATE, DELETE, OPTIONS, HEAD")
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS.toString(),
+                        HttpHeaderNames.CONTENT_TYPE.toString() + ", " + HttpHeaderNames.ACCEPT.toString() +
+                                ", X-Requested-With").build();
         
     }
     

--- a/composer/modules/server/services/file-system/src/main/java/org/ballerinalang/composer/service/fs/service/FileSystemService.java
+++ b/composer/modules/server/services/file-system/src/main/java/org/ballerinalang/composer/service/fs/service/FileSystemService.java
@@ -17,6 +17,7 @@ package org.ballerinalang.composer.service.fs.service;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.composer.server.core.ServerConstants;
 import org.ballerinalang.composer.server.spi.ComposerService;
 import org.ballerinalang.composer.server.spi.ServiceInfo;
@@ -350,10 +351,12 @@ public class FileSystemService implements ComposerService {
      */
     public Response createCORSResponse() {
         return Response.ok()
-                .header("Access-Control-Allow-Origin", "*")
-                .header("Access-Control-Allow-Credentials", "true")
-                .header("Access-Control-Allow-Methods", "POST, GET, OPTIONS ")
-                .header("Access-Control-Allow-Headers", "Content-Type, Accept, X-Requested-With")
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), "*")
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString(), "true")
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString(), "POST, GET, OPTIONS ")
+                .header(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS.toString(),
+                        HttpHeaderNames.CONTENT_TYPE.toString() + ", " + HttpHeaderNames.ACCEPT.toString() +
+                                ", X-Requested-With")
                 .build();
     }
 

--- a/docs/ballerina-by-example/examples/http-disable-chunking/http-disable-chunking.bal
+++ b/docs/ballerina-by-example/examples/http-disable-chunking/http-disable-chunking.bal
@@ -28,8 +28,8 @@ service<http> echo {
     resource echoResource (http:Connection conn, http:InRequest req) {
         string value;
         //Set response according to the request headers.
-        if (req.getHeader("Content-Length") != null) {
-            value = "Lenght-" + req.getHeader("Content-Length");
+        if (req.getHeader("content-length") != null) {
+            value = "Lenght-" + req.getHeader("content-length");
         } else {
             value = req.getHeader("Transfer-Encoding");
         }

--- a/pom.xml
+++ b/pom.xml
@@ -1183,7 +1183,7 @@
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
         <carbon.kernel.version>5.1.0</carbon.kernel.version>
-        <transport.http.version>6.0.93</transport.http.version>
+        <transport.http.version>6.0.94</transport.http.version>
         <carbon.messaging.version>2.3.7</carbon.messaging.version>
         <carbon.deployment.version>5.0.0</carbon.deployment.version>
         <carbon.config.version>2.1.2</carbon.config.version>

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/utils/Constants.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/utils/Constants.java
@@ -22,11 +22,6 @@ package org.ballerinalang.nativeimpl.lang.utils;
 public class Constants {
     
     /**
-     * Content type HTTP header.
-     */
-    public static final String CONTENT_TYPE = "Content-Type";
-    
-    /**
      * HTTP content-type application/json.
      */
     public static final String APPLICATION_JSON = "application/json";

--- a/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
@@ -2,8 +2,8 @@ package ballerina.net.http;
 
 import ballerina.mime;
 
-@Description {value:"Represent 'Content-Legth' header name"}
-public const string CONTENT_LENGTH = "Content-Length";
+@Description {value:"Represent 'content-length' header name"}
+public const string CONTENT_LENGTH = "content-length";
 
 @Description { value:"Represents the HTTP server connector connection"}
 @Field {value:"remoteHost: The server host name"}

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -44,16 +44,8 @@ public class HttpConstants {
     public static final String HTTP_METHOD = "HTTP_METHOD";
     public static final String HTTP_STATUS_CODE = "HTTP_STATUS_CODE";
     public static final String HTTP_REASON_PHRASE = "HTTP_REASON_PHRASE";
-    public static final String HTTP_CONTENT_LENGTH = "Content-Length";
-    public static final String USER_AGENT_HEADER = "User-Agent";
-    public static final String CONTENT_TYPE_HEADER = "Content-Type";
-    public static final String CONTENT_ENCODING_HEADER = "content-encoding";
-    public static final String ACCEPT_HEADER = "Accept";
-    public static final String ALLOW = "Allow";
-    public static final String SERVER_HEADER = "Server";
     public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
     public static final String PROTOCOL = "PROTOCOL";
-    public static final String PORT = "PORT";
     public static final String TO = "TO";
     public static final String LOCAL_ADDRESS = "LOCAL_ADDRESS";
     public static final String HTTP_VERSION = "HTTP_VERSION";
@@ -128,16 +120,6 @@ public class HttpConstants {
     public static final String SESSION = "Session";
     public static final String HTTP_ONLY = "HttpOnly";
     public static final String SECURE = "Secure";
-
-    public static final String ORIGIN = "Origin";
-    public static final String AC_REQUEST_METHOD = "Access-Control-Request-Method";
-    public static final String AC_REQUEST_HEADERS = "Access-Control-Request-Headers";
-    public static final String AC_ALLOW_ORIGIN = "Access-Control-Allow-Origin";
-    public static final String AC_ALLOW_CREDENTIALS = "Access-Control-Allow-Credentials";
-    public static final String AC_ALLOW_METHODS = "Access-Control-Allow-Methods";
-    public static final String AC_MAX_AGE = "Access-Control-Max-Age";
-    public static final String AC_ALLOW_HEADERS = "Access-Control-Allow-Headers";
-    public static final String AC_EXPOSE_HEADERS = "Access-Control-Expose-Headers";
 
     public static final String ALLOW_ORIGIN = "allowOrigins";
     public static final String ALLOW_CREDENTIALS = "allowCredentials";
@@ -236,10 +218,8 @@ public class HttpConstants {
     public static final int RETRY_COUNT_INDEX = 0;
     public static final int RETRY_INTERVAL_INDEX = 1;
 
-    public static final String CONNECTION_HEADER = "Connection";
     public static final String HEADER_VAL_CONNECTION_CLOSE = "Close";
     public static final String HEADER_VAL_CONNECTION_KEEP_ALIVE = "Keep-Alive";
-    public static final String EXPECT_HEADER = "Expect";
     public static final String HEADER_VAL_100_CONTINUE = "100-continue";
 
     //Response codes

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpDispatcher.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpDispatcher.java
@@ -160,7 +160,7 @@ public class HttpDispatcher {
             }
 
             // Find the Resource
-            resource = HTTPResourceDispatcher.findResource(service, httpCarbonMessage);
+            resource = HttpResourceDispatcher.findResource(service, httpCarbonMessage);
         } catch (Throwable throwable) {
             handleError(httpCarbonMessage, throwable);
         }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpResourceDataElement.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpResourceDataElement.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.net.http;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.net.uri.DispatcherUtil;
 import org.ballerinalang.net.uri.parser.DataElement;
 import org.ballerinalang.util.exceptions.BallerinaException;
@@ -119,7 +120,7 @@ public class HttpResourceDataElement implements DataElement<HttpResource, HTTPCa
 
     private boolean setAllowHeadersIfOPTIONS(String httpMethod, HTTPCarbonMessage cMsg) {
         if (httpMethod.equals(HttpConstants.HTTP_METHOD_OPTIONS)) {
-            cMsg.setHeader(HttpConstants.ALLOW, getAllowHeaderValues(cMsg));
+            cMsg.setHeader(HttpHeaderNames.ALLOW.toString(), getAllowHeaderValues(cMsg));
             return true;
         }
         return false;
@@ -140,7 +141,7 @@ public class HttpResourceDataElement implements DataElement<HttpResource, HTTPCa
     }
 
     public HttpResource validateConsumes(HttpResource resource, HTTPCarbonMessage cMsg) {
-        String contentMediaType = extractContentMediaType(cMsg.getHeader(HttpConstants.CONTENT_TYPE_HEADER));
+        String contentMediaType = extractContentMediaType(cMsg.getHeader(HttpHeaderNames.CONTENT_TYPE.toString()));
         List<String> consumesList = resource.getConsumes();
 
         if (consumesList == null) {
@@ -168,7 +169,7 @@ public class HttpResourceDataElement implements DataElement<HttpResource, HTTPCa
     }
 
     public HttpResource validateProduces(HttpResource resource, HTTPCarbonMessage cMsg) {
-        List<String> acceptMediaTypes = extractAcceptMediaTypes(cMsg.getHeader(HttpConstants.ACCEPT_HEADER));
+        List<String> acceptMediaTypes = extractAcceptMediaTypes(cMsg.getHeader(HttpHeaderNames.ACCEPT.toString()));
         List<String> producesList = resource.getProduces();
 
         if (producesList == null || acceptMediaTypes == null) {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpResourceDispatcher.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpResourceDispatcher.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.net.http;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.connector.api.BallerinaConnectorException;
 import org.ballerinalang.net.uri.DispatcherUtil;
 import org.ballerinalang.net.uri.URITemplateException;
@@ -30,7 +31,7 @@ import java.util.Map;
 /**
  * Resource level dispatchers handler for HTTP protocol.
  */
-public class HTTPResourceDispatcher {
+public class HttpResourceDispatcher {
 
     public static HttpResource findResource(HttpService service, HTTPCarbonMessage inboundRequest)
             throws BallerinaConnectorException {
@@ -74,11 +75,12 @@ public class HTTPResourceDispatcher {
     private static void handleOptionsRequest(HTTPCarbonMessage cMsg, HttpService service)
             throws URITemplateException {
         HTTPCarbonMessage response = HttpUtil.createHttpCarbonMessage(false);
-        if (cMsg.getHeader(HttpConstants.ALLOW) != null) {
-            response.setHeader(HttpConstants.ALLOW, cMsg.getHeader(HttpConstants.ALLOW));
+        if (cMsg.getHeader(HttpHeaderNames.ALLOW.toString()) != null) {
+            response.setHeader(HttpHeaderNames.ALLOW.toString(), cMsg.getHeader(HttpHeaderNames.ALLOW.toString()));
         } else if (service.getBasePath().equals(cMsg.getProperty(HttpConstants.TO))
                 && !service.getAllAllowMethods().isEmpty()) {
-            response.setHeader(HttpConstants.ALLOW, DispatcherUtil.concatValues(service.getAllAllowMethods(), false));
+            response.setHeader(HttpHeaderNames.ALLOW.toString(),
+                               DispatcherUtil.concatValues(service.getAllAllowMethods(), false));
         } else {
             cMsg.setProperty(HttpConstants.HTTP_STATUS_CODE, 404);
             throw new BallerinaConnectorException("no matching resource found for path : "

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Execute.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Execute.java
@@ -16,6 +16,7 @@
 
 package org.ballerinalang.net.http.actions;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.connector.api.ConnectorFuture;
 import org.ballerinalang.model.types.TypeKind;
@@ -34,7 +35,6 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
 import java.util.Locale;
 
-import static org.wso2.transport.http.netty.common.Constants.ACCEPT_ENCODING;
 import static org.wso2.transport.http.netty.common.Constants.ENCODING_DEFLATE;
 import static org.wso2.transport.http.netty.common.Constants.ENCODING_GZIP;
 
@@ -98,8 +98,9 @@ public class Execute extends AbstractHTTPAction {
             httpVerb = (String) outboundRequestMsg.getProperty(HttpConstants.HTTP_METHOD);
         }
         outboundRequestMsg.setProperty(HttpConstants.HTTP_METHOD, httpVerb.trim().toUpperCase(Locale.getDefault()));
-        if (outboundRequestMsg.getHeader(ACCEPT_ENCODING) == null) {
-            outboundRequestMsg.setHeader(ACCEPT_ENCODING, ENCODING_DEFLATE + ", " + ENCODING_GZIP);
+        if (outboundRequestMsg.getHeader(HttpHeaderNames.ACCEPT_ENCODING.toString()) == null) {
+            outboundRequestMsg.setHeader(HttpHeaderNames.ACCEPT_ENCODING.toString(),
+                                         ENCODING_DEFLATE + ", " + ENCODING_GZIP);
         }
         return outboundRequestMsg;
     }

--- a/stdlib/ballerina-mime/src/main/java/org/ballerinalang/mime/util/Constants.java
+++ b/stdlib/ballerina-mime/src/main/java/org/ballerinalang/mime/util/Constants.java
@@ -35,18 +35,8 @@ public class Constants {
     /**
      * Content type HTTP header.
      */
-    public static final String CONTENT_TYPE = "Content-Type";
-
-    public static final String CONTENT_LENGTH = "Content-Length";
-
-    public static final String CONTENT_DISPOSITION = "Content-Disposition";
 
     public static final String CONTENT_ID = "Content-Id";
-
-    /**
-     * Content-Transfer-Encoding HTTP header.
-     */
-    public static final String CONTENT_TRANSFER_ENCODING = "Content-Transfer-Encoding";
 
     /**
      * Content-type application/json.

--- a/stdlib/ballerina-mime/src/main/java/org/ballerinalang/mime/util/HeaderUtil.java
+++ b/stdlib/ballerina-mime/src/main/java/org/ballerinalang/mime/util/HeaderUtil.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.mime.util;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStringArray;
@@ -32,10 +33,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.ballerinalang.mime.util.Constants.ASSIGNMENT;
-import static org.ballerinalang.mime.util.Constants.CONTENT_DISPOSITION;
 import static org.ballerinalang.mime.util.Constants.CONTENT_ID;
 import static org.ballerinalang.mime.util.Constants.CONTENT_ID_INDEX;
-import static org.ballerinalang.mime.util.Constants.CONTENT_TYPE;
 import static org.ballerinalang.mime.util.Constants.ENTITY_HEADERS_INDEX;
 import static org.ballerinalang.mime.util.Constants.FIRST_ELEMENT;
 import static org.ballerinalang.mime.util.Constants.SEMICOLON;
@@ -220,7 +219,7 @@ public class HeaderUtil {
      */
     static void setContentTypeHeader(BStruct bodyPart, BMap<String, BValue> entityHeaders) {
         String contentType = MimeUtil.getContentTypeWithParameters(bodyPart);
-        addToEntityHeaders(entityHeaders, CONTENT_TYPE, contentType);
+        addToEntityHeaders(entityHeaders, HttpHeaderNames.CONTENT_TYPE.toString(), contentType);
     }
 
     /**
@@ -232,7 +231,7 @@ public class HeaderUtil {
     static void setContentDispositionHeader(BStruct bodyPart, BMap<String, BValue> entityHeaders) {
         String contentDisposition = MimeUtil.getContentDisposition(bodyPart);
         if (MimeUtil.isNotNullAndEmpty(contentDisposition)) {
-            addToEntityHeaders(entityHeaders, CONTENT_DISPOSITION, contentDisposition);
+            addToEntityHeaders(entityHeaders, HttpHeaderNames.CONTENT_DISPOSITION.toString(), contentDisposition);
         }
     }
 

--- a/stdlib/ballerina-mime/src/main/java/org/ballerinalang/mime/util/MimeUtil.java
+++ b/stdlib/ballerina-mime/src/main/java/org/ballerinalang/mime/util/MimeUtil.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.mime.util;
 
+
 import io.netty.util.internal.PlatformDependent;
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.model.values.BMap;

--- a/stdlib/ballerina-mime/src/main/java/org/ballerinalang/mime/util/MultipartDecoder.java
+++ b/stdlib/ballerina-mime/src/main/java/org/ballerinalang/mime/util/MultipartDecoder.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.mime.util;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.connector.api.ConnectorUtils;
 import org.ballerinalang.model.values.BMap;
@@ -35,10 +36,8 @@ import javax.activation.MimeTypeParseException;
 
 import static org.ballerinalang.mime.util.Constants.BOUNDARY;
 import static org.ballerinalang.mime.util.Constants.BYTE_LIMIT;
-import static org.ballerinalang.mime.util.Constants.CONTENT_DISPOSITION;
 import static org.ballerinalang.mime.util.Constants.CONTENT_DISPOSITION_STRUCT;
 import static org.ballerinalang.mime.util.Constants.CONTENT_ID_INDEX;
-import static org.ballerinalang.mime.util.Constants.CONTENT_LENGTH;
 import static org.ballerinalang.mime.util.Constants.ENTITY;
 import static org.ballerinalang.mime.util.Constants.ENTITY_HEADERS_INDEX;
 import static org.ballerinalang.mime.util.Constants.FIRST_ELEMENT;
@@ -132,7 +131,7 @@ public class MultipartDecoder {
         populateContentLength(mimePart, partStruct);
         populateContentId(mimePart, partStruct);
         populateContentType(mimePart, partStruct, mediaType);
-        List<String> contentDispositionHeaders = mimePart.getHeader(CONTENT_DISPOSITION);
+        List<String> contentDispositionHeaders = mimePart.getHeader(HttpHeaderNames.CONTENT_DISPOSITION.toString());
         if (HeaderUtil.isHeaderExist(contentDispositionHeaders)) {
             BStruct contentDisposition = ConnectorUtils.createAndGetStruct(context, PROTOCOL_PACKAGE_MIME,
                     CONTENT_DISPOSITION_STRUCT);
@@ -156,7 +155,7 @@ public class MultipartDecoder {
     }
 
     private static void populateContentLength(MIMEPart mimePart, BStruct partStruct) {
-        List<String> lengthHeaders = mimePart.getHeader(CONTENT_LENGTH);
+        List<String> lengthHeaders = mimePart.getHeader(HttpHeaderNames.CONTENT_LENGTH.toString());
         if (HeaderUtil.isHeaderExist(lengthHeaders)) {
             MimeUtil.setContentLength(partStruct, Integer.parseInt(lengthHeaders.get(FIRST_ELEMENT)));
         } else {

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http/sample/EchoServiceSampleTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http/sample/EchoServiceSampleTestCase.java
@@ -17,6 +17,7 @@
 */
 package org.ballerinalang.test.service.http.sample;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.test.IntegrationTestCase;
 import org.ballerinalang.test.context.ServerInstance;
 import org.ballerinalang.test.util.HttpClientRequest;
@@ -46,12 +47,12 @@ public class EchoServiceSampleTestCase extends IntegrationTestCase {
                     + File.separator + "httpService" + File.separator + "echoService.bal").getAbsolutePath();
             startServer(relativePath);
             Map<String, String> headers = new HashMap<>();
-            headers.put(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_TEXT_PLAIN);
+            headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_TEXT_PLAIN);
             HttpResponse response = HttpClientRequest.doPost(ballerinaServer
                     .getServiceURLHttp("echo"), requestMessage, headers);
             Assert.assertNotNull(response);
             Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-            Assert.assertEquals(response.getHeaders().get(TestConstant.HEADER_CONTENT_TYPE)
+            Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
                     , TestConstant.CONTENT_TYPE_TEXT_PLAIN, "Content-Type mismatched");
             //request should be returned as response
             Assert.assertEquals(response.getData(), requestMessage, "Message content mismatched");
@@ -67,7 +68,7 @@ public class EchoServiceSampleTestCase extends IntegrationTestCase {
                     + File.separator + "httpService" + File.separator + "httpEchoService.bal").getAbsolutePath();
             startServer(relativePath);
             Map<String, String> headers = new HashMap<>();
-            headers.put(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_JSON);
+            headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
             String serviceUrl = "http://localhost:9094/echo";
             String requestMsg = "{\"key\":\"value\"}";
             HttpResponse response = HttpClientRequest.doPost(serviceUrl, requestMsg, headers);
@@ -77,7 +78,7 @@ public class EchoServiceSampleTestCase extends IntegrationTestCase {
             }
             Assert.assertNotNull(response);
             Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-            Assert.assertEquals(response.getHeaders().get(TestConstant.HEADER_CONTENT_TYPE)
+            Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
                     , TestConstant.CONTENT_TYPE_TEXT_PLAIN, "Content-Type mismatched");
             String respMsg = "hello world";
             Assert.assertEquals(response.getData(), respMsg, "Message content mismatched");
@@ -94,7 +95,7 @@ public class EchoServiceSampleTestCase extends IntegrationTestCase {
                     + File.separator + "httpService" + File.separator + "httpEchoService.bal").getAbsolutePath();
             startServer(relativePath);
             Map<String, String> headers = new HashMap<>();
-            headers.put(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_JSON);
+            headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
             String serviceUrl = "http://localhost:9094/echoOne/abc";
             String requestMsg = "{\"key\":\"value\"}";
             HttpResponse response = HttpClientRequest.doPost(serviceUrl, requestMsg, headers);
@@ -104,7 +105,7 @@ public class EchoServiceSampleTestCase extends IntegrationTestCase {
             }
             Assert.assertNotNull(response);
             Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-            Assert.assertEquals(response.getHeaders().get(TestConstant.HEADER_CONTENT_TYPE)
+            Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
                     , TestConstant.CONTENT_TYPE_TEXT_PLAIN, "Content-Type mismatched");
             String respMsg = "hello world";
             Assert.assertEquals(response.getData(), respMsg, "Message content mismatched");
@@ -121,7 +122,7 @@ public class EchoServiceSampleTestCase extends IntegrationTestCase {
                     + File.separator + "httpService" + File.separator + "httpsEchoService.bal").getAbsolutePath();
             startServer(relativePath);
             Map<String, String> headers = new HashMap<>();
-            headers.put(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_JSON);
+            headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
             String serviceUrl = "https://localhost:9095/echo";
             String serverHome = getServerInstance().getServerHome();
             String requestMsg = "{\"key\":\"value\"}";
@@ -132,7 +133,7 @@ public class EchoServiceSampleTestCase extends IntegrationTestCase {
             }
             Assert.assertNotNull(response);
             Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-            Assert.assertEquals(response.getHeaders().get(TestConstant.HEADER_CONTENT_TYPE)
+            Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
                     , TestConstant.CONTENT_TYPE_TEXT_PLAIN, "Content-Type mismatched");
             String respMsg = "hello world";
             Assert.assertEquals(response.getData(), respMsg, "Message content mismatched");
@@ -149,7 +150,7 @@ public class EchoServiceSampleTestCase extends IntegrationTestCase {
                     + File.separator + "httpService" + File.separator + "httpsEchoService.bal").getAbsolutePath();
             startServer(relativePath);
             Map<String, String> headers = new HashMap<>();
-            headers.put(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_JSON);
+            headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
             String serviceUrl = "https://localhost:9095/echoOne/abc";
             String serverHome = getServerInstance().getServerHome();
             String requestMsg = "{\"key\":\"value\"}";
@@ -160,7 +161,7 @@ public class EchoServiceSampleTestCase extends IntegrationTestCase {
             }
             Assert.assertNotNull(response);
             Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-            Assert.assertEquals(response.getHeaders().get(TestConstant.HEADER_CONTENT_TYPE)
+            Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
                     , TestConstant.CONTENT_TYPE_TEXT_PLAIN, "Content-Type mismatched");
             String respMsg = "hello world";
             Assert.assertEquals(response.getData(), respMsg, "Message content mismatched");

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http/sample/EcommerceSampleTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http/sample/EcommerceSampleTestCase.java
@@ -17,6 +17,7 @@
 */
 package org.ballerinalang.test.service.http.sample;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.test.IntegrationTestCase;
 import org.ballerinalang.test.context.ServerInstance;
 import org.ballerinalang.test.util.HttpClientRequest;
@@ -52,8 +53,8 @@ public class EcommerceSampleTestCase extends IntegrationTestCase {
         HttpResponse response = HttpClientRequest.doGet(ballerinaServer
                 .getServiceURLHttp("ecommerceservice/products/123001"));
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-        Assert.assertEquals(response.getHeaders().get(TestConstant.HEADER_CONTENT_TYPE), TestConstant.CONTENT_TYPE_JSON,
-                "Content-Type mismatched");
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString()),
+                            TestConstant.CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(response.getData(),
                 "{\"Product\":{\"ID\":\"123001\",\"Name\":\"ABC_2\",\"Description\":\"Sample product.\"}}",
                 "Message content mismatched");
@@ -64,7 +65,7 @@ public class EcommerceSampleTestCase extends IntegrationTestCase {
         HttpResponse response = HttpClientRequest.doGet(ballerinaServer
                 .getServiceURLHttp("ecommerceservice/orders"));
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-        Assert.assertEquals(response.getHeaders().get(TestConstant.HEADER_CONTENT_TYPE)
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(response.getData(), "{\"Order\":{\"ID\":\"111999\",\"Name\":\"ABC123\"," +
                                                 "\"Description\":\"Sample order.\"}}"
@@ -76,7 +77,7 @@ public class EcommerceSampleTestCase extends IntegrationTestCase {
         HttpResponse response = HttpClientRequest.doGet(ballerinaServer
                 .getServiceURLHttp("ecommerceservice/customers"));
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-        Assert.assertEquals(response.getHeaders().get(TestConstant.HEADER_CONTENT_TYPE)
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(response.getData(), "{\"Customer\":{\"ID\":\"987654\",\"Name\":\"ABC PQR\"," +
                                                 "\"Description\":\"Sample Customer.\"}}"
@@ -86,12 +87,12 @@ public class EcommerceSampleTestCase extends IntegrationTestCase {
     @Test(description = "Test resource POST orders in E-Commerce sample")
     public void testPostOrder() throws IOException {
         Map<String, String> headers = new HashMap<>();
-        headers.put(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_JSON);
+        headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
         HttpResponse response = HttpClientRequest.doPost(ballerinaServer
                         .getServiceURLHttp("ecommerceservice/orders")
                 , "{\"Order\":{\"ID\":\"111222\",\"Name\":\"XYZ123\"}}", headers);
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-        Assert.assertEquals(response.getHeaders().get(TestConstant.HEADER_CONTENT_TYPE)
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(response.getData(), "{\"Status\":\"Order is successfully added.\"}"
                 , "Message content mismatched");
@@ -100,12 +101,12 @@ public class EcommerceSampleTestCase extends IntegrationTestCase {
     @Test(description = "Test resource POST products in E-Commerce sample")
     public void testPostProduct() throws IOException {
         Map<String, String> headers = new HashMap<>();
-        headers.put(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_JSON);
+        headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
         HttpResponse response = HttpClientRequest.doPost(ballerinaServer
                         .getServiceURLHttp("ecommerceservice/products")
                 , "{\"Product\":{\"ID\":\"123345\",\"Name\":\"PQR\"}}", headers);
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-        Assert.assertEquals(response.getHeaders().get(TestConstant.HEADER_CONTENT_TYPE)
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(response.getData(), "{\"Status\":\"Product is successfully added.\"}"
                 , "Message content mismatched");
@@ -114,12 +115,12 @@ public class EcommerceSampleTestCase extends IntegrationTestCase {
     @Test(description = "Test resource POST customers in E-Commerce sample")
     public void testPostCustomers() throws IOException {
         Map<String, String> headers = new HashMap<>();
-        headers.put(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_JSON);
+        headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
         HttpResponse response = HttpClientRequest.doPost(ballerinaServer
                         .getServiceURLHttp("ecommerceservice/customers")
                 , "{\"Customer\":{\"ID\":\"97453\",\"Name\":\"ABC XYZ\"}}", headers);
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-        Assert.assertEquals(response.getHeaders().get(TestConstant.HEADER_CONTENT_TYPE)
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(response.getData(), "{\"Status\":\"Customer is successfully added.\"}"
                 , "Message content mismatched");

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http/sample/HTTPVerbsPassthruTestCases.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http/sample/HTTPVerbsPassthruTestCases.java
@@ -17,6 +17,7 @@
 */
 package org.ballerinalang.test.service.http.sample;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.test.IntegrationTestCase;
 import org.ballerinalang.test.context.ServerInstance;
 import org.ballerinalang.test.util.HttpClientRequest;
@@ -110,7 +111,7 @@ public class HTTPVerbsPassthruTestCases extends IntegrationTestCase {
     public void testDataBindingJsonPayload() throws IOException {
         String payload = "{\"name\":\"WSO2\",\"team\":\"ballerina\"}";
         Map<String, String> headers = new HashMap<>();
-        headers.put(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_JSON);
+        headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
         HttpResponse response = HttpClientRequest.doPost(ballerinaServer.getServiceURLHttp("getQuote/employee")
                 , payload, headers);
 
@@ -123,7 +124,7 @@ public class HTTPVerbsPassthruTestCases extends IntegrationTestCase {
     public void testDataBindingWithIncompatiblePayload() throws IOException {
         String payload = "name:WSO2,team:ballerina";
         Map<String, String> headers = new HashMap<>();
-        headers.put(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_TEXT_PLAIN);
+        headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_TEXT_PLAIN);
         HttpResponse response = HttpClientRequest.doPost(ballerinaServer.getServiceURLHttp("getQuote/employee")
                 , payload, headers);
 

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http/sample/HelloWorldSampleTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http/sample/HelloWorldSampleTestCase.java
@@ -17,6 +17,7 @@
 */
 package org.ballerinalang.test.service.http.sample;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.test.IntegrationTestCase;
 import org.ballerinalang.test.context.ServerInstance;
 import org.ballerinalang.test.util.HttpClientRequest;
@@ -49,7 +50,7 @@ public class HelloWorldSampleTestCase extends IntegrationTestCase {
     public void testHelloWorldServiceByBasePath() throws IOException {
         HttpResponse response = HttpClientRequest.doGet(ballerinaServer.getServiceURLHttp("hello"));
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-        Assert.assertEquals(response.getHeaders().get(TestConstant.HEADER_CONTENT_TYPE)
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_TEXT_PLAIN, "Content-Type mismatched");
         Assert.assertEquals(response.getData(), "Hello, World!", "Message content mismatched");
     }

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http/sample/HttpOptionsTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http/sample/HttpOptionsTestCase.java
@@ -17,6 +17,7 @@
 */
 package org.ballerinalang.test.service.http.sample;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.test.context.ServerInstance;
 import org.ballerinalang.test.util.HttpClientRequest;
 import org.ballerinalang.test.util.HttpResponse;
@@ -47,28 +48,28 @@ public class HttpOptionsTestCase {
     @Test(description = "Test OPTIONS content length header sample test case")
     public void testOptionsContentLengthHeader() throws Exception {
         Map<String, String> headers = new HashMap<>();
-        headers.put(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_JSON);
+        headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
         String serviceUrl = "http://localhost:9090/echoDummy";
         HttpResponse response = HttpClientRequest.doOptions(serviceUrl, headers);
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-        Assert.assertEquals(response.getHeaders().get(TestConstant.HEADER_CONTENT_LENGTH)
-                , "0", "Content-Length mismatched");
-        Assert.assertEquals(response.getHeaders().get(TestConstant.ALLOW)
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_LENGTH.toString()), "0",
+                            "Content-Length mismatched");
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.ALLOW.toString())
                 , "POST, OPTIONS", "Content-Length mismatched");
     }
 
     @Test(description = "Test OPTIONS content length header sample test case")
     public void testOptionsResourceWithPayload() throws Exception {
         Map<String, String> headers = new HashMap<>();
-        headers.put(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_JSON);
+        headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
         String serviceUrl = "http://localhost:9090/echoDummy/getOptions";
         HttpResponse response = HttpClientRequest.doOptions(serviceUrl, headers);
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-        Assert.assertEquals(response.getHeaders().get(TestConstant.HEADER_CONTENT_LENGTH)
-                , String.valueOf(response.getData().length()), "Content-Length mismatched");
-        Assert.assertEquals(response.getHeaders().get(TestConstant.HEADER_CONTENT_TYPE)
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_LENGTH.toString()),
+                            String.valueOf(response.getData().length()), "Content-Length mismatched");
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_TEXT_PLAIN, "Content-Type mismatched");
         String respMsg = "hello Options";
         Assert.assertEquals(response.getData(), respMsg, "Message content mismatched");

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http/sample/PassthroughServiceSampleTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http/sample/PassthroughServiceSampleTestCase.java
@@ -17,6 +17,7 @@
 */
 package org.ballerinalang.test.service.http.sample;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.test.IntegrationTestCase;
 import org.ballerinalang.test.context.ServerInstance;
 import org.ballerinalang.test.util.HttpClientRequest;
@@ -52,7 +53,7 @@ public class PassthroughServiceSampleTestCase extends IntegrationTestCase {
         HttpResponse response = HttpClientRequest.doGet(ballerinaServer
                 .getServiceURLHttp("passthrough"));
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-        Assert.assertEquals(response.getHeaders().get(TestConstant.HEADER_CONTENT_TYPE)
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(response.getData(), responseMessage, "Message content mismatched");
     }

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http/sample/RoutingServiceSampleTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http/sample/RoutingServiceSampleTestCase.java
@@ -17,6 +17,7 @@
 */
 package org.ballerinalang.test.service.http.sample;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.test.IntegrationTestCase;
 import org.ballerinalang.test.context.ServerInstance;
 import org.ballerinalang.test.util.HttpClientRequest;
@@ -55,12 +56,12 @@ public class RoutingServiceSampleTestCase extends IntegrationTestCase {
     @Test(description = "Test Content base routing sample")
     public void testContentBaseRouting() throws IOException {
         Map<String, String> headers = new HashMap<>();
-        headers.put(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_JSON);
+        headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
         //sending nyse as name
         HttpResponse response = HttpClientRequest.doPost(ballerinaServer
                 .getServiceURLHttp("cbr"), requestNyseMessage, headers);
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-        Assert.assertEquals(response.getHeaders().get(TestConstant.HEADER_CONTENT_TYPE)
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(response.getData(), responseNyseMessage, "Message content mismatched. " +
                                                                      "Routing failed for nyse");
@@ -69,7 +70,7 @@ public class RoutingServiceSampleTestCase extends IntegrationTestCase {
         response = HttpClientRequest.doPost(ballerinaServer
                 .getServiceURLHttp("cbr"), requestNasdaqMessage, headers);
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-        Assert.assertEquals(response.getHeaders().get(TestConstant.HEADER_CONTENT_TYPE)
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(response.getData(), responseNasdaqMessage, "Message content mismatched. " +
                                                                        "Routing failed for nasdaq");
@@ -78,13 +79,13 @@ public class RoutingServiceSampleTestCase extends IntegrationTestCase {
     @Test(description = "Test Header base routing sample")
     public void testHeaderBaseRouting() throws IOException {
         Map<String, String> headers = new HashMap<>();
-        headers.put(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_JSON);
+        headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
         //sending nyse as name header
         headers.put("name", "nyse");
         HttpResponse response = HttpClientRequest.doGet(ballerinaServer
                 .getServiceURLHttp("hbr"), headers);
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-        Assert.assertEquals(response.getHeaders().get(TestConstant.HEADER_CONTENT_TYPE)
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(response.getData(), responseNyseMessage
                 , "Message content mismatched. Routing failed for nyse");
@@ -94,7 +95,7 @@ public class RoutingServiceSampleTestCase extends IntegrationTestCase {
         response = HttpClientRequest.doGet(ballerinaServer
                 .getServiceURLHttp("hbr"), headers);
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-        Assert.assertEquals(response.getHeaders().get(TestConstant.HEADER_CONTENT_TYPE)
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(response.getData(), responseNasdaqMessage
                 , "Message content mismatched. Routing failed for nasdaq");

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http/sample/ServiceChainingSampleTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http/sample/ServiceChainingSampleTestCase.java
@@ -17,6 +17,7 @@
 */
 package org.ballerinalang.test.service.http.sample;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.test.IntegrationTestCase;
 import org.ballerinalang.test.context.ServerInstance;
 import org.ballerinalang.test.util.HttpClientRequest;
@@ -54,12 +55,12 @@ public class ServiceChainingSampleTestCase extends IntegrationTestCase {
     @Test(description = "Test service chaining sample")
     public void testEchoServiceByBasePath() throws IOException {
         Map<String, String> headers = new HashMap<>();
-        headers.put(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_JSON);
+        headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
         HttpResponse response = HttpClientRequest.doPost(ballerinaServer
                         .getServiceURLHttp("ABCBank/locator"), requestMessage
                 , headers);
         Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
-        Assert.assertEquals(response.getHeaders().get(TestConstant.HEADER_CONTENT_TYPE)
+        Assert.assertEquals(response.getHeaders().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(response.getData(), responseMessage, "Message content mismatched");
     }

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http2/sample/EchoServiceSampleTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http2/sample/EchoServiceSampleTestCase.java
@@ -43,7 +43,7 @@ public class EchoServiceSampleTestCase extends HTTP2IntegrationTestCase {
     @Test(description = "Test echo service sample test case invoking base path")
     public void testEchoServiceByBasePath() throws Exception {
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, POST, "/echo");
-        request.headers().set(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_JSON);
+        request.headers().set(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
         ByteBuf buffer = request.content().clear();
         int p0 = buffer.writerIndex();
         buffer.writeBytes(requestMessage.getBytes());
@@ -53,7 +53,7 @@ public class EchoServiceSampleTestCase extends HTTP2IntegrationTestCase {
         FullHttpResponse response = http2Client.getResponse(send);
         //request should be returned as response
         Assert.assertEquals(response.getStatus().code(), 200, "Response code mismatched");
-        Assert.assertEquals(response.headers().get(TestConstant.HEADER_CONTENT_TYPE)
+        Assert.assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(getResponse(response), requestMessage, "Message content mismatched");
     }
@@ -61,8 +61,8 @@ public class EchoServiceSampleTestCase extends HTTP2IntegrationTestCase {
     @Test(description = "Test echo service sample test case")
     public void testEchoServiceByResourcePath() throws Exception {
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, POST, "/echo/resource");
-        request.headers().set(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_JSON);
-        request.headers().set(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_JSON);
+        request.headers().set(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
+        request.headers().set(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
         ByteBuf buffer = request.content().clear();
         int p0 = buffer.writerIndex();
         buffer.writeBytes(requestMessage.getBytes());
@@ -72,7 +72,7 @@ public class EchoServiceSampleTestCase extends HTTP2IntegrationTestCase {
         FullHttpResponse response = http2Client.getResponse(send);
         //request should be returned as response
         Assert.assertEquals(response.getStatus().code(), 200, "Response code mismatched");
-        Assert.assertEquals(response.headers().get(TestConstant.HEADER_CONTENT_TYPE)
+        Assert.assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(getResponse(response),  requestMessage, "Message content mismatched");
     }

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http2/sample/EcommerceSampleTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http2/sample/EcommerceSampleTestCase.java
@@ -46,7 +46,7 @@ public class EcommerceSampleTestCase extends HTTP2IntegrationTestCase {
         int send = http2Client.send(request);
         FullHttpResponse response = http2Client.getResponse(send);
         Assert.assertEquals(response.getStatus().code(), 200, "Response code mismatched");
-        Assert.assertEquals(response.headers().get(TestConstant.HEADER_CONTENT_TYPE.toLowerCase()), TestConstant
+        Assert.assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE.toString()), TestConstant
                         .CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(getResponse(response),
                 "{\"Product\":{\"ID\":\"123001\",\"Name\":\"ABC_2\",\"Description\":\"Sample product.\"}}",
@@ -59,7 +59,7 @@ public class EcommerceSampleTestCase extends HTTP2IntegrationTestCase {
         int send = http2Client.send(request);
         FullHttpResponse response = http2Client.getResponse(send);
         Assert.assertEquals(response.getStatus().code(), 200, "Response code mismatched");
-        Assert.assertEquals(response.headers().get(TestConstant.HEADER_CONTENT_TYPE)
+        Assert.assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(getResponse(response), "{\"Order\":{\"ID\":\"111999\",\"Name\":\"ABC123\"," +
                 "\"Description\":\"Sample order.\"}}", "Message content mismatched");
@@ -72,7 +72,7 @@ public class EcommerceSampleTestCase extends HTTP2IntegrationTestCase {
         FullHttpResponse response = http2Client.getResponse(send);
         //request should be returned as response
         Assert.assertEquals(response.getStatus().code(), 200, "Response code mismatched");
-        Assert.assertEquals(response.headers().get(TestConstant.HEADER_CONTENT_TYPE)
+        Assert.assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(getResponse(response), "{\"Customer\":{\"ID\":\"987654\",\"Name\":\"ABC PQR\"," +
                 "\"Description\":\"Sample Customer.\"}}", "Message content mismatched");
@@ -83,7 +83,7 @@ public class EcommerceSampleTestCase extends HTTP2IntegrationTestCase {
         String requestMessage = "{\"Order\":{\"ID\":\"111222\",\"Name\":\"XYZ123\"}}";
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, POST,
                 "ecommerceservice/orders");
-        request.headers().set(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_JSON);
+        request.headers().set(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
         ByteBuf buffer = request.content().clear();
         int p0 = buffer.writerIndex();
         buffer.writeBytes(requestMessage.getBytes());
@@ -92,8 +92,8 @@ public class EcommerceSampleTestCase extends HTTP2IntegrationTestCase {
         int send = http2Client.send(request);
         FullHttpResponse response = http2Client.getResponse(send);
         Assert.assertEquals(response.getStatus().code(), 200, "Response code mismatched");
-        Assert.assertEquals(response.headers().get(TestConstant.HEADER_CONTENT_TYPE), TestConstant.CONTENT_TYPE_JSON,
-                "Content-Type mismatched");
+        Assert.assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE.toString()),
+                            TestConstant.CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(getResponse(response), "{\"Status\":\"Order is successfully added.\"}"
                 , "Message content mismatched");
     }
@@ -102,7 +102,7 @@ public class EcommerceSampleTestCase extends HTTP2IntegrationTestCase {
     public void testPostProduct() throws Exception {
         String requestMessage = "{\"Product\":{\"ID\":\"123345\",\"Name\":\"PQR\"}}";
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, POST, "/ecommerceservice/products");
-        request.headers().set(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_JSON);
+        request.headers().set(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
         ByteBuf buffer = request.content().clear();
         int p0 = buffer.writerIndex();
         buffer.writeBytes(requestMessage.getBytes());
@@ -111,7 +111,7 @@ public class EcommerceSampleTestCase extends HTTP2IntegrationTestCase {
         int send = http2Client.send(request);
         FullHttpResponse response = http2Client.getResponse(send);
         Assert.assertEquals(response.getStatus().code(), 200, "Response code mismatched");
-        Assert.assertEquals(response.headers().get(TestConstant.HEADER_CONTENT_TYPE)
+        Assert.assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(getResponse(response), "{\"Status\":\"Product is successfully added.\"}"
                 , "Message content mismatched");
@@ -121,7 +121,7 @@ public class EcommerceSampleTestCase extends HTTP2IntegrationTestCase {
     public void testPostCustomers() throws Exception {
         String requestMessage = "{\"Customer\":{\"ID\":\"97453\",\"Name\":\"ABC XYZ\"}}";
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, POST, "/ecommerceservice/customers");
-        request.headers().set(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_JSON);
+        request.headers().set(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
         ByteBuf buffer = request.content().clear();
         int p0 = buffer.writerIndex();
         buffer.writeBytes(requestMessage.getBytes());
@@ -130,8 +130,8 @@ public class EcommerceSampleTestCase extends HTTP2IntegrationTestCase {
         int send = http2Client.send(request);
         FullHttpResponse response = http2Client.getResponse(send);
         Assert.assertEquals(response.getStatus().code(), 200, "Response code mismatched");
-        Assert.assertEquals(response.headers().get(TestConstant.HEADER_CONTENT_TYPE), TestConstant.CONTENT_TYPE_JSON,
-                "Content-Type mismatched");
+        Assert.assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE.toString()),
+                            TestConstant.CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(getResponse(response), "{\"Status\":\"Customer is successfully added.\"}"
                 , "Message content mismatched");
     }

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http2/sample/HelloWorldSampleTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http2/sample/HelloWorldSampleTestCase.java
@@ -19,6 +19,7 @@ package org.ballerinalang.test.service.http2.sample;
 
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.test.HTTP2IntegrationTestCase;
 import org.ballerinalang.test.util.TestConstant;
 import org.testng.Assert;
@@ -39,7 +40,7 @@ public class HelloWorldSampleTestCase extends HTTP2IntegrationTestCase {
         int send = http2Client.send(request);
         FullHttpResponse response = http2Client.getResponse(send);
         Assert.assertEquals(response.getStatus().code(), 200, "Response code mismatched");
-        Assert.assertEquals(response.headers().get(TestConstant.HEADER_CONTENT_TYPE.toLowerCase())
+        Assert.assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_TEXT_PLAIN, "Content-Type mismatched");
         Assert.assertEquals(getResponse(response), "Hello, World!", "Message content mismatched");
     }
@@ -50,7 +51,7 @@ public class HelloWorldSampleTestCase extends HTTP2IntegrationTestCase {
         int send = http2Client.send(request);
         FullHttpResponse response = http2Client.getResponse(send);
         Assert.assertEquals(response.getStatus().code(), 200, "Response code mismatched");
-        Assert.assertEquals(response.headers().get(TestConstant.HEADER_CONTENT_TYPE.toLowerCase())
+        Assert.assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_TEXT_PLAIN, "Content-Type mismatched");
         Assert.assertEquals(getResponse(response), "Hello, World!", "Message content mismatched");
     }

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http2/sample/PassthroughServiceSampleTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http2/sample/PassthroughServiceSampleTestCase.java
@@ -19,6 +19,7 @@ package org.ballerinalang.test.service.http2.sample;
 
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.test.HTTP2IntegrationTestCase;
 import org.ballerinalang.test.util.TestConstant;
 import org.testng.Assert;
@@ -40,7 +41,7 @@ public class PassthroughServiceSampleTestCase extends HTTP2IntegrationTestCase {
         int send = http2Client.send(request);
         FullHttpResponse response = http2Client.getResponse(send);
         Assert.assertEquals(response.getStatus().code(), 200, "Response code mismatched");
-        Assert.assertEquals(response.headers().get(TestConstant.HEADER_CONTENT_TYPE)
+        Assert.assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(getResponse(response), responseMessage, "Message content mismatched");
     }
@@ -51,7 +52,7 @@ public class PassthroughServiceSampleTestCase extends HTTP2IntegrationTestCase {
         int send = http2Client.send(request);
         FullHttpResponse response = http2Client.getResponse(send);
         Assert.assertEquals(response.getStatus().code(), 200, "Response code mismatched");
-        Assert.assertEquals(response.headers().get(TestConstant.HEADER_CONTENT_TYPE.toLowerCase())
+        Assert.assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE.toString())
                 , TestConstant.CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(getResponse(response), responseMessage, "Message content mismatched");
     }

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http2/sample/RoutingServiceSampleTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http2/sample/RoutingServiceSampleTestCase.java
@@ -43,7 +43,7 @@ public class RoutingServiceSampleTestCase extends HTTP2IntegrationTestCase {
     @Test(description = "Test Content base routing sample")
     public void testContentBaseRouting() throws Exception {
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, POST, "/cbr");
-        request.headers().set(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_JSON);
+        request.headers().set(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
         ByteBuf buffer = request.content().clear();
         int p0 = buffer.writerIndex();
         buffer.writeBytes(requestNyseMessage.getBytes());
@@ -52,13 +52,13 @@ public class RoutingServiceSampleTestCase extends HTTP2IntegrationTestCase {
         int send = http2Client.send(request);
         FullHttpResponse response = http2Client.getResponse(send);
         Assert.assertEquals(response.getStatus().code(), 200, "Response code mismatched");
-        Assert.assertEquals(response.headers().get(TestConstant.HEADER_CONTENT_TYPE.toLowerCase()), TestConstant
+        Assert.assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE.toString().toLowerCase()), TestConstant
                         .CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(getResponse(response), responseNyseMessage, "Message content mismatched. " +
                 "Routing failed for nyse");
         //sending nasdaq as name
         request = new DefaultFullHttpRequest(HTTP_1_1, POST, "/cbr");
-        request.headers().set(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_JSON);
+        request.headers().set(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
         buffer = request.content().clear();
         p0 = buffer.writerIndex();
         buffer.writeBytes(requestNasdaqMessage.getBytes());
@@ -67,7 +67,7 @@ public class RoutingServiceSampleTestCase extends HTTP2IntegrationTestCase {
         send = http2Client.send(request);
         response = http2Client.getResponse(send);
         Assert.assertEquals(response.getStatus().code(), 200, "Response code mismatched");
-        Assert.assertEquals(response.headers().get(TestConstant.HEADER_CONTENT_TYPE.toLowerCase()), TestConstant
+        Assert.assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE.toString()), TestConstant
                         .CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(getResponse(response), responseNasdaqMessage, "Message content mismatched. " +
                 "Routing failed for nasdaq");
@@ -81,7 +81,7 @@ public class RoutingServiceSampleTestCase extends HTTP2IntegrationTestCase {
         int send = http2Client.send(request);
         FullHttpResponse response = http2Client.getResponse(send);
         Assert.assertEquals(response.getStatus().code(), 200, "Response code mismatched");
-        Assert.assertEquals(response.headers().get(TestConstant.HEADER_CONTENT_TYPE.toLowerCase()), TestConstant
+        Assert.assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE.toString()), TestConstant
                         .CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(getResponse(response), responseNyseMessage, "Message content mismatched. Routing failed " +
                 "for nyse");
@@ -91,7 +91,7 @@ public class RoutingServiceSampleTestCase extends HTTP2IntegrationTestCase {
         send = http2Client.send(request);
         response = http2Client.getResponse(send);
         Assert.assertEquals(response.getStatus().code(), 200, "Response code mismatched");
-        Assert.assertEquals(response.headers().get(TestConstant.HEADER_CONTENT_TYPE.toLowerCase()), TestConstant
+        Assert.assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE.toString()), TestConstant
                 .CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(getResponse(response), responseNasdaqMessage, "Message content mismatched. Routing failed" +
                 " for nasdaq");

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http2/sample/ServiceChainingSampleTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http2/sample/ServiceChainingSampleTestCase.java
@@ -41,7 +41,7 @@ public class ServiceChainingSampleTestCase extends HTTP2IntegrationTestCase {
     @Test(description = "Test service chaining sample")
     public void testEchoServiceByBasePath() throws Exception {
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, POST, "/ABCBank/locator");
-        request.headers().set(TestConstant.HEADER_CONTENT_TYPE, TestConstant.CONTENT_TYPE_JSON);
+        request.headers().set(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_JSON);
         ByteBuf buffer = request.content().clear();
         int p0 = buffer.writerIndex();
         buffer.writeBytes(requestMessage.getBytes());
@@ -50,7 +50,7 @@ public class ServiceChainingSampleTestCase extends HTTP2IntegrationTestCase {
         int send = http2Client.send(request);
         FullHttpResponse response = http2Client.getResponse(send);
         Assert.assertEquals(response.getStatus().code(), 200, "Response code mismatched");
-        Assert.assertEquals(response.headers().get(TestConstant.HEADER_CONTENT_TYPE.toLowerCase()), TestConstant
+        Assert.assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE.toString()), TestConstant
                         .CONTENT_TYPE_JSON, "Content-Type mismatched");
         Assert.assertEquals(getResponse(response), responseMessage, "Message content mismatched");
     }

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/util/TestConstant.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/util/TestConstant.java
@@ -23,11 +23,8 @@ import java.util.concurrent.TimeUnit;
  * Constants used in test cases.
  */
 public class TestConstant {
-    public static final String HEADER_CONTENT_TYPE = "Content-Type";
     public static final String CONTENT_TYPE_JSON = "application/json";
     public static final String CONTENT_TYPE_TEXT_PLAIN = "text/plain";
-    public static final String HEADER_CONTENT_LENGTH = "Content-Length";
-    public static final String ALLOW = "Allow";
     public static final String CHARSET_NAME = "UTF-8";
     public static final String HTTP_METHOD_GET = "GET";
     public static final String HTTP_METHOD_POST = "POST";

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/mime/MultipartDecoderTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/mime/MultipartDecoderTest.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.test.mime;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.util.internal.StringUtil;
 import org.ballerinalang.launcher.util.BServiceUtil;
 import org.ballerinalang.launcher.util.CompileResult;
@@ -39,8 +40,6 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.ballerinalang.mime.util.Constants.CONTENT_TYPE;
-
 /**
  * Unit tests for multipart decoder.
  *
@@ -60,7 +59,8 @@ public class MultipartDecoderTest {
         String path = "/test/multipleparts";
         List<Header> headers = new ArrayList<>();
         String multipartDataBoundary = MimeUtil.getNewMultipartDelimiter();
-        headers.add(new Header(CONTENT_TYPE, "multipart/mixed; boundary=" + multipartDataBoundary));
+        headers.add(new Header(HttpHeaderNames.CONTENT_TYPE.toString(),
+                               "multipart/mixed; boundary=" + multipartDataBoundary));
         String multipartBody = "--" + multipartDataBoundary + "\r\n" +
                 "Content-Type: text/plain; charset=UTF-8" + "\r\n" +
                 "\r\n" +
@@ -86,7 +86,8 @@ public class MultipartDecoderTest {
         String path = "/test/multipleparts";
         List<Header> headers = new ArrayList<>();
         String multipartDataBoundary = MimeUtil.getNewMultipartDelimiter();
-        headers.add(new Header(CONTENT_TYPE, "multipart/form-data; boundary=" + multipartDataBoundary));
+        headers.add(new Header(HttpHeaderNames.CONTENT_TYPE.toString(),
+                               "multipart/form-data; boundary=" + multipartDataBoundary));
         String multipartBody = "--" + multipartDataBoundary + "\r\n" +
                 "Content-Disposition: form-data; name=\"foo\"" + "\r\n" +
                 "Content-Type: text/plain; charset=UTF-8" + "\r\n" +
@@ -114,7 +115,8 @@ public class MultipartDecoderTest {
         String path = "/test/multipleparts";
         List<Header> headers = new ArrayList<>();
         String multipartDataBoundary = MimeUtil.getNewMultipartDelimiter();
-        headers.add(new Header(CONTENT_TYPE, "multipart/new-sub-type; boundary=" + multipartDataBoundary));
+        headers.add(new Header(HttpHeaderNames.CONTENT_TYPE.toString(),
+                               "multipart/new-sub-type; boundary=" + multipartDataBoundary));
         String multipartBody = "--" + multipartDataBoundary + "\r\n" +
                 "Content-Disposition: form-data; name=\"foo\"" + "\r\n" +
                 "Content-Type: text/plain; charset=UTF-8" + "\r\n" +
@@ -142,7 +144,8 @@ public class MultipartDecoderTest {
         String path = "/test/emptyparts";
         List<Header> headers = new ArrayList<>();
         String multipartDataBoundary = MimeUtil.getNewMultipartDelimiter();
-        headers.add(new Header(CONTENT_TYPE, "multipart/mixed; boundary=" + multipartDataBoundary));
+        headers.add(new Header(HttpHeaderNames.CONTENT_TYPE.toString(),
+                               "multipart/mixed; boundary=" + multipartDataBoundary));
         String multipartBody = "--" + multipartDataBoundary + "\r\n" +
                 "--" + multipartDataBoundary + "--" + "\r\n";
 
@@ -167,7 +170,8 @@ public class MultipartDecoderTest {
         List<Header> headers = new ArrayList<>();
         String multipartDataBoundary = MimeUtil.getNewMultipartDelimiter();
         String multipartMixedBoundary = MimeUtil.getNewMultipartDelimiter();
-        headers.add(new Header(CONTENT_TYPE, "multipart/form-data; boundary=" + multipartDataBoundary));
+        headers.add(new Header(HttpHeaderNames.CONTENT_TYPE.toString(),
+                               "multipart/form-data; boundary=" + multipartDataBoundary));
         String multipartBodyWithNestedParts = "--" + multipartDataBoundary + "\r\n" +
                 "Content-Disposition: form-data; name=\"parent1\"" + "\r\n" +
                 "Content-Type: text/plain; charset=UTF-8" + "\r\n" +

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/mime/Util.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/mime/Util.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.test.mime;
 
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.multipart.DefaultHttpDataFactory;
 import io.netty.handler.codec.http.multipart.FileUpload;
@@ -66,7 +67,6 @@ import static org.ballerinalang.mime.util.Constants.APPLICATION_XML;
 import static org.ballerinalang.mime.util.Constants.BYTE_CHANNEL_STRUCT;
 import static org.ballerinalang.mime.util.Constants.CONTENT_DISPOSITION_NAME;
 import static org.ballerinalang.mime.util.Constants.CONTENT_DISPOSITION_STRUCT;
-import static org.ballerinalang.mime.util.Constants.CONTENT_TRANSFER_ENCODING;
 import static org.ballerinalang.mime.util.Constants.ENTITY_BYTE_CHANNEL;
 import static org.ballerinalang.mime.util.Constants.ENTITY_HEADERS_INDEX;
 import static org.ballerinalang.mime.util.Constants.MEDIA_TYPE;
@@ -171,7 +171,8 @@ public class Util {
                     file.getAbsolutePath()));
             MimeUtil.setContentType(getMediaTypeStruct(result), bodyPart, TEXT_PLAIN);
             BMap<String, BValue> headerMap = new BMap<>();
-            headerMap.put(CONTENT_TRANSFER_ENCODING, new BStringArray(new String[]{contentTransferEncoding}));
+            headerMap.put(HttpHeaderNames.CONTENT_TRANSFER_ENCODING.toString(),
+                          new BStringArray(new String[]{contentTransferEncoding}));
             bodyPart.setRefField(ENTITY_HEADERS_INDEX, headerMap);
             return bodyPart;
         } catch (IOException e) {
@@ -485,7 +486,9 @@ public class Util {
             contentHolder.setFileName(TEMP_FILE_NAME + TEMP_FILE_EXTENSION);
             contentHolder.setContentType(MimeUtil.getContentType(bodyPart));
             contentHolder.setBodyPartFormat(org.ballerinalang.mime.util.Constants.BodyPartForm.INPUTSTREAM);
-            String contentTransferHeaderValue = HeaderUtil.getHeaderValue(bodyPart, CONTENT_TRANSFER_ENCODING);
+            String contentTransferHeaderValue = HeaderUtil.getHeaderValue(bodyPart,
+                                                                          HttpHeaderNames.CONTENT_TRANSFER_ENCODING
+                                                                                  .toString());
             if (contentTransferHeaderValue != null) {
                 contentHolder.setContentTransferEncoding(contentTransferHeaderValue);
             }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/ServiceTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/ServiceTest.java
@@ -20,6 +20,7 @@ package org.ballerinalang.test.services;
 
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.launcher.util.BAssertUtil;
 import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.BServiceUtil;
@@ -42,7 +43,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.ballerinalang.mime.util.Constants.APPLICATION_FORM;
-import static org.ballerinalang.mime.util.Constants.CONTENT_TYPE;
 import static org.ballerinalang.mime.util.Constants.TEXT_PLAIN;
 
 /**
@@ -179,7 +179,7 @@ public class ServiceTest {
         String path = "/echo/getFormParams";
         HTTPTestRequest requestMsg = MessageUtils
                 .generateHTTPMessage(path, "POST", "firstName=WSO2&team=BalDance");
-        requestMsg.setHeader(CONTENT_TYPE, APPLICATION_FORM);
+        requestMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), APPLICATION_FORM);
         HTTPCarbonMessage responseMsg = Services.invokeNew(compileResult, requestMsg);
 
         Assert.assertNotNull(responseMsg, "responseMsg message not found");
@@ -195,7 +195,7 @@ public class ServiceTest {
         String path = "/echo/getFormParams";
         HTTPTestRequest requestMsg = MessageUtils
                 .generateHTTPMessage(path, "POST", "firstName=WSO2&company=BalDance");
-        requestMsg.setHeader(CONTENT_TYPE, APPLICATION_FORM);
+        requestMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), APPLICATION_FORM);
         HTTPCarbonMessage responseMsg = Services.invokeNew(compileResult, requestMsg);
 
         Assert.assertNotNull(responseMsg, "responseMsg message not found");
@@ -207,7 +207,7 @@ public class ServiceTest {
     public void testGetFormParamsEmptyresponseMsgPayload() {
         String path = "/echo/getFormParams";
         HTTPTestRequest requestMsg = MessageUtils.generateHTTPMessage(path, "POST", "");
-        requestMsg.setHeader(CONTENT_TYPE, APPLICATION_FORM);
+        requestMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), APPLICATION_FORM);
         HTTPCarbonMessage responseMsg = Services.invokeNew(compileResult, requestMsg);
         Assert.assertNotNull(responseMsg, "responseMsg message not found");
         BJSON bJson = new BJSON(new HttpMessageDataStreamer(responseMsg).getInputStream());

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/cors/HTTPCorsTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/cors/HTTPCorsTest.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.test.services.cors;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.launcher.util.BServiceUtil;
 import org.ballerinalang.launcher.util.CompileResult;
 import org.ballerinalang.model.values.BJSON;
@@ -46,119 +47,125 @@ public class HTTPCorsTest {
     public void assertEqualsCorsResponse(HTTPCarbonMessage response, int statusCode, String origin, String credentials
             , String headers, String methods, String maxAge) {
         Assert.assertEquals(response.getProperty(HttpConstants.HTTP_STATUS_CODE), statusCode);
-        Assert.assertEquals(response.getHeader(HttpConstants.AC_ALLOW_ORIGIN), origin);
-        Assert.assertEquals(response.getHeader(HttpConstants.AC_ALLOW_CREDENTIALS), credentials);
-        Assert.assertEquals(response.getHeader(HttpConstants.AC_ALLOW_HEADERS), headers);
-        Assert.assertEquals(response.getHeader(HttpConstants.AC_ALLOW_METHODS), methods);
-        Assert.assertEquals(response.getHeader(HttpConstants.AC_MAX_AGE), maxAge);
+        Assert.assertEquals(response.getHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()), origin);
+        Assert.assertEquals(response.getHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()),
+                            credentials);
+        Assert.assertEquals(response.getHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS.toString()), headers);
+        Assert.assertEquals(response.getHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString()), methods);
+        Assert.assertEquals(response.getHeader(HttpHeaderNames.ACCESS_CONTROL_MAX_AGE.toString()), maxAge);
     }
 
     @Test(description = "Test for CORS override at two levels for simple requests")
     public void testSimpleReqServiceResourceCorsOverride() {
         String path = "/hello1/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "POST", "Hello there");
-        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.wso2.com");
+        cMsg.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://www.wso2.com");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
         BJSON bJson = new BJSON(new HttpMessageDataStreamer(response).getInputStream());
         Assert.assertEquals(bJson.value().get("echo").asText(), "resCors");
-        Assert.assertEquals("http://www.wso2.com", response.getHeader(HttpConstants.AC_ALLOW_ORIGIN));
-        Assert.assertEquals("true", response.getHeader(HttpConstants.AC_ALLOW_CREDENTIALS));
+        Assert.assertEquals("http://www.wso2.com",
+                            response.getHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()));
+        Assert.assertEquals("true", response.getHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()));
     }
 
     @Test(description = "Test for simple request service CORS")
     public void testSimpleReqServiceCors() {
         String path = "/hello1/test2";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
-        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.hello.com");
+        cMsg.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://www.hello.com");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
         BJSON bJson = new BJSON(new HttpMessageDataStreamer(response).getInputStream());
         Assert.assertEquals(bJson.value().get("echo").asText(), "serCors");
-        Assert.assertEquals("http://www.hello.com", response.getHeader(HttpConstants.AC_ALLOW_ORIGIN));
-        Assert.assertEquals("true", response.getHeader(HttpConstants.AC_ALLOW_CREDENTIALS));
+        Assert.assertEquals("http://www.hello.com",
+                            response.getHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()));
+        Assert.assertEquals("true", response.getHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()));
     }
 
     @Test(description = "Test for resource only CORS declaration")
     public void testSimpleReqResourceOnlyCors() {
         String path = "/hello2/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "POST", "hello");
-        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.hello.com");
+        cMsg.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://www.hello.com");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
         BJSON bJson = new BJSON(new HttpMessageDataStreamer(response).getInputStream());
         Assert.assertEquals(bJson.value().get("echo").asText(), "resOnlyCors");
-        Assert.assertEquals("http://www.hello.com", response.getHeader(HttpConstants.AC_ALLOW_ORIGIN));
-        Assert.assertEquals(null, response.getHeader(HttpConstants.AC_ALLOW_CREDENTIALS));
-        Assert.assertEquals("X-PINGOTHER, X-Content-Type-Options", response.getHeader(HttpConstants.AC_EXPOSE_HEADERS));
+        Assert.assertEquals("http://www.hello.com",
+                            response.getHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()));
+        Assert.assertEquals(null, response.getHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()));
+        Assert.assertEquals("X-PINGOTHER, X-Content-Type-Options",
+                            response.getHeader(HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS.toString()));
     }
 
     @Test(description = "Test simple request with multiple origins")
     public void testSimpleReqMultipleOrigins() {
         String path = "/hello1/test3";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "POST", "Hello there");
-        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.wso2.com http://www.amazon.com");
+        cMsg.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://www.wso2.com http://www.amazon.com");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
         BJSON bJson = new BJSON(new HttpMessageDataStreamer(response).getInputStream());
         Assert.assertEquals(bJson.value().get("echo").asText(), "moreOrigins");
         Assert.assertEquals("http://www.wso2.com http://www.amazon.com",
-                            response.getHeader(HttpConstants.AC_ALLOW_ORIGIN));
-        Assert.assertEquals("true", response.getHeader(HttpConstants.AC_ALLOW_CREDENTIALS));
+                            response.getHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()));
+        Assert.assertEquals("true", response.getHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()));
     }
 
     @Test(description = "Test simple request for invalid origins")
     public void testSimpleReqInvalidOrigin() {
         String path = "/hello1/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "POST", "Hello there");
-        cMsg.setHeader(HttpConstants.ORIGIN, "www.wso2.com");
+        cMsg.setHeader(HttpHeaderNames.ORIGIN.toString(), "www.wso2.com");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
         BJSON bJson = new BJSON(new HttpMessageDataStreamer(response).getInputStream());
         Assert.assertEquals(bJson.value().get("echo").asText(), "resCors");
-        Assert.assertEquals(null, response.getHeader(HttpConstants.AC_ALLOW_ORIGIN));
-        Assert.assertNull(null, response.getHeader(HttpConstants.AC_ALLOW_CREDENTIALS));
+        Assert.assertEquals(null, response.getHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()));
+        Assert.assertNull(null, response.getHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()));
     }
 
     @Test(description = "Test simple request for null origins")
     public void testSimpleReqWithNullOrigin() {
         String path = "/hello1/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "POST", "Hello there");
-        cMsg.setHeader(HttpConstants.ORIGIN, "");
+        cMsg.setHeader(HttpHeaderNames.ORIGIN.toString(), "");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
         BJSON bJson = new BJSON(new HttpMessageDataStreamer(response).getInputStream());
         Assert.assertEquals(bJson.value().get("echo").asText(), "resCors");
-        Assert.assertEquals(null, response.getHeader(HttpConstants.AC_ALLOW_ORIGIN));
-        Assert.assertNull(null, response.getHeader(HttpConstants.AC_ALLOW_CREDENTIALS));
+        Assert.assertEquals(null, response.getHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()));
+        Assert.assertNull(null, response.getHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()));
     }
 
     @Test(description = "Test for values with extra white spaces")
     public void testSimpleReqwithExtraWS() {
         String path = "/hello2/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "POST", "hello");
-        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.facebook.com");
+        cMsg.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://www.facebook.com");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
         BJSON bJson = new BJSON(new HttpMessageDataStreamer(response).getInputStream());
         Assert.assertEquals(bJson.value().get("echo").asText(), "resOnlyCors");
-        Assert.assertEquals("http://www.facebook.com", response.getHeader(HttpConstants.AC_ALLOW_ORIGIN));
+        Assert.assertEquals("http://www.facebook.com",
+                            response.getHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()));
     }
 
     @Test(description = "Test for CORS override at two levels with preflight")
     public void testPreFlightReqServiceResourceCorsOverride() {
         String path = "/hello1/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.wso2.com");
-        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_POST);
-        cMsg.setHeader(HttpConstants.AC_REQUEST_HEADERS, "X-PINGOTHER");
+        cMsg.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://www.wso2.com");
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), HttpConstants.HTTP_METHOD_POST);
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS.toString(), "X-PINGOTHER");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -170,8 +177,8 @@ public class HTTPCorsTest {
     public void testPreFlightReqwithNoOrigin() {
         String path = "/hello1/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_POST);
-        cMsg.setHeader(HttpConstants.AC_REQUEST_HEADERS, "X-PINGOTHER");
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), HttpConstants.HTTP_METHOD_POST);
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS.toString(), "X-PINGOTHER");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -183,8 +190,8 @@ public class HTTPCorsTest {
     public void testPreFlightReqwithNoMethod() {
         String path = "/hello1/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.wso2.com");
-        cMsg.setHeader(HttpConstants.AC_REQUEST_HEADERS, "X-PINGOTHER");
+        cMsg.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://www.wso2.com");
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS.toString(), "X-PINGOTHER");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -196,9 +203,9 @@ public class HTTPCorsTest {
     public void testPreFlightReqwithUnavailableMethod() {
         String path = "/hello1/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.wso2.com");
-        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_PUT);
-        cMsg.setHeader(HttpConstants.AC_REQUEST_HEADERS, "X-PINGOTHER");
+        cMsg.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://www.wso2.com");
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), HttpConstants.HTTP_METHOD_PUT);
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS.toString(), "X-PINGOTHER");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -210,9 +217,9 @@ public class HTTPCorsTest {
     public void testPreFlightReqwithHeadMethod() {
         String path = "/hello1/test2";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.m3.com");
-        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_HEAD);
-        cMsg.setHeader(HttpConstants.AC_REQUEST_HEADERS, "CORELATION_ID");
+        cMsg.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://www.m3.com");
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), HttpConstants.HTTP_METHOD_HEAD);
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS.toString(), "CORELATION_ID");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -224,9 +231,9 @@ public class HTTPCorsTest {
     public void testPreFlightReqwithInvalidHeaders() {
         String path = "/hello1/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.wso2.com");
-        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_POST);
-        cMsg.setHeader(HttpConstants.AC_REQUEST_HEADERS, "WSO2");
+        cMsg.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://www.wso2.com");
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), HttpConstants.HTTP_METHOD_POST);
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS.toString(), "WSO2");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -238,8 +245,8 @@ public class HTTPCorsTest {
     public void testPreFlightReqwithNoHeaders() {
         String path = "/hello1/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.wso2.com");
-        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_POST);
+        cMsg.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://www.wso2.com");
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), HttpConstants.HTTP_METHOD_POST);
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -251,9 +258,9 @@ public class HTTPCorsTest {
     public void testPreFlightReqwithRestrictedMethodsServiceLevel() {
         String path = "/hello3/info1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.m3.com");
-        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_POST);
-        cMsg.setHeader(HttpConstants.AC_REQUEST_HEADERS, "X-PINGOTHER");
+        cMsg.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://www.m3.com");
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), HttpConstants.HTTP_METHOD_POST);
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS.toString(), "X-PINGOTHER");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -265,9 +272,9 @@ public class HTTPCorsTest {
     public void testPreFlightReqwithRestrictedMethodsResourceLevel() {
         String path = "/hello2/test2";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.bbc.com");
-        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_DELETE);
-        cMsg.setHeader(HttpConstants.AC_REQUEST_HEADERS, "X-PINGOTHER");
+        cMsg.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://www.bbc.com");
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), HttpConstants.HTTP_METHOD_DELETE);
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS.toString(), "X-PINGOTHER");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -279,9 +286,9 @@ public class HTTPCorsTest {
     public void testPreFlightReqwithAllowedMethod() {
         String path = "/hello3/info1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.m3.com");
-        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_PUT);
-        cMsg.setHeader(HttpConstants.AC_REQUEST_HEADERS, "X-PINGOTHER");
+        cMsg.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://www.m3.com");
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), HttpConstants.HTTP_METHOD_PUT);
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS.toString(), "X-PINGOTHER");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -293,9 +300,9 @@ public class HTTPCorsTest {
     public void testPreFlightReqwithMissingHeadersAtResourceLevel() {
         String path = "/hello2/test2";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.bbc.com");
-        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_PUT);
-        cMsg.setHeader(HttpConstants.AC_REQUEST_HEADERS, "X-PINGOTHER");
+        cMsg.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://www.bbc.com");
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), HttpConstants.HTTP_METHOD_PUT);
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS.toString(), "X-PINGOTHER");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -307,21 +314,21 @@ public class HTTPCorsTest {
     public void testPreFlightReqNoCorsResource() {
         String path = "/echo4/info1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.wso2.com");
-        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_POST);
+        cMsg.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://www.wso2.com");
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), HttpConstants.HTTP_METHOD_POST);
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
         assertEqualsCorsResponse(response, 200, null, null
                 , null, null, null);
-        Assert.assertEquals(response.getHeader(HttpConstants.ALLOW), "POST, OPTIONS");
+        Assert.assertEquals(response.getHeader(HttpHeaderNames.ALLOW.toString()), "POST, OPTIONS");
     }
 
     @Test(description = "Test for simple OPTIONS request")
     public void testSimpleOPTIONSReq() {
         String path = "/echo4/info2";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.wso2.com");
+        cMsg.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://www.wso2.com");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -333,8 +340,8 @@ public class HTTPCorsTest {
     public void testPreFlightReqwithCaseInsensitiveOrigin() {
         String path = "/hello1/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.Wso2.com");
-        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_POST);
+        cMsg.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://www.Wso2.com");
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), HttpConstants.HTTP_METHOD_POST);
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);
@@ -346,9 +353,9 @@ public class HTTPCorsTest {
     public void testPreFlightReqwithCaseInsensitiveHeader() {
         String path = "/hello1/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "OPTIONS", "Hello there");
-        cMsg.setHeader(HttpConstants.ORIGIN, "http://www.wso2.com");
-        cMsg.setHeader(HttpConstants.AC_REQUEST_METHOD, HttpConstants.HTTP_METHOD_POST);
-        cMsg.setHeader(HttpConstants.AC_REQUEST_HEADERS, "X-PINGOTHER");
+        cMsg.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://www.wso2.com");
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), HttpConstants.HTTP_METHOD_POST);
+        cMsg.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS.toString(), "X-PINGOTHER");
         HTTPCarbonMessage response = Services.invokeNew(complieResult, cMsg);
 
         Assert.assertNotNull(response);

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/dispatching/DataBindingTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/dispatching/DataBindingTest.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.test.services.dispatching;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.connector.api.BallerinaConnectorException;
 import org.ballerinalang.launcher.util.BServiceUtil;
 import org.ballerinalang.launcher.util.CompileResult;
@@ -33,7 +34,6 @@ import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 
 import static org.ballerinalang.mime.util.Constants.APPLICATION_JSON;
 import static org.ballerinalang.mime.util.Constants.APPLICATION_XML;
-import static org.ballerinalang.mime.util.Constants.CONTENT_TYPE;
 import static org.ballerinalang.mime.util.Constants.OCTET_STREAM;
 import static org.ballerinalang.mime.util.Constants.TEXT_PLAIN;
 
@@ -53,7 +53,7 @@ public class DataBindingTest {
     public void testDataBindingWithStringPayload() {
         HTTPTestRequest requestMsg = MessageUtils
                 .generateHTTPMessage("/echo/body1", "POST", "WSO2");
-        requestMsg.setHeader(CONTENT_TYPE, TEXT_PLAIN);
+        requestMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), TEXT_PLAIN);
         HTTPCarbonMessage responseMsg = Services.invokeNew(compileResult, requestMsg);
 
         Assert.assertNotNull(responseMsg, "responseMsg message not found");
@@ -66,7 +66,7 @@ public class DataBindingTest {
     public void testDataBindingWhenPathParamExist() {
         HTTPTestRequest requestMsg = MessageUtils
                 .generateHTTPMessage("/echo/body2/hello", "POST", "WSO2");
-        requestMsg.setHeader(CONTENT_TYPE, TEXT_PLAIN);
+        requestMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), TEXT_PLAIN);
         HTTPCarbonMessage responseMsg = Services.invokeNew(compileResult, requestMsg);
 
         Assert.assertNotNull(responseMsg, "responseMsg message not found");
@@ -81,7 +81,7 @@ public class DataBindingTest {
     public void testDataBindingWithJSONPayload() {
         HTTPTestRequest requestMsg = MessageUtils
                 .generateHTTPMessage("/echo/body3", "POST", "{'name':'WSO2', 'team':'ballerina'}");
-        requestMsg.setHeader(CONTENT_TYPE, APPLICATION_JSON);
+        requestMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), APPLICATION_JSON);
         HTTPCarbonMessage responseMsg = Services.invokeNew(compileResult, requestMsg);
 
         Assert.assertNotNull(responseMsg, "responseMsg message not found");
@@ -96,7 +96,7 @@ public class DataBindingTest {
     public void testDataBindingWithXMLPayload() {
         HTTPTestRequest requestMsg = MessageUtils
                 .generateHTTPMessage("/echo/body4", "POST", "<name>WSO2</name>");
-        requestMsg.setHeader(CONTENT_TYPE, APPLICATION_XML);
+        requestMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), APPLICATION_XML);
         HTTPCarbonMessage responseMsg = Services.invokeNew(compileResult, requestMsg);
 
         Assert.assertNotNull(responseMsg, "responseMsg message not found");
@@ -111,7 +111,7 @@ public class DataBindingTest {
     public void testDataBindingWithBinaryPayload() {
         HTTPTestRequest requestMsg = MessageUtils
                 .generateHTTPMessage("/echo/body5", "POST", "WSO2");
-        requestMsg.setHeader(CONTENT_TYPE, OCTET_STREAM);
+        requestMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), OCTET_STREAM);
         HTTPCarbonMessage responseMsg = Services.invokeNew(compileResult, requestMsg);
 
         Assert.assertNotNull(responseMsg, "responseMsg message not found");
@@ -124,7 +124,7 @@ public class DataBindingTest {
     public void testDataBindingWithGlobalStruct() {
         HTTPTestRequest requestMsg = MessageUtils
                 .generateHTTPMessage("/echo/body6", "POST", "{'name':'wso2','age':12}");
-        requestMsg.setHeader(CONTENT_TYPE, APPLICATION_JSON);
+        requestMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), APPLICATION_JSON);
         HTTPCarbonMessage responseMsg = Services.invokeNew(compileResult, requestMsg);
 
         Assert.assertNotNull(responseMsg, "responseMsg message not found");
@@ -151,7 +151,7 @@ public class DataBindingTest {
     public void testDataBindingIncompatibleJSONPayloadType() {
         HTTPTestRequest requestMsg = MessageUtils
                 .generateHTTPMessage("/echo/body3", "POST", "{'name':'WSO2', 'team':'EI'}");
-        requestMsg.setHeader(CONTENT_TYPE, TEXT_PLAIN);
+        requestMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), TEXT_PLAIN);
         HTTPCarbonMessage responseMsg = Services.invokeNew(compileResult, requestMsg);
 
         Assert.assertNotNull(responseMsg, "responseMsg message not found");
@@ -166,7 +166,7 @@ public class DataBindingTest {
     public void testDataBindingCompatiblePayload() {
         HTTPTestRequest requestMsg = MessageUtils
                 .generateHTTPMessage("/echo/body5", "POST", "{'name':'WSO2', 'team':'ballerina'}");
-        requestMsg.setHeader(CONTENT_TYPE, TEXT_PLAIN);
+        requestMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), TEXT_PLAIN);
         HTTPCarbonMessage responseMsg = Services.invokeNew(compileResult, requestMsg);
 
         Assert.assertNotNull(responseMsg, "responseMsg message not found");
@@ -192,7 +192,7 @@ public class DataBindingTest {
     public void testDataBindingIncompatibleXMLPayload() {
         HTTPTestRequest requestMsg = MessageUtils
                 .generateHTTPMessage("/echo/body4", "POST", "name':'WSO2', 'team':'ballerina");
-        requestMsg.setHeader(CONTENT_TYPE, APPLICATION_JSON);
+        requestMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), APPLICATION_JSON);
         Services.invokeNew(compileResult, requestMsg);
     }
 
@@ -201,7 +201,7 @@ public class DataBindingTest {
     public void testDataBindingIncompatibleStructPayload() {
         HTTPTestRequest requestMsg = MessageUtils
                 .generateHTTPMessage("/echo/body6", "POST", "ballerina");
-        requestMsg.setHeader(CONTENT_TYPE, TEXT_PLAIN);
+        requestMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), TEXT_PLAIN);
         Services.invokeNew(compileResult, requestMsg);
     }
 
@@ -218,7 +218,7 @@ public class DataBindingTest {
     public void testDataBindingStructWithNoMatchingContent() {
         HTTPTestRequest requestMsg = MessageUtils
                 .generateHTTPMessage("/echo/body6", "POST", "{'name':'WSO2', 'team':8}");
-        requestMsg.setHeader(CONTENT_TYPE, APPLICATION_JSON);
+        requestMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), APPLICATION_JSON);
         Services.invokeNew(compileResult, requestMsg);
     }
 
@@ -227,7 +227,7 @@ public class DataBindingTest {
     public void testDataBindingStructWithInvalidTypes() {
         HTTPTestRequest requestMsg = MessageUtils
                 .generateHTTPMessage("/echo/body7", "POST", "{'name':'WSO2', 'team':8}");
-        requestMsg.setHeader(CONTENT_TYPE, APPLICATION_JSON);
+        requestMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), APPLICATION_JSON);
         Services.invokeNew(compileResult, requestMsg);
     }
 }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/dispatching/ProducesConsumesAnnotationTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/dispatching/ProducesConsumesAnnotationTest.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.test.services.dispatching;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.launcher.util.BServiceUtil;
 import org.ballerinalang.launcher.util.CompileResult;
 import org.ballerinalang.model.values.BJSON;
@@ -48,7 +49,7 @@ public class ProducesConsumesAnnotationTest {
     public void testConsumesAnnotation() {
         String path = "/echo66/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "POST", "Test");
-        cMsg.setHeader(HttpConstants.CONTENT_TYPE_HEADER, "application/xml; charset=ISO-8859-4");
+        cMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), "application/xml; charset=ISO-8859-4");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -60,7 +61,7 @@ public class ProducesConsumesAnnotationTest {
     public void testIncorrectConsumesAnnotation() {
         String path = "/echo66/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "POST", "Test");
-        cMsg.setHeader(HttpConstants.CONTENT_TYPE_HEADER, "compileResult/json");
+        cMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), "compileResult/json");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -72,7 +73,7 @@ public class ProducesConsumesAnnotationTest {
     public void testBogusConsumesAnnotation() {
         String path = "/echo66/test1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "POST", "Test");
-        cMsg.setHeader(HttpConstants.CONTENT_TYPE_HEADER, ",:vhjv");
+        cMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), ",:vhjv");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -84,7 +85,7 @@ public class ProducesConsumesAnnotationTest {
     public void testProducesAnnotation() {
         String path = "/echo66/test2";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
-        cMsg.setHeader(HttpConstants.ACCEPT_HEADER, "text/xml;q=0.3, multipart/*;Level=1;q=0.7");
+        cMsg.setHeader(HttpHeaderNames.ACCEPT.toString(), "text/xml;q=0.3, multipart/*;Level=1;q=0.7");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -107,7 +108,7 @@ public class ProducesConsumesAnnotationTest {
     public void testProducesAnnotationWithWildCard() {
         String path = "/echo66/test2";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
-        cMsg.setHeader(HttpConstants.ACCEPT_HEADER, "*/*, text/html;Level=1;q=0.7");
+        cMsg.setHeader(HttpHeaderNames.ACCEPT.toString(), "*/*, text/html;Level=1;q=0.7");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -119,7 +120,7 @@ public class ProducesConsumesAnnotationTest {
     public void testProducesAnnotationWithSubTypeWildCard() {
         String path = "/echo66/test2";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
-        cMsg.setHeader(HttpConstants.ACCEPT_HEADER, "text/*;q=0.3, text/html;Level=1;q=0.7");
+        cMsg.setHeader(HttpHeaderNames.ACCEPT.toString(), "text/*;q=0.3, text/html;Level=1;q=0.7");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -131,7 +132,7 @@ public class ProducesConsumesAnnotationTest {
     public void testIncorrectProducesAnnotation() {
         String path = "/echo66/test2";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
-        cMsg.setHeader(HttpConstants.ACCEPT_HEADER, "multipart/*;q=0.3, text/html;Level=1;q=0.7");
+        cMsg.setHeader(HttpHeaderNames.ACCEPT.toString(), "multipart/*;q=0.3, text/html;Level=1;q=0.7");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -143,7 +144,7 @@ public class ProducesConsumesAnnotationTest {
     public void testBogusProducesAnnotation() {
         String path = "/echo66/test2";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
-        cMsg.setHeader(HttpConstants.ACCEPT_HEADER, ":,;,v567br");
+        cMsg.setHeader(HttpHeaderNames.ACCEPT.toString(), ":,;,v567br");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -155,8 +156,8 @@ public class ProducesConsumesAnnotationTest {
     public void testProducesConsumeAnnotation() {
         String path = "/echo66/test3";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "POST", "Test");
-        cMsg.setHeader(HttpConstants.CONTENT_TYPE_HEADER, "text/plain; charset=ISO-8859-4");
-        cMsg.setHeader(HttpConstants.ACCEPT_HEADER, "text/*;q=0.3, text/html;Level=1;q=0.7");
+        cMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), "text/plain; charset=ISO-8859-4");
+        cMsg.setHeader(HttpHeaderNames.ACCEPT.toString(), "text/*;q=0.3, text/html;Level=1;q=0.7");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -168,8 +169,8 @@ public class ProducesConsumesAnnotationTest {
     public void testIncorrectProducesConsumeAnnotation() {
         String path = "/echo66/test3";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "POST", "Test");
-        cMsg.setHeader(HttpConstants.CONTENT_TYPE_HEADER, "text/plain ; charset=ISO-8859-4");
-        cMsg.setHeader(HttpConstants.ACCEPT_HEADER, "compileResult/xml, text/html");
+        cMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), "text/plain ; charset=ISO-8859-4");
+        cMsg.setHeader(HttpHeaderNames.ACCEPT.toString(), "compileResult/xml, text/html");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -181,8 +182,8 @@ public class ProducesConsumesAnnotationTest {
     public void testWithoutProducesConsumeAnnotation() {
         String path = "/echo67/echo1";
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage(path, "GET");
-        cMsg.setHeader(HttpConstants.CONTENT_TYPE_HEADER, "text/plain; charset=ISO-8859-4");
-        cMsg.setHeader(HttpConstants.ACCEPT_HEADER, "text/*;q=0.3, text/html;Level=1;q=0.7");
+        cMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), "text/plain; charset=ISO-8859-4");
+        cMsg.setHeader(HttpHeaderNames.ACCEPT.toString(), "text/*;q=0.3, text/html;Level=1;q=0.7");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
 
         Assert.assertNotNull(response, "Response message not found");

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/dispatching/UriTemplateDispatcherTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/dispatching/UriTemplateDispatcherTest.java
@@ -17,6 +17,7 @@
 */
 package org.ballerinalang.test.services.dispatching;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.launcher.util.BServiceUtil;
 import org.ballerinalang.launcher.util.CompileResult;
 import org.ballerinalang.model.util.StringUtils;
@@ -243,7 +244,7 @@ public class UriTemplateDispatcherTest {
         Assert.assertEquals(response.getProperty(HttpConstants.HTTP_STATUS_CODE), 200
                 , "Response code mismatch");
 
-        String allowHeader = cMsg.getHeader(HttpConstants.ALLOW);
+        String allowHeader = cMsg.getHeader(HttpHeaderNames.ALLOW.toString());
         Assert.assertEquals(allowHeader, "GET, HEAD, OPTIONS");
     }
 
@@ -259,7 +260,7 @@ public class UriTemplateDispatcherTest {
         Assert.assertEquals(response.getProperty(HttpConstants.HTTP_STATUS_CODE), 200
                 , "Response code mismatch");
 
-        String allowHeader = cMsg.getHeader(HttpConstants.ALLOW);
+        String allowHeader = cMsg.getHeader(HttpHeaderNames.ALLOW.toString());
         Assert.assertEquals(allowHeader, "POST, OPTIONS");
     }
 
@@ -275,7 +276,7 @@ public class UriTemplateDispatcherTest {
         Assert.assertEquals(response.getProperty(HttpConstants.HTTP_STATUS_CODE), 200
                 , "Response code mismatch");
 
-        String allowHeader = response.getHeader(HttpConstants.ALLOW);
+        String allowHeader = response.getHeader(HttpHeaderNames.ALLOW.toString());
         Assert.assertEquals(allowHeader, "PUT, OPTIONS");
     }
 
@@ -291,7 +292,7 @@ public class UriTemplateDispatcherTest {
         Assert.assertEquals(response.getProperty(HttpConstants.HTTP_STATUS_CODE), 200
                 , "Response code mismatch");
 
-        String allowHeader = response.getHeader(HttpConstants.ALLOW);
+        String allowHeader = response.getHeader(HttpHeaderNames.ALLOW.toString());
         Assert.assertEquals(allowHeader, "UPDATE, POST, PUT, GET, HEAD, OPTIONS");
     }
 
@@ -306,7 +307,7 @@ public class UriTemplateDispatcherTest {
         Assert.assertEquals(response.getProperty(HttpConstants.HTTP_STATUS_CODE), 200
                 , "Response code mismatch");
 
-        String allowHeader = response.getHeader(HttpConstants.ALLOW);
+        String allowHeader = response.getHeader(HttpHeaderNames.ALLOW.toString());
         Assert.assertEquals(allowHeader, "OPTIONS, POST, GET, UPDATE, PUT, HEAD");
     }
 

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/inbound/request/InRequestNativeFunctionNegativeTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/inbound/request/InRequestNativeFunctionNegativeTest.java
@@ -17,6 +17,7 @@
  */
 package org.ballerinalang.test.services.nativeimpl.inbound.request;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.launcher.util.BAssertUtil;
 import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.BRunUtil;
@@ -33,7 +34,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
-import static org.ballerinalang.mime.util.Constants.CONTENT_TYPE;
 import static org.ballerinalang.mime.util.Constants.ENTITY_BYTE_CHANNEL;
 import static org.ballerinalang.mime.util.Constants.IS_BODY_BYTE_CHANNEL_ALREADY_SET;
 import static org.ballerinalang.mime.util.Constants.MEDIA_TYPE;
@@ -71,7 +71,7 @@ public class InRequestNativeFunctionNegativeTest {
     @Test
     public void testGetHeader() {
         BStruct inRequest = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageHttp, inReqStruct);
-        BString key = new BString(CONTENT_TYPE);
+        BString key = new BString(HttpHeaderNames.CONTENT_TYPE.toString());
         BValue[] inputArg = {inRequest, key};
         BValue[] returnVals = BRunUtil.invoke(result, "testGetHeader", inputArg);
         Assert.assertNotNull(returnVals[0]);

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/inbound/request/InRequestNativeFunctionSuccessTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/inbound/request/InRequestNativeFunctionSuccessTest.java
@@ -17,6 +17,7 @@
  */
 package org.ballerinalang.test.services.nativeimpl.inbound.request;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.BRunUtil;
@@ -52,7 +53,6 @@ import java.util.List;
 import static org.ballerinalang.mime.util.Constants.APPLICATION_FORM;
 import static org.ballerinalang.mime.util.Constants.APPLICATION_JSON;
 import static org.ballerinalang.mime.util.Constants.APPLICATION_XML;
-import static org.ballerinalang.mime.util.Constants.CONTENT_TYPE;
 import static org.ballerinalang.mime.util.Constants.ENTITY_BYTE_CHANNEL;
 import static org.ballerinalang.mime.util.Constants.ENTITY_HEADERS_INDEX;
 import static org.ballerinalang.mime.util.Constants.IS_BODY_BYTE_CHANNEL_ALREADY_SET;
@@ -107,7 +107,7 @@ public class InRequestNativeFunctionSuccessTest {
         BStruct entity = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageMime, entityStruct);
         String payload = "ballerina";
         BMap<String, BStringArray> headersMap = new BMap<>();
-        headersMap.put(HttpConstants.HTTP_CONTENT_LENGTH,
+        headersMap.put(HttpHeaderNames.CONTENT_LENGTH.toString(),
                        new BStringArray(new String[]{String.valueOf(payload.length())}));
         entity.setRefField(ENTITY_HEADERS_INDEX, headersMap);
         inRequest.addNativeData(MESSAGE_ENTITY, entity);
@@ -128,7 +128,7 @@ public class InRequestNativeFunctionSuccessTest {
         int length = jsonString.length();
         HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_POST,
                                                                         jsonString);
-        inRequestMsg.setHeader(HttpConstants.HTTP_CONTENT_LENGTH, String.valueOf(length));
+        inRequestMsg.setHeader(HttpHeaderNames.CONTENT_LENGTH.toString(), String.valueOf(length));
 
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
@@ -141,13 +141,13 @@ public class InRequestNativeFunctionSuccessTest {
     public void testGetHeader() {
         BStruct inRequest = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageHttp, inReqStruct);
         HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage("", HttpConstants.HTTP_METHOD_GET);
-        inRequestMsg.setHeader(CONTENT_TYPE, APPLICATION_FORM);
+        inRequestMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), APPLICATION_FORM);
 
         BStruct entity = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageMime, entityStruct);
         BStruct mediaType = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageMime, mediaTypeStruct);
         HttpUtil.populateInboundRequest(inRequest, entity, mediaType, inRequestMsg);
 
-        BString key = new BString(CONTENT_TYPE);
+        BString key = new BString(HttpHeaderNames.CONTENT_TYPE.toString());
         BValue[] inputArg = {inRequest, key};
         BValue[] returnVals = BRunUtil.invoke(result, "testGetHeader", inputArg);
         Assert.assertFalse(returnVals == null || returnVals.length == 0 || returnVals[0] == null,
@@ -159,7 +159,7 @@ public class InRequestNativeFunctionSuccessTest {
     public void testServiceGetHeader() {
         String path = "/hello/getHeader";
         HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
-        inRequestMsg.setHeader(CONTENT_TYPE, APPLICATION_FORM);
+        inRequestMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), APPLICATION_FORM);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 
         Assert.assertNotNull(response, "Response message not found");
@@ -213,7 +213,7 @@ public class InRequestNativeFunctionSuccessTest {
         String path = "/hello/getJsonPayload";
         String jsonString = "{\"" + key + "\":\"" + value + "\"}";
         List<Header> headers = new ArrayList<>();
-        headers.add(new Header("Content-Type", APPLICATION_JSON));
+        headers.add(new Header(HttpHeaderNames.CONTENT_TYPE.toString(), APPLICATION_JSON));
         HTTPTestRequest inRequestMsg = MessageUtils
                 .generateHTTPMessage(path, HttpConstants.HTTP_METHOD_POST, headers, jsonString);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
@@ -275,7 +275,7 @@ public class InRequestNativeFunctionSuccessTest {
         String value = "ballerina";
         String path = "/hello/GetStringPayload";
         List<Header> headers = new ArrayList<>();
-        headers.add(new Header("Content-Type", TEXT_PLAIN));
+        headers.add(new Header(HttpHeaderNames.CONTENT_TYPE.toString(), TEXT_PLAIN));
         HTTPTestRequest inRequestMsg = MessageUtils
                 .generateHTTPMessage(path, HttpConstants.HTTP_METHOD_POST, headers, value);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
@@ -308,7 +308,7 @@ public class InRequestNativeFunctionSuccessTest {
         String path = "/hello/GetXmlPayload";
         String bxmlItemString = "<name>ballerina</name>";
         List<Header> headers = new ArrayList<>();
-        headers.add(new Header("Content-Type", APPLICATION_XML));
+        headers.add(new Header(HttpHeaderNames.CONTENT_TYPE.toString(), APPLICATION_XML));
         HTTPTestRequest inRequestMsg = MessageUtils
                 .generateHTTPMessage(path, HttpConstants.HTTP_METHOD_POST, headers, bxmlItemString);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/inbound/response/InResponseNativeFunctionNegativeTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/inbound/response/InResponseNativeFunctionNegativeTest.java
@@ -17,6 +17,7 @@
  */
 package org.ballerinalang.test.services.nativeimpl.inbound.response;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.launcher.util.BAssertUtil;
 import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.BRunUtil;
@@ -34,7 +35,6 @@ import org.testng.annotations.Test;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
 import static org.ballerinalang.mime.util.Constants.BYTE_CHANNEL_STRUCT;
-import static org.ballerinalang.mime.util.Constants.CONTENT_TYPE;
 import static org.ballerinalang.mime.util.Constants.IS_BODY_BYTE_CHANNEL_ALREADY_SET;
 import static org.ballerinalang.mime.util.Constants.MEDIA_TYPE;
 import static org.ballerinalang.mime.util.Constants.MESSAGE_ENTITY;
@@ -71,7 +71,7 @@ public class InResponseNativeFunctionNegativeTest {
     @Test
     public void testGetHeader() {
         BStruct inResponse = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageHttp, inRespStruct);
-        BString key = new BString(CONTENT_TYPE);
+        BString key = new BString(HttpHeaderNames.CONTENT_TYPE.toString());
         BValue[] inputArg = {inResponse, key};
         BValue[] returnVals = BRunUtil.invoke(result, "testGetHeader", inputArg);
         Assert.assertNull(((BString) returnVals[0]).value());

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/inbound/response/InResponseNativeFunctionSuccessTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/inbound/response/InResponseNativeFunctionSuccessTest.java
@@ -17,6 +17,7 @@
  */
 package org.ballerinalang.test.services.nativeimpl.inbound.response;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.BRunUtil;
@@ -44,7 +45,6 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import static org.ballerinalang.mime.util.Constants.APPLICATION_FORM;
 import static org.ballerinalang.mime.util.Constants.APPLICATION_JSON;
 import static org.ballerinalang.mime.util.Constants.APPLICATION_XML;
-import static org.ballerinalang.mime.util.Constants.CONTENT_TYPE;
 import static org.ballerinalang.mime.util.Constants.ENTITY_BYTE_CHANNEL;
 import static org.ballerinalang.mime.util.Constants.IS_BODY_BYTE_CHANNEL_ALREADY_SET;
 import static org.ballerinalang.mime.util.Constants.MEDIA_TYPE;
@@ -98,7 +98,7 @@ public class InResponseNativeFunctionSuccessTest {
         HTTPCarbonMessage inResponseMsg = HttpUtil.createHttpCarbonMessage(false);
 
         String payload = "ballerina";
-        inResponseMsg.setHeader(HttpConstants.HTTP_CONTENT_LENGTH, String.valueOf(payload.length()));
+        inResponseMsg.setHeader(HttpHeaderNames.CONTENT_LENGTH.toString(), String.valueOf(payload.length()));
         inResponseMsg.setProperty(HttpConstants.HTTP_STATUS_CODE, 200);
         HttpUtil.addCarbonMsg(inResponse, inResponseMsg);
 
@@ -117,7 +117,7 @@ public class InResponseNativeFunctionSuccessTest {
     public void testGetHeader() {
         BStruct inResponse = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageHttp, inResStruct);
         HTTPCarbonMessage inResponseMsg = HttpUtil.createHttpCarbonMessage(false);
-        inResponseMsg.setHeader(CONTENT_TYPE, APPLICATION_FORM);
+        inResponseMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), APPLICATION_FORM);
         inResponseMsg.setProperty(HttpConstants.HTTP_STATUS_CODE, 200);
         HttpUtil.addCarbonMsg(inResponse, inResponseMsg);
 
@@ -125,7 +125,7 @@ public class InResponseNativeFunctionSuccessTest {
         BStruct mediaType = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageMime, mediaTypeStruct);
         HttpUtil.populateInboundResponse(inResponse, entity, mediaType, inResponseMsg);
 
-        BString key = new BString(CONTENT_TYPE);
+        BString key = new BString(HttpHeaderNames.CONTENT_TYPE.toString());
         BValue[] inputArg = {inResponse, key};
         BValue[] returnVals = BRunUtil.invoke(result, "testGetHeader", inputArg);
         Assert.assertFalse(returnVals == null || returnVals.length == 0 || returnVals[0] == null,

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/outbound/request/OutRequestNativeFunctionNegativeTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/outbound/request/OutRequestNativeFunctionNegativeTest.java
@@ -17,6 +17,7 @@
  */
 package org.ballerinalang.test.services.nativeimpl.outbound.request;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.launcher.util.BAssertUtil;
 import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.BRunUtil;
@@ -34,7 +35,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.ballerinalang.mime.util.Constants.BYTE_CHANNEL_STRUCT;
-import static org.ballerinalang.mime.util.Constants.CONTENT_TYPE;
 import static org.ballerinalang.mime.util.Constants.ENTITY_HEADERS_INDEX;
 import static org.ballerinalang.mime.util.Constants.IS_BODY_BYTE_CHANNEL_ALREADY_SET;
 import static org.ballerinalang.mime.util.Constants.MEDIA_TYPE;
@@ -72,7 +72,7 @@ public class OutRequestNativeFunctionNegativeTest {
     @Test
     public void testGetHeader() {
         BStruct outRequest = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageHttp, outReqStruct);
-        BString key = new BString(CONTENT_TYPE);
+        BString key = new BString(HttpHeaderNames.CONTENT_TYPE.toString());
         BValue[] inputArg = {outRequest, key};
         BValue[] returnVals = BRunUtil.invoke(result, "testGetHeader", inputArg);
         Assert.assertNotNull(returnVals[0]);

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/outbound/request/OutRequestNativeFunctionSuccessTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/outbound/request/OutRequestNativeFunctionSuccessTest.java
@@ -17,6 +17,7 @@
  */
 package org.ballerinalang.test.services.nativeimpl.outbound.request;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.BRunUtil;
 import org.ballerinalang.launcher.util.BServiceUtil;
@@ -58,7 +59,6 @@ import java.io.IOException;
 import static org.ballerinalang.mime.util.Constants.APPLICATION_FORM;
 import static org.ballerinalang.mime.util.Constants.APPLICATION_JSON;
 import static org.ballerinalang.mime.util.Constants.APPLICATION_XML;
-import static org.ballerinalang.mime.util.Constants.CONTENT_TYPE;
 import static org.ballerinalang.mime.util.Constants.ENTITY_BYTE_CHANNEL;
 import static org.ballerinalang.mime.util.Constants.ENTITY_HEADERS_INDEX;
 import static org.ballerinalang.mime.util.Constants.FILE;
@@ -148,7 +148,7 @@ public class OutRequestNativeFunctionSuccessTest {
         BStruct entity = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageMime, entityStruct);
 
         BMap<String, BStringArray> headersMap = new BMap<>();
-        headersMap.put(HttpConstants.HTTP_CONTENT_LENGTH,
+        headersMap.put(HttpHeaderNames.CONTENT_LENGTH.toString(),
                        new BStringArray(new String[]{String.valueOf(payload.length())}));
         entity.setRefField(ENTITY_HEADERS_INDEX, headersMap);
         outRequest.addNativeData(MESSAGE_ENTITY, entity);
@@ -177,11 +177,12 @@ public class OutRequestNativeFunctionSuccessTest {
         BStruct entity = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageMime, entityStruct);
 
         BMap<String, BStringArray> headersMap = new BMap<>();
-        headersMap.put(CONTENT_TYPE, new BStringArray(new String[]{APPLICATION_FORM + ";a=2"}));
+        headersMap.put(HttpHeaderNames.CONTENT_TYPE.toString(),
+                       new BStringArray(new String[]{APPLICATION_FORM + ";a=2"}));
         entity.setRefField(ENTITY_HEADERS_INDEX, headersMap);
         outRequest.addNativeData(MESSAGE_ENTITY, entity);
 
-        BString key = new BString(CONTENT_TYPE);
+        BString key = new BString(HttpHeaderNames.CONTENT_TYPE.toString());
         BValue[] inputArg = {outRequest, key};
         BValue[] returnVals = BRunUtil.invoke(result, "testGetHeader", inputArg);
         Assert.assertFalse(returnVals == null || returnVals.length == 0 || returnVals[0] == null,

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/outbound/response/OutResponseNativeFunctionNegativeTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/outbound/response/OutResponseNativeFunctionNegativeTest.java
@@ -17,6 +17,7 @@
  */
 package org.ballerinalang.test.services.nativeimpl.outbound.response;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.launcher.util.BAssertUtil;
 import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.BRunUtil;
@@ -35,7 +36,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
-import static org.ballerinalang.mime.util.Constants.CONTENT_TYPE;
 import static org.ballerinalang.mime.util.Constants.ENTITY_BYTE_CHANNEL;
 import static org.ballerinalang.mime.util.Constants.ENTITY_HEADERS_INDEX;
 import static org.ballerinalang.mime.util.Constants.IS_BODY_BYTE_CHANNEL_ALREADY_SET;
@@ -76,7 +76,7 @@ public class OutResponseNativeFunctionNegativeTest {
     @Test
     public void testGetHeader() {
         BStruct outResponse = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageHttp, inRespStruct);
-        BString key = new BString(CONTENT_TYPE);
+        BString key = new BString(HttpHeaderNames.CONTENT_TYPE.toString());
         BValue[] inputArg = {outResponse, key};
         BValue[] returnVals = BRunUtil.invoke(result, "testGetHeader", inputArg);
         Assert.assertNull(((BString) returnVals[0]).value());

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/outbound/response/OutResponseNativeFunctionSuccessTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/outbound/response/OutResponseNativeFunctionSuccessTest.java
@@ -17,6 +17,7 @@
  */
 package org.ballerinalang.test.services.nativeimpl.outbound.response;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.BRunUtil;
 import org.ballerinalang.launcher.util.BServiceUtil;
@@ -47,7 +48,6 @@ import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 import static org.ballerinalang.mime.util.Constants.APPLICATION_FORM;
 import static org.ballerinalang.mime.util.Constants.APPLICATION_JSON;
 import static org.ballerinalang.mime.util.Constants.APPLICATION_XML;
-import static org.ballerinalang.mime.util.Constants.CONTENT_TYPE;
 import static org.ballerinalang.mime.util.Constants.ENTITY_BYTE_CHANNEL;
 import static org.ballerinalang.mime.util.Constants.ENTITY_HEADERS_INDEX;
 import static org.ballerinalang.mime.util.Constants.IS_BODY_BYTE_CHANNEL_ALREADY_SET;
@@ -134,7 +134,7 @@ public class OutResponseNativeFunctionSuccessTest {
         BStruct entity = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageMime, entityStruct);
 
         BMap<String, BStringArray> headersMap = new BMap<>();
-        headersMap.put(HttpConstants.HTTP_CONTENT_LENGTH,
+        headersMap.put(HttpHeaderNames.CONTENT_LENGTH.toString(),
                        new BStringArray(new String[]{String.valueOf(payload.length())}));
         entity.setRefField(ENTITY_HEADERS_INDEX, headersMap);
         outResponse.addNativeData(MESSAGE_ENTITY, entity);
@@ -152,11 +152,12 @@ public class OutResponseNativeFunctionSuccessTest {
         BStruct entity = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageMime, entityStruct);
 
         BMap<String, BStringArray> headersMap = new BMap<>();
-        headersMap.put(CONTENT_TYPE, new BStringArray(new String[]{APPLICATION_FORM + "; q=0.7"}));
+        headersMap.put(HttpHeaderNames.CONTENT_TYPE.toString(),
+                       new BStringArray(new String[]{APPLICATION_FORM + "; q=0.7"}));
         entity.setRefField(ENTITY_HEADERS_INDEX, headersMap);
         outResponse.addNativeData(MESSAGE_ENTITY, entity);
 
-        BString key = new BString(CONTENT_TYPE);
+        BString key = new BString(HttpHeaderNames.CONTENT_TYPE.toString());
         BValue[] inputArg = {outResponse, key};
         BValue[] returnVals = BRunUtil.invoke(result, "testGetHeader", inputArg);
         Assert.assertFalse(returnVals == null || returnVals.length == 0 || returnVals[0] == null,
@@ -167,7 +168,7 @@ public class OutResponseNativeFunctionSuccessTest {
     @Test(description = "Test GetHeader function within a service")
     public void testServiceGetHeader() {
         String value = "x-www-form-urlencoded";
-        String path = "/hello/getHeader/" + CONTENT_TYPE + "/" + value;
+        String path = "/hello/getHeader/" + HttpHeaderNames.CONTENT_TYPE.toString() + "/" + value;
         HTTPTestRequest inRequest = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequest);
 
@@ -348,7 +349,7 @@ public class OutResponseNativeFunctionSuccessTest {
     @Test(description = "Test RemoveHeader function within a service")
     public void testServiceRemoveHeader() {
         String value = "x-www-form-urlencoded";
-        String path = "/hello/RemoveHeader/" + CONTENT_TYPE + "/" + value;
+        String path = "/hello/RemoveHeader/Content-Type/" + value;
         HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
 

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/session/HTTPSessionEssentialMethodsTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/session/HTTPSessionEssentialMethodsTest.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.test.services.session;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.launcher.util.BServiceUtil;
 import org.ballerinalang.launcher.util.CompileResult;
 import org.ballerinalang.model.util.StringUtils;
@@ -411,7 +412,7 @@ public class HTTPSessionEssentialMethodsTest {
     @Test(description = "Test for struct attribute")
     public void testSessionForStructAttribute() {
         List<Header> headers = new ArrayList<Header>();
-        headers.add(new Header("Content-Type", TEXT_PLAIN));
+        headers.add(new Header(HttpHeaderNames.CONTENT_TYPE.toString(), TEXT_PLAIN));
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage("/sample2/myStruct", "POST", headers, "wso2");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
         Assert.assertNotNull(response);
@@ -438,7 +439,7 @@ public class HTTPSessionEssentialMethodsTest {
     @Test(description = "Test for POST method string attribute")
     public void testPOSTForStringOutput() {
         List<Header> headers = new ArrayList<Header>();
-        headers.add(new Header("Content-Type", TEXT_PLAIN));
+        headers.add(new Header(HttpHeaderNames.CONTENT_TYPE.toString(), TEXT_PLAIN));
         HTTPTestRequest cMsg = MessageUtils.generateHTTPMessage("/sample/hello", "POST", headers, "chamil");
         HTTPCarbonMessage response = Services.invokeNew(compileResult, cMsg);
         Assert.assertNotNull(response);

--- a/tests/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/inbound/request/in-request-native-function.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/inbound/request/in-request-native-function.bal
@@ -91,7 +91,7 @@ service<http> helloServer {
     }
     resource getHeader (http:Connection conn, http:InRequest req) {
         http:OutResponse res = {};
-        string header = req.getHeader("Content-Type");
+        string header = req.getHeader("content-type");
         res.setJsonPayload({value:header});
         _ = conn.respond(res);
     }

--- a/tests/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/outbound/request/out-request-native-function.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/outbound/request/out-request-native-function.bal
@@ -122,7 +122,7 @@ service<http> helloServer {
     }
     resource GetContentLength (http:Connection conn, http:InRequest inReq) {
         http:OutRequest req = {};
-        req.setHeader("Content-Length", "15");
+        req.setHeader("content-length", "15");
         int length = req.getContentLength();
 
         http:OutResponse res = {};


### PR DESCRIPTION
## Purpose
> Resolve https://github.com/ballerina-lang/ballerina/issues/4741

## Goals
> This fixes the inconsistent use of lower case headers.

## Approach
> Use only the header constants from netty's `HttpHeaderNames` as much as possible

## Related PRs
> https://github.com/wso2/transport-http/pull/59
