### PR TITLE
Add transformer iterable operation design support

### DIFF
--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/function.jsx
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/function.jsx
@@ -79,10 +79,12 @@ export default class FunctionInv extends React.Component {
                 <div
                     id={`${funcInvID}:${viewId}`}
                     className='function-header'
-                    onClick={() => this.props.onHeaderClick(funcInvID)}
                     title={isCollapsed ? 'Expand' : 'Collapse'}
                 >
-                    <i className={`fw ${foldIndicator} fold-indicator`} />
+                    <i
+                        className={`fw ${foldIndicator} fold-indicator`}
+                        onClick={() => this.props.onHeaderClick(funcInvID)}
+                    />
                     <i className={`fw fw-${func.type === 'iterable' ? 'iterable-operations' : 'function'} fw-inverse`} />
                     <span className='func-name'>{funcInv.getFunctionName()}</span>
                     <span

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/function.jsx
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/function.jsx
@@ -17,6 +17,7 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import Tree from './tree.jsx';
 import './function.css';
 
@@ -85,7 +86,9 @@ export default class FunctionInv extends React.Component {
                         className={`fw ${foldIndicator} fold-indicator`}
                         onClick={() => this.props.onHeaderClick(funcInvID)}
                     />
-                    <i className={`fw fw-${func.type === 'iterable' ? 'iterable-operations' : 'function'} fw-inverse`} />
+                    <i className={`fw fw-${func.type === 'iterable'
+                        ? 'iterable-operations' : 'function'} fw-inverse`}
+                    />
                     <span className='func-name'>{funcInv.getFunctionName()}</span>
                     <span
                         onClick={(e) => {
@@ -97,9 +100,26 @@ export default class FunctionInv extends React.Component {
                     >
                         <i className='fw-delete fw-stack-1x fw-inverse' />
                     </span>
+                    { funcInv.iterableOperation
+                        && funcInv.getArgumentExpressions().length > 0 &&
+                        <span
+                            onClick={(e) => {
+                                const { editor } = this.context;
+                                editor.goToSource(funcInv.getArgumentExpressions()[0].functionNode);
+                            }}
+                            className='fw-stack fw-lg btn btn-remove-func'
+                            title='Jump to Source'
+                        >
+                            <i className='fw-edit fw-stack-1x fw-inverse' />
+                        </span>
+                    }
                 </div>
                 { !isCollapsed && functionBody }
             </div>
         );
     }
 }
+
+FunctionInv.contextTypes = {
+    editor: PropTypes.instanceOf(Object).isRequired,
+};

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/iterable-list.css
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/iterable-list.css
@@ -1,0 +1,19 @@
+.iterable-menu {
+    opacity: 1;
+    background: #f1f1f1;
+    overflow: visible;
+    margin-left: 1px;
+    color: #333;
+    position: fixed;
+    z-index: 1001;
+}
+
+.iterable-menu-item {
+    color: #333 !important;
+    display: block;
+    line-height: 30px;
+    padding-left: 15px;
+    padding-right: 15px;
+    color: inherit;
+    cursor: pointer;
+}

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/iterable-list.jsx
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/iterable-list.jsx
@@ -24,6 +24,10 @@ import './iterable-list.css';
  */
 class IterableList extends React.Component {
 
+    /**
+     * IterableList extended component constructor
+     * @param {any} props props for the component
+     */
     constructor(props) {
         super(props);
         this.state = { showIterables: true };
@@ -39,6 +43,7 @@ class IterableList extends React.Component {
     componentDidMount() {
         document.addEventListener('mousedown', this.handleClickOutside);
     }
+
     /**
      * remove mouse down event bound  when mounting component
      */
@@ -76,6 +81,11 @@ class IterableList extends React.Component {
         }
     }
 
+    /**
+     * Handles add iterable click event
+     * @param {string} type iterable operation type
+     * @param {boolean} isLambda is given iterable operation has a lambda function
+     */
     addIterable(type, isLambda) {
         this.props.transformNodeManager.addIterableOperator(this.props.currrentConnection, type, isLambda);
         this.setState({ showIterables: false });

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/iterable-list.jsx
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/iterable-list.jsx
@@ -17,10 +17,6 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import Button from '../../../../../interactions/button';
-import Item from '../../../../../interactions/item';
-import Area from '../../../../../interactions/area';
-import Menu from '../../../../../interactions/menu';
 import './iterable-list.css';
 
 /**
@@ -132,14 +128,6 @@ IterableList.propTypes = {
     currrentConnection: PropTypes.valueOf(PropTypes.object).isRequired,
     transformNodeManager: PropTypes.valueOf(PropTypes.object).isRequired,
     callback: PropTypes.valueOf(PropTypes.object).isRequired,
-};
-
-IterableList.defaultProps = {
-    
-};
-
-IterableList.contextTypes = {
-
 };
 
 export default IterableList;

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/iterable-list.jsx
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/iterable-list.jsx
@@ -65,6 +65,7 @@ class IterableList extends React.Component {
     handleClickOutside(event) {
         if (this.wrapperRef && !this.wrapperRef.contains(event.target)) {
             this.setState({ showIterables: false });
+            this.props.callback();
         } else {
             this.buttonClick();
         }
@@ -74,12 +75,15 @@ class IterableList extends React.Component {
      * Handles button click event
      */
     buttonClick() {
-        this.setState({ showIterables: true });
+        if (this.props.showIterables) {
+            this.setState({ showIterables: true });
+        }
     }
 
     addIterable(type, isLambda) {
         this.props.transformNodeManager.addIterableOperator(this.props.currrentConnection, type, isLambda);
         this.setState({ showIterables: false });
+        this.props.callback();
     }
 
     /**
@@ -127,6 +131,7 @@ IterableList.propTypes = {
     showIterables: PropTypes.valueOf(PropTypes.bool).isRequired,
     currrentConnection: PropTypes.valueOf(PropTypes.object).isRequired,
     transformNodeManager: PropTypes.valueOf(PropTypes.object).isRequired,
+    callback: PropTypes.valueOf(PropTypes.object).isRequired,
 };
 
 IterableList.defaultProps = {

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/iterable-list.jsx
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/iterable-list.jsx
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import Button from '../../../../../interactions/button';
+import Item from '../../../../../interactions/item';
+import Area from '../../../../../interactions/area';
+import Menu from '../../../../../interactions/menu';
+import './iterable-list.css';
+
+/**
+ * Iterable Operator List
+ */
+class IterableList extends React.Component {
+
+    constructor(props) {
+        super(props);
+        this.state = { showIterables: true };
+        this.buttonClick = this.buttonClick.bind(this);
+        this.setWrapperRef = this.setWrapperRef.bind(this);
+        this.handleClickOutside = this.handleClickOutside.bind(this);
+        this.addIterable = this.addIterable.bind(this);
+    }
+
+    /**
+     * Bind mouse down event to handle out side click events
+     */
+    componentDidMount() {
+        document.addEventListener('mousedown', this.handleClickOutside);
+    }
+    /**
+     * remove mouse down event bound  when mounting component
+     */
+    componentWillUnmount() {
+        document.removeEventListener('mousedown', this.handleClickOutside);
+    }
+
+    /**
+     * Set specified node as wrapper reference for check outside clicks
+     * @param {*} node node click event needs to be detected
+     */
+    setWrapperRef(node) {
+        this.wrapperRef = node;
+    }
+
+    /**
+     * Handle outside click event and close menu accordingly
+     * @param {*} event triggerred event
+     */
+    handleClickOutside(event) {
+        if (this.wrapperRef && !this.wrapperRef.contains(event.target)) {
+            this.setState({ showIterables: false });
+        } else {
+            this.buttonClick();
+        }
+    }
+
+    /**
+     * Handles button click event
+     */
+    buttonClick() {
+        this.setState({ showIterables: true });
+    }
+
+    addIterable(type, isLambda) {
+        this.props.transformNodeManager.addIterableOperator(this.props.currrentConnection, type, isLambda);
+        this.setState({ showIterables: false });
+    }
+
+    /**
+     * render hover area and button
+     * @return {object} button rendering object
+     */
+    render() {
+        if (this.props.showIterables && this.state.showIterables) {
+            return (
+                <div
+                    ref={this.setWrapperRef}
+                    style={{ top: this.props.bBox.y - 10, left: this.props.bBox.x - 20 }}
+                    className='iterable-menu'
+                >
+                    <a onClick={() => { this.addIterable('filter', true); }} className='iterable-menu-item'>
+                        <i className={'fw fw-iterable-operations'} /> Add Filter
+                    </a>
+                    <a onClick={() => { this.addIterable('map', true); }} className='iterable-menu-item'>
+                        <i className={'fw fw-iterable-operations'} /> Add Map
+                    </a>
+                    <a onClick={() => { this.addIterable('sum', false); }} className='iterable-menu-item'>
+                        <i className={'fw fw-iterable-operations'} /> Add Sum
+                    </a>
+                    <a onClick={() => { this.addIterable('average', false); }} className='iterable-menu-item'>
+                        <i className={'fw fw-iterable-operations'} /> Add Average
+                    </a>
+                    <a onClick={() => { this.addIterable('min', false); }} className='iterable-menu-item'>
+                        <i className={'fw fw-iterable-operations'} /> Add Min
+                    </a>
+                    <a onClick={() => { this.addIterable('max', false); }} className='iterable-menu-item'>
+                        <i className={'fw fw-iterable-operations'} /> Add Max
+                    </a>
+                    <a onClick={() => { this.addIterable('count', false); }} className='iterable-menu-item'>
+                        <i className={'fw fw-iterable-operations'} /> Add Count
+                    </a>
+                </div>);
+        } else {
+            return (<div />);
+        }
+    }
+}
+
+IterableList.propTypes = {
+    bBox: PropTypes.valueOf(PropTypes.object).isRequired,
+    showIterables: PropTypes.valueOf(PropTypes.bool).isRequired,
+    currrentConnection: PropTypes.valueOf(PropTypes.object).isRequired,
+    transformNodeManager: PropTypes.valueOf(PropTypes.object).isRequired,
+};
+
+IterableList.defaultProps = {
+    
+};
+
+IterableList.contextTypes = {
+
+};
+
+export default IterableList;

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-expanded.jsx
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-expanded.jsx
@@ -551,9 +551,14 @@ class TransformerExpanded extends React.Component {
                     }
                 }
             } else if (TreeUtil.isInvocation(expression)) {
-                type = this.getFunctionArgConversionType(expression.getArgumentExpressions(),
-                                                          sourceId.split(':')[0]);
-            } else if (TreeUtil.isFieldBasedAccessExpr(expression) && expression.symbolType[0].includes('[]')) {
+                if (expression.iterableOperation) {
+                    type = 'array';
+                } else {
+                    type = this.getFunctionArgConversionType(expression.getArgumentExpressions(),
+                    sourceId.split(':')[0]);
+                }
+            } else if (TreeUtil.isFieldBasedAccessExpr(expression) && (expression.symbolType[0].includes('[]')
+            || expression.symbolType[0] === 'other')) {
                 type = 'array';
             }
         }
@@ -1201,6 +1206,12 @@ class TransformerExpanded extends React.Component {
 
         this.props.model.getBody().getStatements().forEach((stmt) => {
             let stmtExp;
+
+            const addIterableCallback = (type, isLambda, currrentConnection) => {
+                this.transformNodeManager.addIterableOperator(currrentConnection, type, isLambda);
+                this.setState({ showIterables: false });
+            };
+
             if (TreeUtil.isAssignment(stmt)) {
                 stmtExp = stmt.getExpression();
             } else if (TreeUtil.isVariableDef(stmt)) {
@@ -1366,6 +1377,7 @@ class TransformerExpanded extends React.Component {
                                         bBox={{ x: this.state.iterableX, y: this.state.iterableY, h: 0, w: 0 }}
                                         currrentConnection={this.state.currrentConnection}
                                         transformNodeManager={this.transformNodeManager}
+                                        callback={() => { this.setState({ showIterables: false }); }}
                                     />
                                     <div className='right-content'>
                                         <div className='rightType'>

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-expanded.jsx
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-expanded.jsx
@@ -34,6 +34,7 @@ import TreeUtil from '../../../../../model/tree-util';
 import DropZone from '../../../../../drag-drop/DropZone';
 import Button from '../../../../../interactions/transform-button';
 import './transformer-expanded.css';
+import IterableList from './iterable-list';
 
 /**
  * React component for transform expanded view
@@ -52,6 +53,10 @@ class TransformerExpanded extends React.Component {
         super(props, context);
         this.state = {
             // vertices changes must re-render. Hence added as a state.
+            showIterables: false,
+            iterableX: 0,
+            iterableY: 0,
+            currrentConnection: {},
             vertices: [],
             typedSource: '',
             typedTarget: '',
@@ -548,9 +553,16 @@ class TransformerExpanded extends React.Component {
             } else if (TreeUtil.isInvocation(expression)) {
                 type = this.getFunctionArgConversionType(expression.getArgumentExpressions(),
                                                           sourceId.split(':')[0]);
+            } else if (TreeUtil.isFieldBasedAccessExpr(expression) && expression.symbolType[0].includes('[]')) {
+                type = 'array';
             }
         }
-        this.mapper.addConnection(sourceId, targetId, folded, type);
+
+        const callback = (pageX, pageY, connection) => {
+            this.setState({ showIterables: true, iterableX: pageX, iterableY: pageY, currrentConnection: connection });
+        };
+
+        this.mapper.addConnection(sourceId, targetId, folded, type, callback);
     }
 
     /**
@@ -1343,9 +1355,16 @@ class TransformerExpanded extends React.Component {
                                         }
                                     </DropZone>
                                     <Button
+                                        className='transformer-button'
                                         bBox={{ x: 0, y: 0, h: 0, w: 300 }}
                                         showAlways
                                         model={this.props.model.getBody()}
+                                        transformNodeManager={this.transformNodeManager}
+                                    />
+                                    <IterableList
+                                        showIterables={this.state.showIterables}
+                                        bBox={{ x: this.state.iterableX, y: this.state.iterableY, h: 0, w: 0 }}
+                                        currrentConnection={this.state.currrentConnection}
                                         transformNodeManager={this.transformNodeManager}
                                     />
                                     <div className='right-content'>

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-expanded.jsx
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-expanded.jsx
@@ -549,14 +549,13 @@ class TransformerExpanded extends React.Component {
                 }
             } else if (TreeUtil.isInvocation(expression)) {
                 if (expression.iterableOperation && !targetId.includes('receiver')) {
-                    type = 'array';
+                    type = 'iterable';
                 } else {
                     type = this.getFunctionArgConversionType(expression.getArgumentExpressions(),
                     sourceId.split(':')[0]);
                 }
-            } else if (TreeUtil.isFieldBasedAccessExpr(expression) && (expression.symbolType[0].includes('[]')
-            || expression.symbolType[0] === 'other')) {
-                type = 'array';
+            } else if (TreeUtil.isFieldBasedAccessExpr(expression) && (expression.symbolType[0].includes('[]'))) {
+                type = 'iterable';
             }
         }
         const callback = (pageX, pageY, connection) => {
@@ -1206,12 +1205,6 @@ class TransformerExpanded extends React.Component {
 
         this.props.model.getBody().getStatements().forEach((stmt) => {
             let stmtExp;
-
-            const addIterableCallback = (type, isLambda, currrentConnection) => {
-                this.transformNodeManager.addIterableOperator(currrentConnection, type, isLambda);
-                this.setState({ showIterables: false });
-            };
-
             if (TreeUtil.isAssignment(stmt)) {
                 stmtExp = stmt.getExpression();
             } else if (TreeUtil.isVariableDef(stmt)) {

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-expanded.jsx
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-expanded.jsx
@@ -53,10 +53,7 @@ class TransformerExpanded extends React.Component {
         super(props, context);
         this.state = {
             // vertices changes must re-render. Hence added as a state.
-            showIterables: false,
-            iterableX: 0,
-            iterableY: 0,
-            currrentConnection: {},
+            iterableOperationMenu : {},
             vertices: [],
             typedSource: '',
             typedTarget: '',
@@ -551,7 +548,7 @@ class TransformerExpanded extends React.Component {
                     }
                 }
             } else if (TreeUtil.isInvocation(expression)) {
-                if (expression.iterableOperation) {
+                if (expression.iterableOperation && !targetId.includes('receiver')) {
                     type = 'array';
                 } else {
                     type = this.getFunctionArgConversionType(expression.getArgumentExpressions(),
@@ -562,11 +559,14 @@ class TransformerExpanded extends React.Component {
                 type = 'array';
             }
         }
-
         const callback = (pageX, pageY, connection) => {
-            this.setState({ showIterables: true, iterableX: pageX, iterableY: pageY, currrentConnection: connection });
+            this.setState({ iterableOperationMenu: {
+                showIterables: true,
+                iterableX: pageX,
+                iterableY: pageY,
+                currrentConnection: connection,
+            } });
         };
-
         this.mapper.addConnection(sourceId, targetId, folded, type, callback);
     }
 
@@ -1373,11 +1373,16 @@ class TransformerExpanded extends React.Component {
                                         transformNodeManager={this.transformNodeManager}
                                     />
                                     <IterableList
-                                        showIterables={this.state.showIterables}
-                                        bBox={{ x: this.state.iterableX, y: this.state.iterableY, h: 0, w: 0 }}
-                                        currrentConnection={this.state.currrentConnection}
+                                        showIterables={this.state.iterableOperationMenu.showIterables}
+                                        bBox={{
+                                            x: this.state.iterableOperationMenu.iterableX,
+                                            y: this.state.iterableOperationMenu.iterableY,
+                                            h: 0,
+                                            w: 0,
+                                        }}
+                                        currrentConnection={this.state.iterableOperationMenu.currrentConnection}
                                         transformNodeManager={this.transformNodeManager}
-                                        callback={() => { this.setState({ showIterables: false }); }}
+                                        callback={() => { this.setState({ iterableOperationMenu: { showIterables: false } }); }}
                                     />
                                     <div className='right-content'>
                                         <div className='rightType'>

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-node-manager.js
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-node-manager.js
@@ -174,7 +174,7 @@ class TransformerNodeManager {
     removeStatementEdge(connection) {
         const { source, target } = connection;
 
-        if (source.endpointKind === 'input' && target.endpointKind === 'output') {
+        if (source.endpointKind === 'input' && (target.endpointKind === 'output' || target.endpointKind === 'param')) {
             this._mapper.removeInputToOutputMapping(source.name, target.name);
             return;
         }
@@ -282,7 +282,9 @@ class TransformerNodeManager {
                     type: argType,
                     index: 0 }];
             }
-            returnParams = [{ name: returnParamName,
+            returnParams = [{
+                index: 0,
+                name: returnParamName,
                 type: dataReturnType.replace('intermediate_collection', '[]'),
                 funcInv: functionInvocationExpression }];
         } else if (!funcDef) {
@@ -579,9 +581,14 @@ class TransformerNodeManager {
         }
     }
 
+    /**
+     * Generate iterable operation to the given connection
+     * @param {*} connection where iterable operation should be added
+     * @param {*} type iterable operation type
+     * @param {*} isLamda is given iterable operation has a lambda function
+     */
     addIterableOperator(connection, type, isLamda) {
-        this._mapper
-        .addIterator(connection, type, isLamda);
+        this._mapper.addIterableOperator(connection, type, isLamda);
     }
  }
 

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-node-manager.js
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-node-manager.js
@@ -565,6 +565,10 @@ class TransformerNodeManager {
             return false;
         }
     }
+
+    addIterableOperator(connection, type, isLamda) {
+        this._mapper.addIterator(connection.source.name, connection.target.name, type, connection.source.type, isLamda);
+    }
  }
 
 export default TransformerNodeManager;

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-node-manager.js
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-node-manager.js
@@ -252,25 +252,20 @@ class TransformerNodeManager {
         let parameters = [];
         let returnParams = [];
         let receiver;
-
         if (functionInvocationExpression.iterableOperation) {
             const inputParamName = `${functionInvocationExpression.getID()}:0:receiver`;
             const returnParamName = `${functionInvocationExpression.getID()}:0:return`;
-            type = 'iterable';
-
             let dataType = '[]';
             let dataReturnType = '[]';
+            type = 'iterable';
             if (functionInvocationExpression.getExpression().symbolType
                 && functionInvocationExpression.getExpression().symbolType.length > 0) {
                 dataType = functionInvocationExpression.getExpression().symbolType[0];
             }
-
             if (functionInvocationExpression.symbolType && functionInvocationExpression.symbolType.length > 0) {
                 dataReturnType = functionInvocationExpression.symbolType[0];
             }
-
-            const argType = dataType
-                                .replace('intermediate_collection', '[]');
+            const argType = dataType.replace('intermediate_collection', '[]');
             if (functionInvocationExpression.argumentExpressions.length === 0) {
                 receiver = {
                     name: inputParamName,

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-node-manager.js
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-node-manager.js
@@ -252,11 +252,24 @@ class TransformerNodeManager {
         let parameters = [];
         let returnParams = [];
         let receiver;
+
         if (functionInvocationExpression.iterableOperation) {
             const inputParamName = `${functionInvocationExpression.getID()}:0:receiver`;
             const returnParamName = `${functionInvocationExpression.getID()}:0:return`;
             type = 'iterable';
-            const argType = functionInvocationExpression.getExpression().symbolType[0]
+
+            let dataType = '[]';
+            let dataReturnType = '[]';
+            if (functionInvocationExpression.getExpression().symbolType
+                && functionInvocationExpression.getExpression().symbolType.length > 0) {
+                dataType = functionInvocationExpression.getExpression().symbolType[0];
+            }
+
+            if (functionInvocationExpression.symbolType && functionInvocationExpression.symbolType.length > 0) {
+                dataReturnType = functionInvocationExpression.symbolType[0];
+            }
+
+            const argType = dataType
                                 .replace('intermediate_collection', '[]');
             if (functionInvocationExpression.argumentExpressions.length === 0) {
                 receiver = {
@@ -270,7 +283,7 @@ class TransformerNodeManager {
                     index: 0 }];
             }
             returnParams = [{ name: returnParamName,
-                type: functionInvocationExpression.symbolType[0].replace('intermediate_collection', '[]'),
+                type: dataReturnType.replace('intermediate_collection', '[]'),
                 funcInv: functionInvocationExpression }];
         } else if (!funcDef) {
             log.error('Cannot find function definition for ' + functionInvocationExpression.getFunctionName());
@@ -567,7 +580,8 @@ class TransformerNodeManager {
     }
 
     addIterableOperator(connection, type, isLamda) {
-        this._mapper.addIterator(connection.source.name, connection.target.name, type, connection.source.type, isLamda);
+        this._mapper
+        .addIterator(connection, type, isLamda);
     }
  }
 

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-node-mapper.js
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-node-mapper.js
@@ -1687,18 +1687,22 @@ class TransformerNodeMapper {
         return kvp;
     }
 
-    addIterator(source, target, type, sourceType, isLamda) {
+    addIterator(connection, type, isLamda) {
         this.getMappingStatements().forEach((stmt) => {
             if (TreeUtil.isAssignment(stmt)) {
-                if (stmt.getVariables()[0].getSource().trim() === target &&
-                    stmt.getExpression().getSource().trim() === source) {
+                if ((stmt.getVariables()[0].getSource().trim() === connection.target.name
+                    || connection.target.funcInv.iterableOperation) &&
+                    (stmt.getExpression().getSource().trim() === connection.source.name
+                    || connection.source.funcInv.iterableOperation)) {
+                    const sourceContent = stmt.getExpression().getSource().trim() === connection.source.name ?
+                    connection.source.name : connection.source.funcInv.getSource();
                     stmt.setExpression(
-                        TransformerFactory
-                            .createIterableOperation(source, type, sourceType.replace('[]', '')), isLamda);
+                        TransformerFactory.createIterableOperation(sourceContent,
+                            type, connection.source.type.replace('[]', ''), isLamda));
                     stmt.trigger('tree-modified', {
                         origin: stmt,
                         type: 'variable-update',
-                        title: `Variable update ${source}`,
+                        title: `Variable update ${connection.source.name}`,
                         data: {},
                     });
                 }

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-node-mapper.js
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-node-mapper.js
@@ -1686,6 +1686,25 @@ class TransformerNodeMapper {
         });
         return kvp;
     }
+
+    addIterator(source, target, type, sourceType, isLamda) {
+        this.getMappingStatements().forEach((stmt) => {
+            if (TreeUtil.isAssignment(stmt)) {
+                if (stmt.getVariables()[0].getSource().trim() === target &&
+                    stmt.getExpression().getSource().trim() === source) {
+                    stmt.setExpression(
+                        TransformerFactory
+                            .createIterableOperation(source, type, sourceType.replace('[]', '')), isLamda);
+                    stmt.trigger('tree-modified', {
+                        origin: stmt,
+                        type: 'variable-update',
+                        title: `Variable update ${source}`,
+                        data: {},
+                    });
+                }
+            }
+        });
+    }
 }
 
 export default TransformerNodeMapper;

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-node-mapper.js
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-node-mapper.js
@@ -581,7 +581,7 @@ class TransformerNodeMapper {
         } else {
             let defaultExp = TransformerFactory.createDefaultExpression();
             if (TreeUtil.isInvocation(parentNode)) {
-                if (parentDef && parentDef.type !== 'iterable') {
+                if (parentDef) {
                     const index = parentNode.getIndexOfArgumentExpressions(nodeExpression);
                     defaultExp = TransformerFactory.createDefaultExpression(parentDef.parameters[index].type);
                 }
@@ -1689,9 +1689,9 @@ class TransformerNodeMapper {
 
     /**
      * Generate iterable operation to the given connection
-     * @param {*} connection where iterable operation should be added
-     * @param {*} type iterable operation type
-     * @param {*} isLamda is given iterable operation has a lambda function
+     * @param {object} connection where iterable operation should be added
+     * @param {string} type iterable operation type
+     * @param {boolean} isLamda is given iterable operation has a lambda function
      */
     addIterableOperator(connection, type, isLamda) {
         this.getMappingStatements().forEach((stmt) => {

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-render.js
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-render.js
@@ -167,7 +167,7 @@ class TransformerRender {
      * @param {string}  targetId target identifier
      * @param {Boolean} [folded=false] connection is folded
      */
-    addConnection(sourceId, targetId, folded = false, castType = false) {
+    addConnection(sourceId, targetId, folded = false, castType = false, callback = null) {
         const render = this;
         this.jsPlumbInstance.importDefaults(
           { Connector: this.getConnectorConfig(this.midpointOnAddConnection(sourceId)) });
@@ -204,7 +204,25 @@ class TransformerRender {
                 outlineWidth: 2,
                 outlineStroke: '#ffe0b3',
             };
-            if (castType) {
+            if (castType === 'array') {
+                options.overlays = [['Custom', {
+                    location: 0.9,
+                    id: 'label',
+                    create: (component) => {
+                        return $('<span class="button-show-always fw-lg button-background" title="">'
+                        + '<i class="fw fw-iterable-operations fw-lg button-icon"></i></span>');
+                    },
+                    cssClass: 'connectionLabel',
+                    events: {
+                        mousedown: (connection, e) => {
+                            callback(e.pageX,
+                                e.pageY,
+                                render.getConnectionObject(connection.component.getParameter('input'),
+                                connection.component.getParameter('output')));
+                        },
+                    },
+                }]];
+            } else if (castType) {
                 options.overlays = [['Label', {
                     location: 0.9,
                     id: 'label',
@@ -216,7 +234,7 @@ class TransformerRender {
                         },
                     },
                 }]];
-            }
+            } 
         }
 
         this.jsPlumbInstance.connect(options);

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-render.js
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-render.js
@@ -204,7 +204,7 @@ class TransformerRender {
                 outlineWidth: 2,
                 outlineStroke: '#ffe0b3',
             };
-            if (castType === 'array') {
+            if (castType === 'iterable') {
                 options.overlays = [['Custom', {
                     location: 0.75,
                     id: 'label',
@@ -234,7 +234,7 @@ class TransformerRender {
                         },
                     },
                 }]];
-            } 
+            }
         }
 
         this.jsPlumbInstance.connect(options);

--- a/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-render.js
+++ b/composer/modules/web/src/plugins/ballerina/diagram/views/default/components/transformer/transformer-render.js
@@ -206,11 +206,11 @@ class TransformerRender {
             };
             if (castType === 'array') {
                 options.overlays = [['Custom', {
-                    location: 0.9,
+                    location: 0.75,
                     id: 'label',
                     create: (component) => {
                         return $('<span class="button-show-always fw-lg button-background" title="">'
-                        + '<i class="fw fw-iterable-operations fw-lg button-icon"></i></span>');
+                        + '<i class="fw fw-iterable-operations fw-lg"></i></span>');
                     },
                     cssClass: 'connectionLabel',
                     events: {

--- a/composer/modules/web/src/plugins/ballerina/model/transformer-factory.js
+++ b/composer/modules/web/src/plugins/ballerina/model/transformer-factory.js
@@ -83,8 +83,17 @@ class TransformerFactory {
         const fragment = FragmentUtils.createExpressionFragment(`${name}.${type}(${lambdaFunction})`);
         const parsedJson = FragmentUtils.parseFragment(fragment);
         const exp = TreeBuilder.build(parsedJson).getVariable().getInitialExpression();
+        TransformerFactory.updateItreableOperation(exp, sourceType);
         exp.clearWS();
         return exp;
+    }
+
+    static updateItreableOperation(node, sourceType) {
+        node.iterableOperation = true;
+        node.symbolType[0] = sourceType;
+        if (TreeUtil.isInvocation(node.getExpression())) {
+            TransformerFactory.updateItreableOperation(node.getExpression(), sourceType);
+        }
     }
 
     /**

--- a/composer/modules/web/src/plugins/ballerina/model/transformer-factory.js
+++ b/composer/modules/web/src/plugins/ballerina/model/transformer-factory.js
@@ -75,6 +75,14 @@ class TransformerFactory {
         return variable;
     }
 
+    /**
+     * create a iterable operation for provided name and type
+     * @param {string} name collection name
+     * @param {string} type iterable operation type
+     * @param {string} sourceType source collection type
+     * @param {boolean} isLamda is given iterable operation has a lambda function
+     * @return {object} created iterable operation node
+     */
     static createIterableOperation(name, type, sourceType, isLamda) {
         let lambdaFunction = '';
         if (isLamda) {
@@ -88,6 +96,11 @@ class TransformerFactory {
         return exp;
     }
 
+    /**
+     * Update iterable flag recursive for chained iterable operations
+     * @param {object} node expression node
+     * @param {*} sourceType source collection type
+     */
     static updateItreableOperation(node, sourceType) {
         node.iterableOperation = true;
         node.symbolType[0] = sourceType;

--- a/composer/modules/web/src/plugins/ballerina/model/transformer-factory.js
+++ b/composer/modules/web/src/plugins/ballerina/model/transformer-factory.js
@@ -75,6 +75,18 @@ class TransformerFactory {
         return variable;
     }
 
+    static createIterableOperation(name, type, sourceType, isLamda) {
+        let lambdaFunction = '';
+        if (isLamda) {
+            lambdaFunction = `function(${sourceType} item)(boolean){ return true; }`;
+        }
+        const fragment = FragmentUtils.createExpressionFragment(`${name}.${type}(${lambdaFunction})`);
+        const parsedJson = FragmentUtils.parseFragment(fragment);
+        const exp = TreeBuilder.build(parsedJson).getVariable().getInitialExpression();
+        exp.clearWS();
+        return exp;
+    }
+
     /**
      * Create default expression based on argument type
      * @static


### PR DESCRIPTION
## Purpose
> Allow user to add iterable operation from the Transformer design view. Resolves https://github.com/ballerina-lang/ballerina/issues/4648

## Goals
> Generate the source code when adding iterable operations from the Transformer design view

## Approach
> User can map collection mapping, then iterable operation icon will be appeared. By clicking the icon user can add iterable operations. For the iterable operations with lambda function, user can click edit button and update the code from source view.
![transform-iterable-operators](https://user-images.githubusercontent.com/2918812/36531059-b785bd26-17e2-11e8-9091-7cfd06facaaf.gif)

