### PR TITLE
Extend references support for ballerina constructs

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -243,7 +243,7 @@ public class BallerinaTextDocumentService implements TextDocumentService {
     @Override
     public CompletableFuture<List<? extends SymbolInformation>> documentSymbol(DocumentSymbolParams params) {
         String uri = params.getTextDocument().getUri();
-        List<SymbolInformation> symbols = new ArrayList<SymbolInformation>();
+        List<SymbolInformation> symbols = new ArrayList<>();
 
         TextDocumentServiceContext symbolsContext = new TextDocumentServiceContext();
         symbolsContext.put(DocumentServiceKeys.FILE_URI_KEY, uri);
@@ -267,10 +267,7 @@ public class BallerinaTextDocumentService implements TextDocumentService {
     public CompletableFuture<List<? extends Command>> codeAction(CodeActionParams params) {
         return CompletableFuture.supplyAsync(() ->
                 params.getContext().getDiagnostics().stream()
-                        .map(diagnostic -> {
-                            List<Command> res = new ArrayList<>();
-                            return res.stream();
-                        })
+                        .map(diagnostic -> new ArrayList<Command>().stream())
                         .flatMap(it -> it)
                         .collect(Collectors.toList())
         );

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/position/PositionTreeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/position/PositionTreeVisitor.java
@@ -172,6 +172,7 @@ public class PositionTreeVisitor extends NodeVisitor {
             this.context.put(NodeContextKeys.SYMBOL_KIND_OF_NODE_KEY, userDefinedType.type.tsymbol.kind.name());
             this.context.put(NodeContextKeys.NODE_OWNER_KEY, userDefinedType.type.tsymbol.owner.name.getValue());
             this.context.put(NodeContextKeys.NODE_OWNER_PACKAGE_KEY, userDefinedType.type.tsymbol.owner.pkgID);
+            this.context.put(NodeContextKeys.VAR_NAME_OF_NODE_KEY, userDefinedType.typeName.getValue());
             terminateVisitor = true;
         }
     }
@@ -318,8 +319,14 @@ public class PositionTreeVisitor extends NodeVisitor {
         previousNode = ifNode;
         if (ifNode.expr != null && HoverUtil.isMatchingPosition(ifNode.expr.pos, this.position)) {
             acceptNode(ifNode.expr);
-        } else if (ifNode.body != null) {
+        }
+
+        if (ifNode.body != null) {
             acceptNode(ifNode.body);
+        }
+
+        if (ifNode.elseStmt != null) {
+            acceptNode(ifNode.elseStmt);
         }
     }
 


### PR DESCRIPTION
## Purpose
> Fix #4787
Fix #4786
Fix #4785
Fix #4784
Fix #4782

## Goals
> This will extend the find all references support for more ballerina language constructs like transformer, if/else, while, binary expressions, structs and improve the position calculation of enum and fix the issues with enum reference listing and position highlighting.

## Approach
### Transformer Support
![ezgif com-video-to-gif 24](https://user-images.githubusercontent.com/9109762/36479788-f6f9609c-172f-11e8-8d33-27f8e57bc72d.gif)

### If, While, Binary Expression support
![ezgif com-video-to-gif 25](https://user-images.githubusercontent.com/9109762/36479900-69926aae-1730-11e8-999d-524d4f16999b.gif)

### Struct
![ezgif com-video-to-gif 26](https://user-images.githubusercontent.com/9109762/36480101-111fbc5e-1731-11e8-9df9-49f5bf14076f.gif)

### Enum
![ezgif com-video-to-gif 27](https://user-images.githubusercontent.com/9109762/36480191-69a5bdce-1731-11e8-8262-f158f92d35ea.gif)



