### PR TITLE
Make Ballerina by example more readable

### DIFF
--- a/docs/ballerina-by-example/examples/http-failover/http-failover.server.sh
+++ b/docs/ballerina-by-example/examples/http-failover/http-failover.server.sh
@@ -1,5 +1,5 @@
-# To run the service, put the code in `http-failover`
-# and use `$BALLERINA_HOME/bin`.
+# To run the service, put the code in `http-failover.bal`
+# and execute the following command from `$BALLERINA_HOME/bin`.
 $ ballerina run http-failover.bal
 ballerina: deploying service(s) in 'http-failover.bal'
 ballerina: started HTTP/WS server connector 0.0.0.0:9090

--- a/docs/ballerina-by-example/examples/http-load-balancer/http-load-balancer.bal
+++ b/docs/ballerina-by-example/examples/http-load-balancer/http-load-balancer.bal
@@ -1,64 +1,51 @@
 import ballerina.net.http;
 import ballerina.net.http.resiliency;
-import ballerina.mime;
 
 service<http> loadBalancerService {
 
-    // Set of HttpClient connectors to be Load Balanced.
-    http:HttpClient endPoint1 =
-                    create http:HttpClient("http://localhost:9090/mock1", {});
-    http:HttpClient endPoint2 =
-                    create http:HttpClient("http://localhost:9090/mock2", {});
-    http:HttpClient endPoint3 =
-                    create http:HttpClient("http://localhost:9090/mock3", {});
-
-    http:HttpClient[] loadbalanceGruop = [ endPoint1, endPoint2, endPoint3];
-
-    @Description {value:"Requests which contain any HTTP method will be directed to passthrough resource."}
+    @Description {value:"Requests which contain any HTTP method will be directed to loadBalanceResource resource."}
     @http:resourceConfig {
         path:"/"
     }
 
     resource loadBalanceResource (http:Connection conn, http:InRequest req) {
 
-        // LoadBalancer connector takes the input as an array of HttpClient connectors and an algorithm as a function pointer.
-        // The pointed function contains the implementation of the load balancing strategy.
-        // With this approach users will be able to implement their own load balancing strategies and plug it into the connector.
-        endpoint<http:HttpClient> ep {
-            create resiliency:LoadBalancer (loadbalanceGruop, resiliency:roundRobin);
+        endpoint<http:HttpClient> endPoint {
+            create resiliency:LoadBalancer(
+            [create http:HttpClient("http://localhost:9090/mock1", {}),
+             create http:HttpClient("http://localhost:9090/mock2", {}),
+             create http:HttpClient("http://localhost:9090/mock3", {})],
+            resiliency:roundRobin);
         }
 
-        http:InResponse clientResponse = {};
-        http:HttpConnectorError err;
+        http:InResponse inResponse = {};
+        http:HttpConnectorError httpConnectorError;
 
-        http:OutRequest outReq = {};
+        http:OutRequest outRequest = {};
         json requestPayload = {"name":"Ballerina"};
-        outReq.setJsonPayload(requestPayload);
-        clientResponse, err = ep.post("/", outReq);
+        outRequest.setJsonPayload(requestPayload);
+        inResponse, httpConnectorError = endPoint.post("/", outRequest);
 
-        http:OutResponse res = {};
-        if (err != null) {
-            res.statusCode = err.statusCode;
-            res.setStringPayload(err.message);
-            _ = conn.respond(res);
+        http:OutResponse outResponse = {};
+        if (httpConnectorError != null) {
+            outResponse.statusCode = httpConnectorError.statusCode;
+            outResponse.setStringPayload(httpConnectorError.message);
+            _ = conn.respond(outResponse);
         } else {
-            _ = conn.forward(clientResponse);
+            _ = conn.forward(inResponse);
         }
     }
 }
 
-
-// Below sample services are used mock the backend services.
-// Mock services are run separately from the Load Balancer Service.
 service<http> mock1 {
     @http:resourceConfig {
         methods:["POST", "PUT", "GET"],
         path:"/"
     }
     resource mock1Resource (http:Connection conn, http:InRequest req) {
-        http:OutResponse res = {};
-        res.setStringPayload("Mock1 Resource is invoked.");
-        _ = conn.respond(res);
+        http:OutResponse outResponse = {};
+        outResponse.setStringPayload("Mock1 Resource is invoked.");
+        _ = conn.respond(outResponse);
     }
 }
 
@@ -68,10 +55,10 @@ service<http> mock2 {
         path:"/"
     }
     resource mock2Resource (http:Connection conn, http:InRequest req) {
-        http:OutResponse res = {};
-        res.statusCode = 200;
-        res.setStringPayload("Mock2 Resource is Invoked.");
-        _ = conn.respond(res);
+        http:OutResponse outResponse = {};
+        outResponse.statusCode = 200;
+        outResponse.setStringPayload("Mock2 Resource is Invoked.");
+        _ = conn.respond(outResponse);
     }
 }
 
@@ -81,9 +68,9 @@ service<http> mock3 {
         path:"/"
     }
     resource mock3Resource (http:Connection conn, http:InRequest req) {
-        http:OutResponse res = {};
-        res.statusCode = 200;
-        res.setStringPayload("Mock3 Resource is Invoked.");
-        _ = conn.respond(res);
+        http:OutResponse outResponse = {};
+        outResponse.statusCode = 200;
+        outResponse.setStringPayload("Mock3 Resource is Invoked.");
+        _ = conn.respond(outResponse);
     }
 }

--- a/docs/ballerina-by-example/examples/http-load-balancer/http-load-balancer.server.sh
+++ b/docs/ballerina-by-example/examples/http-load-balancer/http-load-balancer.server.sh
@@ -1,5 +1,5 @@
-# To run the service, put the code in `http-load-balancer`
-# and use `$BALLERINA_HOME/bin`.
+# To run the service, put the code in `http-load-balancer.bal`
+# and execute the following command from `$BALLERINA_HOME/bin`.
 $ ballerina run http-load-balancer.bal
 # Service deployment:
 ballerina: deploying service(s) in 'http-circuit-breaker.bal'


### PR DESCRIPTION
This will make Ballerina by examples more readable by moving the connection creation inside connector creation.