### PR TITLE
Show error messages to users for possible mistakes

### DIFF
--- a/tool-plugins/vscode/extension.js
+++ b/tool-plugins/vscode/extension.js
@@ -20,6 +20,7 @@
 const { workspace, commands, window, ExtensionContext, debug } = require('vscode');
 const { LanguageClient, LanguageClientOptions, ServerOptions } = require('vscode-languageclient');
 const path = require('path');
+const fs = require('fs');
 
 let oldConfig;
 
@@ -31,6 +32,16 @@ const debugConfigResolver = {
 			if (workspaceConfig.sdk) {
 				config['ballerina.sdk'] = workspaceConfig.sdk;
 			}
+		}
+
+		if (config['ballerina.sdk']) {
+			if (fs.readdirSync(config['ballerina.sdk']).indexOf('bin') < 0) {
+				const msg = "Couldn't find a bin directory inside the configured sdk path. Please set ballerina.sdk correctly."
+				window.showErrorMessage(msg);
+			}
+		} else {
+			const msg = "To start the debug server please set ballerina.sdk."
+			window.showErrorMessage(msg);
 		}
 
 		return config;


### PR DESCRIPTION
## Purpose
When the ballerina sdk path is not set, or when its set to a directory not containing a valid ballerina distribution, the debugger just logs to the console. This may confuse the user. With this PR additionally we display an error message in these cases.

## Approach
![image](https://user-images.githubusercontent.com/3872221/36518988-d9e4e844-17ae-11e8-99b2-604bf8971b9e.png)

