### PR TITLE
Add Open API conversion support

### DIFF
--- a/misc/swagger-ballerina/modules/ballerina-to-swagger/pom.xml
+++ b/misc/swagger-ballerina/modules/ballerina-to-swagger/pom.xml
@@ -75,6 +75,12 @@
         <artifactId>composer-ballerina-parser-service</artifactId>
         <version>${project.version}</version>
     </dependency>
+        <dependency>
+        <groupId>io.swagger.parser.v3</groupId>
+        <artifactId>swagger-parser-v2-converter</artifactId>
+        <version>2.0.0-rc3</version>
+    </dependency>
+
     <dependency>
         <groupId>org.testng</groupId>
         <artifactId>testng</artifactId>

--- a/misc/swagger-ballerina/modules/ballerina-to-swagger/pom.xml
+++ b/misc/swagger-ballerina/modules/ballerina-to-swagger/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
         <groupId>io.swagger.parser.v3</groupId>
         <artifactId>swagger-parser-v2-converter</artifactId>
-        <version>2.0.0-rc3</version>
+        <version>${swagger.parser.v2.converter.version}</version>
     </dependency>
 
     <dependency>

--- a/misc/swagger-ballerina/modules/ballerina-to-swagger/src/main/java/org/ballerinalang/ballerina/swagger/convertor/Constants.java
+++ b/misc/swagger-ballerina/modules/ballerina-to-swagger/src/main/java/org/ballerinalang/ballerina/swagger/convertor/Constants.java
@@ -21,4 +21,8 @@ package org.ballerinalang.ballerina.swagger.convertor;
 public class Constants {
     public static final String SERVICE_NAME = "ballerina-to-swagger";
     public static final String SERVICE_PATH = "ballerina/swagger";
+    public static final String SWAGGER_PACKAGE_NAME = "ballerina.net.http.swagger";
+    public static final String BALLERINA_HTTP_PACKAGE_NAME = "ballerina.net.http";
+    public static final String CURRENT_PACKAGE_NAME = "Current Package";
+
 }

--- a/misc/swagger-ballerina/modules/ballerina-to-swagger/src/main/java/org/ballerinalang/ballerina/swagger/convertor/service/SwaggerConverterUtils.java
+++ b/misc/swagger-ballerina/modules/ballerina-to-swagger/src/main/java/org/ballerinalang/ballerina/swagger/convertor/service/SwaggerConverterUtils.java
@@ -17,6 +17,9 @@
 package org.ballerinalang.ballerina.swagger.convertor.service;
 
 import io.swagger.models.Swagger;
+import io.swagger.v3.core.util.Yaml;
+import io.swagger.v3.parser.converter.SwaggerConverter;
+
 import org.apache.commons.lang3.StringUtils;
 import org.ballerinalang.compiler.CompilerPhase;
 import org.ballerinalang.composer.service.ballerina.parser.service.model.BFile;
@@ -119,7 +122,51 @@ public class SwaggerConverterUtils {
     
         return swaggerSource;
     }
