### PR TITLE
Add support for completion of iterable operations

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/SymbolInfo.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/SymbolInfo.java
@@ -28,6 +28,8 @@ public class SymbolInfo {
     private String symbolName;
     private BLangSymbol symbol;
     private Scope.ScopeEntry scopeEntry;
+    private boolean isIterableOperation;
+    private IterableOperationSignature iterableOperationSignature;
 
     public SymbolInfo(String symbolName, BLangSymbol symbol) {
         this.symbolName = symbolName;
@@ -37,6 +39,9 @@ public class SymbolInfo {
     public SymbolInfo(String symbolName, Scope.ScopeEntry scopeEntry) {
         this.symbolName = symbolName;
         this.scopeEntry = scopeEntry;
+    }
+    
+    public SymbolInfo() {
     }
 
     public String getSymbolName() {
@@ -57,5 +62,42 @@ public class SymbolInfo {
 
     public Scope.ScopeEntry getScopeEntry() {
         return scopeEntry;
+    }
+
+    public boolean isIterableOperation() {
+        return isIterableOperation;
+    }
+
+    public void setIterableOperation(boolean iterableOperation) {
+        isIterableOperation = iterableOperation;
+    }
+
+    public IterableOperationSignature getIterableOperationSignature() {
+        return iterableOperationSignature;
+    }
+
+    public void setIterableOperationSignature(IterableOperationSignature iterableOperationSignature) {
+        this.iterableOperationSignature = iterableOperationSignature;
+    }
+
+    /**
+     * Holds the iterable operation signature information.
+     */
+    public static class IterableOperationSignature {
+        String label;
+        String insertText;
+
+        public IterableOperationSignature(String label, String insertText) {
+            this.label = label;
+            this.insertText = insertText;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public String getInsertText() {
+            return insertText;
+        }
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ItemResolverConstants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ItemResolverConstants.java
@@ -81,5 +81,15 @@ public class ItemResolverConstants {
     // Keyword constants
     public static final String VAR_KEYWORD = "var";
     public static final String CREATE_KEYWORD = "create";
+    
+    // Iterable operators completion item labels
+    public static final String ITR_FOREACH_LABEL = "foreach(<@lambda:function>)";
+    public static final String ITR_MAP_LABEL = "map(<@lambda:function>)";
+    public static final String ITR_FILTER_LABEL = "filter(<@lambda:function>)";
+    public static final String ITR_COUNT_LABEL = "count()";
+    public static final String ITR_MIN_LABEL = "min()";
+    public static final String ITR_MAX_LABEL = "max()";
+    public static final String ITR_AVERAGE_LABEL = "average()";
+    public static final String ITR_SUM_LABEL = "sum()";
 
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/Snippet.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/Snippet.java
@@ -51,7 +51,22 @@ public enum Snippet {
     WORKER("worker ${1:name} {\n\t${2}\n}"),
     XML_ATTRIBUTE_REFERENCE("\"${1}\"@[\"${2}\"]"),
     VAR_KEYWORD_SNIPPET("var "),
-    CREATE_KEYWORD_SNIPPET("create ");    
+    CREATE_KEYWORD_SNIPPET("create "),
+    
+    // Constants for the Iterable operators
+    ITR_FOREACH("foreach(function (%params%) {\n\t${1}\n});"),
+    ITR_MAP("map(function (%params%) (any){\n\t${1}\n});"),
+    ITR_FILTER("filter(function (%params%) (boolean){\n\t${1}\n});"),
+    ITR_COUNT("count();"),
+    ITR_MIN("min();"),
+    ITR_MAX("max();"),
+    ITR_AVERAGE("average();"),
+    ITR_SUM("sum();"),
+    
+    // Iterable operators' lambda function parameters
+    ITR_ON_MAP_PARAMS("string k, any v"),
+    ITR_ON_JSON_PARAMS("json v"),
+    ITR_ON_XML_PARAMS("xml v");
 
     private String value;
 


### PR DESCRIPTION
## Purpose
> With this, add the support for completion and suggestion of iterable operations over collections. Resolves #4789

## Goals
> Support the completion for iterable operations based on the collection type and the dynamic lambda function change based on the types

## Approach
> 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/1329674/36625202-4665065a-1941-11e8-8025-c3d262c28be9.gif)

![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/1329674/36625208-5eb155c4-1941-11e8-8c76-1bb52a8bc440.gif)