-    
+
+
+    /**
+     * This method will generate open API 3.X specification for given ballerina service. Since we will need to
+     * support both swagger 2.0 and OAS 3.0 it was implemented to convert to swagger by default and convert it
+     * to OAS on demand.
+     *
+     * @param ballerinaSource ballerina source to be converted to swagger/OAS definition
+     * @param serviceName specific service name within ballerina source that need to map OAS
+     * @return Generated OAS3 string output.
+     * @throws IOException When error occurs while converting, parsing input source.
+     */
+    public static String generateOAS3Definitions(String ballerinaSource, String serviceName) throws IOException {
+        // Get the ballerina model using the ballerina source code.
+        BFile balFile = new BFile();
+        balFile.setContent(ballerinaSource);
+        //Create empty swagger object.
+        Swagger swaggerDefinition = new Swagger();
+        BLangCompilationUnit topCompilationUnit = SwaggerConverterUtils.getTopLevelNodeFromBallerinaFile(balFile);
+        String httpAlias = getAlias(topCompilationUnit, "ballerina.net.http");
+        String swaggerAlias = getAlias(topCompilationUnit, "ballerina.net.http.swagger");
+        SwaggerServiceMapper swaggerServiceMapper = new SwaggerServiceMapper(httpAlias, swaggerAlias);
+        String swaggerSource = StringUtils.EMPTY;
+        for (TopLevelNode topLevelNode : topCompilationUnit.getTopLevelNodes()) {
+            if (topLevelNode instanceof BLangService) {
+                ServiceNode serviceDefinition = (ServiceNode) topLevelNode;
+                // Generate swagger string for the mentioned service name.
+                if (StringUtils.isNotBlank(serviceName)) {
+                    if (serviceDefinition.getName().getValue().equals(serviceName)) {
+                        swaggerDefinition = swaggerServiceMapper.convertServiceToSwagger(serviceDefinition);
+                        break;
+                    }
+                } else {
+                    // If no service name mentioned, then generate swagger definition for the first service.
+                    swaggerDefinition = swaggerServiceMapper.convertServiceToSwagger(serviceDefinition);
+                    break;
+                }
+            }
+        }
+        swaggerSource = swaggerServiceMapper.generateSwaggerString(swaggerDefinition);
+        SwaggerConverter converter = new SwaggerConverter();
+        return Yaml.pretty(converter.readContents(swaggerSource, null, null).getOpenAPI());
+    }
+
+
     /**
      * Gets the alias for a given package from a bLang file root node.
      * @param topCompilationUnit The root node.

--- a/misc/swagger-ballerina/modules/ballerina-to-swagger/src/main/java/org/ballerinalang/ballerina/swagger/convertor/service/SwaggerConverterUtils.java
+++ b/misc/swagger-ballerina/modules/ballerina-to-swagger/src/main/java/org/ballerinalang/ballerina/swagger/convertor/service/SwaggerConverterUtils.java
@@ -21,6 +21,7 @@ import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.parser.converter.SwaggerConverter;
 
 import org.apache.commons.lang3.StringUtils;
+import org.ballerinalang.ballerina.swagger.convertor.Constants;
 import org.ballerinalang.compiler.CompilerPhase;
 import org.ballerinalang.composer.service.ballerina.parser.service.model.BFile;
 import org.ballerinalang.composer.service.ballerina.parser.service.model.BallerinaFile;
@@ -74,7 +75,7 @@ public class SwaggerConverterUtils {
         }
     
         final Map<String, ModelPackage> modelPackage = new HashMap<>();
-        ParserUtils.loadPackageMap("Current Package", model, modelPackage);
+        ParserUtils.loadPackageMap(Constants.CURRENT_PACKAGE_NAME, model, modelPackage);
     
         Optional<BLangCompilationUnit> compilationUnit = model.getCompilationUnits().stream()
                 .filter(compUnit -> fileName.equals(compUnit.getName()))
@@ -97,8 +98,8 @@ public class SwaggerConverterUtils {
         BFile balFile = new BFile();
         balFile.setContent(ballerinaSource);
         BLangCompilationUnit topCompilationUnit = SwaggerConverterUtils.getTopLevelNodeFromBallerinaFile(balFile);
-        String httpAlias = getAlias(topCompilationUnit, "ballerina.net.http");
-        String swaggerAlias = getAlias(topCompilationUnit, "ballerina.net.http.swagger");
+        String httpAlias = getAlias(topCompilationUnit, Constants.BALLERINA_HTTP_PACKAGE_NAME);
+        String swaggerAlias = getAlias(topCompilationUnit, Constants.SWAGGER_PACKAGE_NAME);
         SwaggerServiceMapper swaggerServiceMapper = new SwaggerServiceMapper(httpAlias, swaggerAlias);
         String swaggerSource = StringUtils.EMPTY;
         for (TopLevelNode topLevelNode : topCompilationUnit.getTopLevelNodes()) {
@@ -141,8 +142,8 @@ public class SwaggerConverterUtils {
         //Create empty swagger object.
         Swagger swaggerDefinition = new Swagger();
         BLangCompilationUnit topCompilationUnit = SwaggerConverterUtils.getTopLevelNodeFromBallerinaFile(balFile);
-        String httpAlias = getAlias(topCompilationUnit, "ballerina.net.http");
-        String swaggerAlias = getAlias(topCompilationUnit, "ballerina.net.http.swagger");
+        String httpAlias = getAlias(topCompilationUnit, Constants.BALLERINA_HTTP_PACKAGE_NAME);
+        String swaggerAlias = getAlias(topCompilationUnit, Constants.SWAGGER_PACKAGE_NAME);
         SwaggerServiceMapper swaggerServiceMapper = new SwaggerServiceMapper(httpAlias, swaggerAlias);
         String swaggerSource = StringUtils.EMPTY;
         for (TopLevelNode topLevelNode : topCompilationUnit.getTopLevelNodes()) {

--- a/misc/swagger-ballerina/modules/ballerina-to-swagger/src/test/java/org/ballerinalang/ballerina/swagger/convertor/service/SwaggerConverterUtilsTest.java
+++ b/misc/swagger-ballerina/modules/ballerina-to-swagger/src/test/java/org/ballerinalang/ballerina/swagger/convertor/service/SwaggerConverterUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,37 +22,130 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 
 /**
- * Swagger related utility classes.
+ * Ballerina conversion to swagger and open API will test in this class.
  */
 
 public class SwaggerConverterUtilsTest {
-    @Test(description = "Get application count test")
-    public void testGetApplicationCount() {
-        String ballerinaSource = "package passthroughservice.samples;\n" +
-                "\n" +
-                "import ballerina.net.http;\n" +
-                "\n" +
-                "@http:configuration {basePath:\"/nyseStock\"}\n" +
-                "service<http> nyseStockQuote {\n" +
-                "\n" +
-                "    @http:resourceConfig {\n" +
-                "        methods:[\"GET\"]\n" +
-                "    }\n" +
-                "    resource stocks (http:Connection conn, http:InRequest inReq) {\n" +
-                "        http:OutResponse res = {};\n" +
-                "        json payload = {\"exchange\":\"nyse\", \"name\":\"IBM\", \"value\":\"127.50\"};\n" +
-                "        res.setJsonPayload(payload);\n" +
-                "        _ = conn.respond(res);\n" +
-                "    }\n" +
-                "}\n";
+    //Sample Ballerina Service definitions to be used for tests.
+    private static String sampleBallerinaServiceString = "package passthroughservice.samples;\n" +
+            "\n" +
+            "import ballerina.net.http;\n" +
+            "\n" +
+            "@http:configuration {basePath:\"/nyseStock\"}\n" +
+            "service<http> nyseStockQuote {\n" +
+            "\n" +
+            "    @http:resourceConfig {\n" +
+            "        methods:[\"GET\"]\n" +
+            "    }\n" +
+            "    resource stocks (http:Connection conn, http:InRequest inReq) {\n" +
+            "        http:OutResponse res = {};\n" +
+            "        json payload = {\"exchange\":\"nyse\", \"name\":\"IBM\", \"value\":\"127.50\"};\n" +
+            "        res.setJsonPayload(payload);\n" +
+            "        _ = conn.respond(res);\n" +
+            "    }\n" +
+            "}\n";
+
+    private static String complexServiceSample = "import ballerina.net.http;\n" +
+            "import ballerina.net.http.resiliency;\n" +
+            "import ballerina.runtime;service<http> failoverService {\n" +
+            "    int[] failoverHttpStatusCodes = [400, 404, 500];\n" +
+            "    resiliency:FailoverConfig errorCode = {failoverCodes:failoverHttpStatusCodes};\n" +
+            "    @http:resourceConfig {\n" +
+            "        path:\"/\"\n" +
+            "    }    resource failoverPostResource (http:Connection conn, http:InRequest req) {\n" +
+            "        endpoint<http:HttpClient> endPoint {\n" +
+            "            create resiliency:Failover(\n" +
+            "                    [create http:HttpClient(\"http://localhost:23456/mock\", {}),\n" +
+            "                     create http:HttpClient(\"http://localhost:9090/echo\",\n" +
+            "                                    {endpointTimeout:5000}),\n" +
+            "                     create http:HttpClient(\"http://localhost:9090/mock\", {})],\n" +
+            "                     errorCode);\n" +
+            "        }        http:InResponse inResponse = {};\n" +
+            "        http:HttpConnectorError err;        http:OutRequest outRequest = {};\n" +
+            "        json requestPayload = {\"name\":\"Ballerina\"};\n" +
+            "        outRequest.setJsonPayload(requestPayload);\n" +
+            "        inResponse, err = endPoint.post(\"/\", outRequest);        " +
+            "http:OutResponse outResponse = {};\n" +
+            "        if (err != null) {\n" +
+            "            outResponse.statusCode = err.statusCode;\n" +
+            "            outResponse.setStringPayload(err.message);\n" +
+            "            _ = conn.respond(outResponse);\n" +
+            "        } else {\n" +
+            "            _ = conn.forward(inResponse);\n" +
+            "        }\n" +
+            "    }}\n" +
+            "service<http> echo {\n" +
+            "    @http:resourceConfig {\n" +
+            "        methods:[\"POST\", \"PUT\", \"GET\"],\n" +
+            "        path:\"/\"\n" +
+            "    }\n" +
+            "    resource echoResource (http:Connection conn, http:InRequest req) {\n" +
+            "        http:OutResponse outResponse = {};\n" +
+            "        runtime:sleepCurrentWorker(30000);\n" +
+            "        outResponse.setStringPayload(\"Resource is invoked\");\n" +
+            "        _ = conn.respond(outResponse);\n" +
+            "    }\n" +
+            "}service<http> mock {\n" +
+            "    @http:resourceConfig {\n" +
+            "        methods:[\"POST\", \"PUT\", \"GET\"],\n" +
+            "        path:\"/\"\n" +
+            "    }\n" +
+            "    resource mockResource (http:Connection conn, http:InRequest req) {\n" +
+            "        http:OutResponse outResponse = {};\n" +
+            "        outResponse.setStringPayload(\"Mock Resource is Invoked.\");\n" +
+            "        _ = conn.respond(outResponse);\n" +
+            "    }\n" +
+            "}";
+
+    @Test(description = "Test ballerina to swagger conversion")
+    public void testBallerinaToSwaggerConversion() {
         String serviceName = "nyseStockQuote";
         try {
-            String swaggerDefinition = SwaggerConverterUtils.generateSwaggerDefinitions(ballerinaSource, serviceName);
+            String swaggerDefinition = SwaggerConverterUtils.generateSwaggerDefinitions(sampleBallerinaServiceString,
+                    serviceName);
             Assert.assertNotNull(swaggerDefinition);
         } catch (IOException e) {
+            Assert.fail("Error while converting ballerina service to swagger definition");
         }
+    }
 
 
+    @Test(description = "Test OAS definition generation from ballerina service")
+    public void testOASGeneration() {
+        String serviceName = "nyseStockQuote";
+        try {
+            String swaggerDefinition = SwaggerConverterUtils.generateOAS3Definitions(sampleBallerinaServiceString,
+                    serviceName);
+            Assert.assertNotNull(swaggerDefinition);
+        } catch (IOException e) {
+            Assert.fail("Error while converting ballerina service to swagger definition");
+        }
+    }
+
+
+    @Test(description = "Test OAS definition generation from ballerina service with empty service name")
+    public void testOASGenerationWithEmptyServiceName() {
+        String serviceName = "";
+        try {
+            String swaggerDefinition = SwaggerConverterUtils.generateOAS3Definitions(sampleBallerinaServiceString,
+                    serviceName);
+            Assert.assertNotNull(swaggerDefinition);
+        } catch (IOException e) {
+            Assert.fail("Error while converting ballerina service to swagger definition with empty service name");
+        }
+    }
+
+
+    @Test(description = "Test OAS definition generation from ballerina service with complex service")
+    public void testOASGenerationWithEmptyServiceNameM() {
+        String serviceName = "mock";
+        try {
+            String swaggerDefinition = SwaggerConverterUtils.generateOAS3Definitions(complexServiceSample,
+                    serviceName);
+            Assert.assertNotNull(swaggerDefinition);
+        } catch (IOException e) {
+            Assert.fail("Error while converting ballerina service to swagger definition with empty service name");
+        }
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1225,6 +1225,7 @@
         <com.fasterxml.jackson.datatype.version>2.4.1</com.fasterxml.jackson.datatype.version>
         <swagger.parser.version>1.0.34</swagger.parser.version>
         <swagger.models.version>1.5.16</swagger.models.version>
+        <swagger.parser.v2.converter.version>2.0.0-rc3</swagger.parser.v2.converter.version>
         <com.fasterxml.jackson.core.annotations.version>2.8.0</com.fasterxml.jackson.core.annotations.version>
         <rs-api.version>2.0</rs-api.version>
         <msf4j.version>2.4.2</msf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1223,7 +1223,7 @@
         <commons-cli.version>1.3.1</commons-cli.version>
         <io.swagger.version>1.5.8</io.swagger.version>
         <com.fasterxml.jackson.datatype.version>2.4.1</com.fasterxml.jackson.datatype.version>
-        <swagger.parser.version>1.0.25</swagger.parser.version>
+        <swagger.parser.version>1.0.34</swagger.parser.version>
         <swagger.models.version>1.5.16</swagger.models.version>
         <com.fasterxml.jackson.core.annotations.version>2.8.0</com.fasterxml.jackson.core.annotations.version>
         <rs-api.version>2.0</rs-api.version>


### PR DESCRIPTION
## Purpose
In addition to default swagger support we will be providing OAS 3.0.0 based editor support from next release onward. So at anytime when we move ahead with open API based swagger editor, we should be able to represent ballerina with OAS 3.0.0. This PR is having that conversion logic and test cases.

## Goals
Represent ballerina with OAS 3.0.0

## Approach
https://docs.google.com/document/d/1fNeSq_Oha_AnHx9I2c8xtWiBvl93JJAs_awAo91kS-k/edit#heading=h.hu3u6zwzi49p

## Test environment
java version "1.8.0_144"
 