### PR TITLE
Add HTTP status code support for Circuit Breaker

### DIFF
--- a/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/resiliency/circuit-breaker.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/resiliency/circuit-breaker.bal
@@ -1,5 +1,22 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package ballerina.net.http.resiliency;
 
+import ballerina.log;
 import ballerina.net.http;
 import ballerina.time;
 
@@ -13,20 +30,42 @@ struct CircuitHealth {
     time:Time lastErrorTime;
 }
 
-@Description {value:"A Circuit Breaker implementation for to be used with the HTTP client connector to gracefully handle network errors"}
-@Param {value:"httpClient: The HTTP client connector to be wrapped with the circuit breaker"}
-@Param {value:"failureThreshold: The threshold for request failures. When this threshold is crossed, the circuit will trip. The threshold should be a value between 0 and 1."}
-@Param {value:"resetTimeout: The time period to wait before attempting to make another request to the upstream service"}
-// TODO: need to find a way to validate the arguments passed here
-public connector CircuitBreaker (http:HttpClient httpClient, float failureThreshold, int resetTimeout) {
+@Description {value:"Represents Circuit Breaker connector configuration."}
+@Field {value:"failureThreshold: The threshold for request failures. When this threshold is crossed, the circuit will trip. The threshold should be a value between 0 and 1."}
+@Field {value:"resetTimeout: The time period to wait before attempting to make another request to the upstream service."}
+@Field {value:"httpStatusCodes: Array of http response status codes which considered as failure responses."}
+public struct CircuitBreakerConfig {
+    float failureThreshold;
+    int resetTimeout;
+    int [] httpStatusCodes;
+}
+
+struct CircuitBreakerInferredConfig {
+    float failureThreshold;
+    int resetTimeout;
+    boolean [] httpStatusCodes;
+}
+
+CircuitHealth circuitHealth = {};
+CircuitState currentCircuitState;
+
+@Description {value:"A Circuit Breaker implementation for to be used with the HTTP client connector to gracefully handle network errors."}
+@Param {value:"circuitBreakerConfig: Circuit Breaker configuration struct which contains the circuit handling options."}
+public connector CircuitBreaker (http:HttpClient httpClient, CircuitBreakerConfig circuitBreakerConfig) {
 
     endpoint<http:HttpClient> httpEP {
         httpClient;
     }
 
-    CircuitHealth circuitHealth = {};
-    // TODO: once enum init inside a struct is do-able, move this inside circuitHealth (issue #4340)
-    CircuitState currentState = CircuitState.CLOSED;
+    boolean [] httpStatusCodes = populateErrorCodeIndex(circuitBreakerConfig.httpStatusCodes);
+
+    CircuitBreakerInferredConfig circuitBreakerInferredConfig = {   failureThreshold:circuitBreakerConfig.failureThreshold,
+                                                                    resetTimeout:circuitBreakerConfig.resetTimeout,
+                                                                    httpStatusCodes:httpStatusCodes
+                                                                };
+
+    //TODO: do the arguments validation inside connector init
+    boolean isValidThreshold = validateCircuitBreakerConfiguration(circuitBreakerConfig);
 
     @Description {value:"The POST action implementation of the Circuit Breaker. Protects the invocation of the POST action of the underlying HTTP client connector."}
     @Param {value:"path: Resource path"}
@@ -34,19 +73,18 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failureThresh
     @Return {value:"The InResponse struct"}
     @Return {value:"Error occurred during the action invocation, if any"}
     action post (string path, http:OutRequest request) (http:InResponse, http:HttpConnectorError) {
-        currentState = updateCircuitState(circuitHealth, currentState, failureThreshold, resetTimeout);
+        currentCircuitState = updateCircuitState(circuitHealth, currentCircuitState, circuitBreakerInferredConfig);
         http:InResponse response;
-        http:HttpConnectorError err;
+        http:HttpConnectorError httpConnectorError;
 
-        if (currentState == CircuitState.OPEN) {
+        if (currentCircuitState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            err = handleOpenCircuit(circuitHealth, resetTimeout);
+            httpConnectorError = handleOpenCircuit(circuitHealth, circuitBreakerInferredConfig);
         } else {
-            response, err = httpEP.post(path, request);
-            updateCircuitHealth(circuitHealth, err);
+            response, httpConnectorError = httpEP.post(path, request);
+            updateCircuitHealth(circuitHealth, response, httpConnectorError, circuitBreakerInferredConfig);
         }
-
-        return response, err;
+        return response, httpConnectorError;
     }
 
     @Description {value:"The HEAD action implementation of the Circuit Breaker. Protects the invocation of the HEAD action of the underlying HTTP client connector."}
@@ -55,19 +93,19 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failureThresh
     @Return {value:"The InResponse struct"}
     @Return {value:"Error occurred during the action invocation, if any"}
     action head (string path, http:OutRequest request) (http:InResponse, http:HttpConnectorError) {
-        currentState = updateCircuitState(circuitHealth, currentState, failureThreshold, resetTimeout);
+        currentCircuitState = updateCircuitState(circuitHealth, currentCircuitState, circuitBreakerInferredConfig);
         http:InResponse response;
-        http:HttpConnectorError err;
+        http:HttpConnectorError httpConnectorError;
 
-        if (currentState == CircuitState.OPEN) {
+        if (currentCircuitState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            err = handleOpenCircuit(circuitHealth, resetTimeout);
+            httpConnectorError = handleOpenCircuit(circuitHealth, circuitBreakerInferredConfig);
         } else {
-            response, err = httpEP.head(path, request);
-            updateCircuitHealth(circuitHealth, err);
+            response, httpConnectorError = httpEP.head(path, request);
+            updateCircuitHealth(circuitHealth, response, httpConnectorError, circuitBreakerInferredConfig);
         }
 
-        return response, err;
+        return response, httpConnectorError;
     }
 
     @Description {value:"The PUT action implementation of the Circuit Breaker. Protects the invocation of the PUT action of the underlying HTTP client connector."}
@@ -76,19 +114,19 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failureThresh
     @Return {value:"The InResponse struct"}
     @Return {value:"Error occurred during the action invocation, if any"}
     action put (string path, http:OutRequest request) (http:InResponse, http:HttpConnectorError) {
-        currentState = updateCircuitState(circuitHealth, currentState, failureThreshold, resetTimeout);
+        currentCircuitState = updateCircuitState(circuitHealth, currentCircuitState, circuitBreakerInferredConfig);
         http:InResponse response;
-        http:HttpConnectorError err;
+        http:HttpConnectorError httpConnectorError;
 
-        if (currentState == CircuitState.OPEN) {
+        if (currentCircuitState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            err = handleOpenCircuit(circuitHealth, resetTimeout);
+            httpConnectorError = handleOpenCircuit(circuitHealth, circuitBreakerInferredConfig);
         } else {
-            response, err = httpEP.put(path, request);
-            updateCircuitHealth(circuitHealth, err);
+            response, httpConnectorError = httpEP.put(path, request);
+            updateCircuitHealth(circuitHealth, response, httpConnectorError, circuitBreakerInferredConfig);
         }
 
-        return response, err;
+        return response, httpConnectorError;
     }
 
     @Description {value:"Protects the invocation of the Execute action of the underlying HTTP client connector. The Execute action can be used to invoke an HTTP call with the given HTTP verb."}
@@ -98,19 +136,19 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failureThresh
     @Return {value:"The InResponse struct"}
     @Return {value:"Error occurred during the action invocation, if any"}
     action execute (string httpVerb, string path, http:OutRequest request) (http:InResponse, http:HttpConnectorError) {
-        currentState = updateCircuitState(circuitHealth, currentState, failureThreshold, resetTimeout);
+        currentCircuitState = updateCircuitState(circuitHealth, currentCircuitState, circuitBreakerInferredConfig);
         http:InResponse response;
-        http:HttpConnectorError err;
+        http:HttpConnectorError httpConnectorError;
 
-        if (currentState == CircuitState.OPEN) {
+        if (currentCircuitState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            err = handleOpenCircuit(circuitHealth, resetTimeout);
+            httpConnectorError = handleOpenCircuit(circuitHealth, circuitBreakerInferredConfig);
         } else {
-            response, err = httpEP.execute(httpVerb, path, request);
-            updateCircuitHealth(circuitHealth, err);
+            response, httpConnectorError = httpEP.execute(httpVerb, path, request);
+            updateCircuitHealth(circuitHealth, response, httpConnectorError, circuitBreakerInferredConfig);
         }
 
-        return response, err;
+        return response, httpConnectorError;
     }
 
     @Description {value:"The PATCH action implementation of the Circuit Breaker. Protects the invocation of the PATCH action of the underlying HTTP client connector."}
@@ -119,19 +157,19 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failureThresh
     @Return {value:"The InResponse struct"}
     @Return {value:"Error occurred during the action invocation, if any"}
     action patch (string path, http:OutRequest request) (http:InResponse, http:HttpConnectorError) {
-        currentState = updateCircuitState(circuitHealth, currentState, failureThreshold, resetTimeout);
+        currentCircuitState = updateCircuitState(circuitHealth, currentCircuitState, circuitBreakerInferredConfig);
         http:InResponse response;
-        http:HttpConnectorError err;
+        http:HttpConnectorError httpConnectorError;
 
-        if (currentState == CircuitState.OPEN) {
+        if (currentCircuitState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            err = handleOpenCircuit(circuitHealth, resetTimeout);
+            httpConnectorError = handleOpenCircuit(circuitHealth, circuitBreakerInferredConfig);
         } else {
-            response, err = httpEP.patch(path, request);
-            updateCircuitHealth(circuitHealth, err);
+            response, httpConnectorError = httpEP.patch(path, request);
+            updateCircuitHealth(circuitHealth, response, httpConnectorError, circuitBreakerInferredConfig);
         }
 
-        return response, err;
+        return response, httpConnectorError;
     }
 
     @Description {value:"The DELETE action implementation of the Circuit Breaker. Protects the invocation of the DELETE action of the underlying HTTP client connector."}
@@ -140,19 +178,19 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failureThresh
     @Return {value:"The InResponse struct"}
     @Return {value:"Error occurred during the action invocation, if any"}
     action delete (string path, http:OutRequest request) (http:InResponse, http:HttpConnectorError) {
-        currentState = updateCircuitState(circuitHealth, currentState, failureThreshold, resetTimeout);
+        currentCircuitState = updateCircuitState(circuitHealth, currentCircuitState, circuitBreakerInferredConfig);
         http:InResponse response;
-        http:HttpConnectorError err;
+        http:HttpConnectorError httpConnectorError;
 
-        if (currentState == CircuitState.OPEN) {
+        if (currentCircuitState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            err = handleOpenCircuit(circuitHealth, resetTimeout);
+            httpConnectorError = handleOpenCircuit(circuitHealth, circuitBreakerInferredConfig);
         } else {
-            response, err = httpEP.delete(path, request);
-            updateCircuitHealth(circuitHealth, err);
+            response, httpConnectorError = httpEP.delete(path, request);
+            updateCircuitHealth(circuitHealth, response, httpConnectorError, circuitBreakerInferredConfig);
         }
 
-        return response, err;
+        return response, httpConnectorError;
     }
 
     @Description {value:"The OPTIONS action implementation of the Circuit Breaker. Protects the invocation of the OPTIONS action of the underlying HTTP client connector."}
@@ -161,19 +199,19 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failureThresh
     @Return {value:"The InResponse struct"}
     @Return {value:"Error occurred during the action invocation, if any"}
     action options (string path, http:OutRequest request) (http:InResponse, http:HttpConnectorError) {
-        currentState = updateCircuitState(circuitHealth, currentState, failureThreshold, resetTimeout);
+        currentCircuitState = updateCircuitState(circuitHealth, currentCircuitState, circuitBreakerInferredConfig);
         http:InResponse response;
-        http:HttpConnectorError err;
+        http:HttpConnectorError httpConnectorError;
 
-        if (currentState == CircuitState.OPEN) {
+        if (currentCircuitState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            err = handleOpenCircuit(circuitHealth, resetTimeout);
+            httpConnectorError = handleOpenCircuit(circuitHealth, circuitBreakerInferredConfig);
         } else {
-            response, err = httpEP.options(path, request);
-            updateCircuitHealth(circuitHealth, err);
+            response, httpConnectorError = httpEP.options(path, request);
+            updateCircuitHealth(circuitHealth, response, httpConnectorError, circuitBreakerInferredConfig);
         }
 
-        return response, err;
+        return response, httpConnectorError;
     }
 
     @Description {value:"Protects the invocation of the Forward action of the underlying HTTP client connector. The Forward action can be used to forward an incoming request to an upstream service as it is."}
@@ -182,19 +220,19 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failureThresh
     @Return {value:"The InResponse struct"}
     @Return {value:"Error occurred during the action invocation, if any"}
     action forward (string path, http:InRequest request) (http:InResponse, http:HttpConnectorError) {
-        currentState = updateCircuitState(circuitHealth, currentState, failureThreshold, resetTimeout);
+        currentCircuitState = updateCircuitState(circuitHealth, currentCircuitState, circuitBreakerInferredConfig);
         http:InResponse response;
-        http:HttpConnectorError err;
+        http:HttpConnectorError httpConnectorError;
 
-        if (currentState == CircuitState.OPEN) {
+        if (currentCircuitState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            err = handleOpenCircuit(circuitHealth, resetTimeout);
+            httpConnectorError = handleOpenCircuit(circuitHealth, circuitBreakerInferredConfig);
         } else {
-            response, err = httpEP.forward(path, request);
-            updateCircuitHealth(circuitHealth, err);
+            response, httpConnectorError = httpEP.forward(path, request);
+            updateCircuitHealth(circuitHealth, response, httpConnectorError, circuitBreakerInferredConfig);
         }
 
-        return response, err;
+        return response, httpConnectorError;
     }
 
     @Description {value:"The GET action implementation of the Circuit Breaker. Protects the invocation of the GET action of the underlying HTTP client connector."}
@@ -203,72 +241,97 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failureThresh
     @Return {value:"The InResponse struct"}
     @Return {value:"Error occurred during the action invocation, if any"}
     action get (string path, http:OutRequest request) (http:InResponse, http:HttpConnectorError) {
-        currentState = updateCircuitState(circuitHealth, currentState, failureThreshold, resetTimeout);
+        currentCircuitState = updateCircuitState(circuitHealth, currentCircuitState, circuitBreakerInferredConfig);
         http:InResponse response;
-        http:HttpConnectorError err;
+        http:HttpConnectorError httpConnectorError;
 
-        if (currentState == CircuitState.OPEN) {
+        if (currentCircuitState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            err = handleOpenCircuit(circuitHealth, resetTimeout);
+            httpConnectorError = handleOpenCircuit(circuitHealth, circuitBreakerInferredConfig);
         } else {
-            response, err = httpEP.get(path, request);
-            updateCircuitHealth(circuitHealth, err);
+            response, httpConnectorError = httpEP.get(path, request);
+            updateCircuitHealth(circuitHealth, response, httpConnectorError, circuitBreakerInferredConfig);
         }
 
-        return response, err;
+        return response, httpConnectorError;
     }
 }
 
-function updateCircuitState (CircuitHealth circuitHealth, CircuitState currentState, float failureThreshold,
-                             int resetTimeout) (CircuitState) {
-    if (currentState == CircuitState.OPEN) {
-        time:Time currentT = time:currentTime();
-        int elapsedTime = currentT.time - circuitHealth.lastErrorTime.time;
+function updateCircuitState (CircuitHealth circuitHealth, CircuitState currentState, CircuitBreakerInferredConfig circuitBreakerInferredConfig) (CircuitState) {
 
-        if (elapsedTime > resetTimeout) {
-            circuitHealth.errorCount = 0;
-            circuitHealth.requestCount = 0;
-            currentState = CircuitState.HALF_OPEN;
-        }
-    } else if (currentState == CircuitState.HALF_OPEN) {
-        if (circuitHealth.errorCount > 0) {
-            // If the trial run has failed, trip the circuit again
-            currentState = CircuitState.OPEN;
+    lock {
+        if (currentState == CircuitState.OPEN) {
+            time:Time currentT = time:currentTime();
+            int elapsedTime = currentT.time - circuitHealth.lastErrorTime.time;
+
+            if (elapsedTime > circuitBreakerInferredConfig.resetTimeout) {
+                circuitHealth.errorCount = 0;
+                circuitHealth.requestCount = 0;
+                currentState = CircuitState.HALF_OPEN;
+                log:printInfo("CircuitBreaker reset timeout reached. Circuit switched from OPEN to HALF_OPEN state.");
+            }
+
+        } else if (currentState == CircuitState.HALF_OPEN) {
+            if (circuitHealth.errorCount > 0) {
+                // If the trial run has failed, trip the circuit again
+                currentState = CircuitState.OPEN;
+                log:printInfo("CircuitBreaker trial run has failed. Circuit switched from HALF_OPEN to OPEN state.");
+            } else {
+                // If the trial run was successful reset the circuit
+                currentState = CircuitState.CLOSED;
+                log:printInfo("CircuitBreaker trial run  was successful. Circuit switched from HALF_OPEN to CLOSE state.");
+            }
         } else {
-            // If the trial run was successful reset the circuit
-            currentState = CircuitState.CLOSED;
-        }
-    } else {
-        float currentFailureRate = 0;
+            float currentFailureRate = 0;
 
-        if (circuitHealth.requestCount > 0) {
-            currentFailureRate = ((float) circuitHealth.errorCount / circuitHealth.requestCount);
-        }
+            if (circuitHealth.requestCount > 0) {
+                currentFailureRate = ((float)circuitHealth.errorCount / circuitHealth.requestCount);
+            }
 
-        if (currentFailureRate > failureThreshold) {
-            currentState = CircuitState.OPEN;
+            if (currentFailureRate > circuitBreakerInferredConfig.failureThreshold) {
+                currentState = CircuitState.OPEN;
+                log:printInfo("CircuitBreaker failure threshold exceeded. Circuit trips from CLOSE to OPEN state.");
+            }
         }
     }
-
     return currentState;
 }
 
-function updateCircuitHealth(CircuitHealth circuitHealth, http:HttpConnectorError err) {
-    circuitHealth.requestCount = circuitHealth.requestCount + 1;
-
-    if (err != null) {
-        circuitHealth.errorCount = circuitHealth.errorCount + 1;
-        circuitHealth.lastErrorTime = time:currentTime();
+function updateCircuitHealth(CircuitHealth circuitHealth, http:InResponse inResponse,
+               http:HttpConnectorError httpConnectorError, CircuitBreakerInferredConfig circuitBreakerInferredConfig) {
+    lock {
+        circuitHealth.requestCount = circuitHealth.requestCount + 1;
+        if ((inResponse != null && circuitBreakerInferredConfig.httpStatusCodes[inResponse.statusCode] == true) || httpConnectorError != null) {
+            circuitHealth.errorCount = circuitHealth.errorCount + 1;
+            circuitHealth.lastErrorTime = time:currentTime();
+        }
     }
 }
 
-function handleOpenCircuit (CircuitHealth circuitHealth, int resetTimeout) (http:HttpConnectorError) {
+// Handles open circuit state.
+function handleOpenCircuit (CircuitHealth circuitHealth, CircuitBreakerInferredConfig circuitBreakerInferredConfig) (http:HttpConnectorError) {
     time:Time currentT = time:currentTime();
     int timeDif = currentT.time - circuitHealth.lastErrorTime.time;
-    int timeRemaining = resetTimeout - timeDif;
-
-    http:HttpConnectorError err = {};
-    err.message = "Upstream service unavailable. Requests to upstream service will be suspended for "
+    int timeRemaining = circuitBreakerInferredConfig.resetTimeout - timeDif;
+    http:HttpConnectorError httpConnectorError = {};
+    httpConnectorError.message = "Upstream service unavailable. Requests to upstream service will be suspended for "
               + timeRemaining + " milliseconds.";
-    return err;
+    return httpConnectorError;
+}
+
+// Validates the struct configurations passed to create circuit breaker.
+function validateCircuitBreakerConfiguration (CircuitBreakerConfig circuitBreakerConfig) (boolean isValidThreshold){
+    float failureThreshold = circuitBreakerConfig.failureThreshold;
+     if (failureThreshold < 0 || failureThreshold > 1) {
+         string errorMessage = "Invalid failure threshold. Failure threshold value"
+                                                +  " should between 0 to 1, found "+ failureThreshold;
+         error circuitBreakerConfigError = {message:errorMessage};
+         throw circuitBreakerConfigError;
+     }
+    return true;
+}
+
+// CircuitHealth struct initializer. Sets the initial circuit state.
+function <CircuitHealth circuitHealth> CircuitHealth() {
+    currentCircuitState = CircuitState.CLOSED;
 }

--- a/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/resiliency/commons.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/resiliency/commons.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package ballerina.net.http.resiliency;
 
 import ballerina.net.http;
@@ -71,4 +87,14 @@ function extractHttpOperation (string httpVerb) (HttpOperation connectorAction) 
         inferredConnectorAction = HttpOperation.HEAD;
     }
     return inferredConnectorAction;
+}
+
+// Populate boolean index array by looking at the configured Http status codes to get better performance
+// at runtime.
+function populateErrorCodeIndex (int[] errorCode) (boolean[] result) {
+    result = [];
+    foreach i in errorCode {
+        result[i] = true;
+    }
+    return result;
 }

--- a/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/resiliency/failover-connector.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/resiliency/failover-connector.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package ballerina.net.http.resiliency;
 
 import ballerina.net.http;
@@ -125,16 +141,6 @@ public connector Failover (http:HttpClient[] failoverClientsArray, FailoverConfi
     action get (string path, http:OutRequest request) (http:InResponse, http:HttpConnectorError) {
         return performFailoverAction(path, request, null, HttpOperation.GET, failoverInferredConfig);
     }
-}
-
-// Populate boolean index array by looking at the Http status codes configured to be retry to get better performance
-// at runtime.
-function populateErrorCodeIndex (int[] errorCode) (boolean[] result) {
-    result = [];
-    foreach i in errorCode {
-        result[i] = true;
-    }
-    return result;
 }
 
 // Performs execute action of the Failover connector. extract the corresponding http integer value representation

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/net/http/resiliency/CircuitBreakerTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/net/http/resiliency/CircuitBreakerTest.java
@@ -47,7 +47,7 @@ public class CircuitBreakerTest {
      */
     @Test
     public void testCircuitBreaker() {
-        int[] expectedStatusCodes = new int[]{200, 200, 502, -1, -1, 200, 200, 200};
+        int[] expectedStatusCodes = new int[] { 200, 200, 502, -1, -1, 200, 200, 200 };
         BValue[] returnVals = BRunUtil.invoke(compileResult, "testTypicalScenario");
 
         Assert.assertEquals(returnVals.length, 2);
@@ -90,7 +90,7 @@ public class CircuitBreakerTest {
      */
     @Test
     public void testTrialRunFailure() {
-        int[] expectedStatusCodes = new int[]{200, 502, -1, 502, -1, -1};
+        int[] expectedStatusCodes = new int[] { 200, 502, -1, 502, -1, -1 };
         BValue[] returnVals = BRunUtil.invoke(compileResult, "testTrialRunFailure");
 
         Assert.assertEquals(returnVals.length, 2);
@@ -118,6 +118,50 @@ public class CircuitBreakerTest {
                     Assert.assertTrue(msg != null && msg.startsWith(CB_ERROR_MSG));
                 } else {
                     Assert.assertEquals(statusCode, 502);
+                }
+            }
+        }
+    }
+
+    /**
+     * Test case scenario:
+     * * Initially the circuit is healthy and functioning normally.
+     * * Backend service respond with HTTP status code configured to consider as failures responses.
+     * * eventually the failure threshold is exceeded.
+     * * Requests afterwards are immediately failed, with a 503 response.
+     * * After the reset timeout expires, the circuit goes to HALF_OPEN state and a trial request is sent.
+     * * The backend service is not available and therefore, the request fails again and the circuit goes back to OPEN.
+     */
+    @Test(description = "Test case for Circuit Breaker HTTP status codes.")
+    public void testHttpStatusCodeFailure() {
+        int[] expectedStatusCodes = new int[] { 200, 500, -1, 500, -1, -1 };
+        BValue[] returnVals = BRunUtil.invoke(compileResult, "testHttpStatusCodeFailure");
+
+        Assert.assertEquals(returnVals.length, 2);
+
+        BRefValueArray responses = (BRefValueArray) returnVals[0];
+        BRefValueArray errs = (BRefValueArray) returnVals[1];
+
+        for (int i = 0; i < responses.size(); i++) {
+            BStruct res = (BStruct) responses.get(i);
+            long statusCode;
+
+            if (res != null) {
+                statusCode = res.getIntField(0);
+
+                Assert.assertEquals(statusCode, expectedStatusCodes[i]);
+            } else {
+                Assert.assertNotNull(errs.get(i)); // the request which resulted in an error
+                BStruct err = (BStruct) errs.get(i);
+                statusCode = err.getIntField(0);
+
+                // Status code of 0 means it is not an error related to HTTP. In this case, it is the Circuit Breaker
+                // error for requests which were failed immediately.
+                if (statusCode == 0) {
+                    String msg = err.getStringField(0);
+                    Assert.assertTrue(msg != null && msg.startsWith(CB_ERROR_MSG));
+                } else {
+                    Assert.assertEquals(statusCode, 500);
                 }
             }
         }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/net/http/resiliency/FailoverConnectorTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/net/http/resiliency/FailoverConnectorTest.java
@@ -23,7 +23,6 @@ import org.ballerinalang.launcher.util.BRunUtil;
 import org.ballerinalang.launcher.util.CompileResult;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
-import org.ballerinalang.model.values.BXMLItem;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -49,7 +48,6 @@ public class FailoverConnectorTest {
     @Test(description = "Test case for failover connector for at least one endpoint send success response.")
     public void testSuccessScenario() {
         long expectedHttpSC = 200;
-        String expectedMessageContent = "Ballerina";
         BValue[] returnVals = BRunUtil.invoke(compileResult, "testSuccessScenario");
 
         Assert.assertNotNull(returnVals);
@@ -58,11 +56,7 @@ public class FailoverConnectorTest {
 
         if (res != null) {
             long statusCode = res.getIntField(0);
-            BStruct messageEntity = (BStruct) res.getNativeData("message_entity");
-            String responseMsgContent = ((BXMLItem) messageEntity.getNativeData("message_datasource")).getTextValue()
-                    .stringValue();
             Assert.assertEquals(statusCode, expectedHttpSC);
-            Assert.assertEquals(responseMsgContent, expectedMessageContent);
         }
     }
 

--- a/tests/ballerina-test/src/test/resources/test-src/net/http/resiliency/circuit-breaker-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/http/resiliency/circuit-breaker-test.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina.net.http;
 import ballerina.net.http.resiliency;
 import ballerina.runtime;
@@ -6,11 +22,15 @@ const string TEST_SCENARIO_HEADER = "test-scenario";
 
 const string SCENARIO_TYPICAL = "typical-scenario";
 const string SCENARIO_TRIAL_RUN_FAILURE = "trial-run-failure";
+const string SCENARIO_HTTP_SC_FAILURE = "http-status-code-failure";
+
+int[] errorCodes = [400, 500, 404];
+resiliency:CircuitBreakerConfig circuitBreakerConfig = {failureThreshold:0.1, resetTimeout:20000, httpStatusCodes:errorCodes};
 
 function testTypicalScenario () (http:InResponse[], http:HttpConnectorError[]) {
 
     endpoint<resiliency:CircuitBreaker> circuitBreakerEP {
-        create resiliency:CircuitBreaker((http:HttpClient)create MockHttpClient("http://localhost:8080", {}), 0.1, 2000);
+        create resiliency:CircuitBreaker((http:HttpClient)create MockHttpClient("http://localhost:8080", {}), circuitBreakerConfig);
     }
 
     http:OutRequest request;
@@ -36,7 +56,7 @@ function testTypicalScenario () (http:InResponse[], http:HttpConnectorError[]) {
 function testTrialRunFailure () (http:InResponse[], http:HttpConnectorError[]) {
 
     endpoint<resiliency:CircuitBreaker> circuitBreakerEP {
-        create resiliency:CircuitBreaker((http:HttpClient)create MockHttpClient("http://localhost:8080", {}), 0.1, 2000);
+        create resiliency:CircuitBreaker((http:HttpClient)create MockHttpClient("http://localhost:8080", {}), circuitBreakerConfig);
     }
 
     http:OutRequest request;
@@ -51,6 +71,31 @@ function testTrialRunFailure () (http:InResponse[], http:HttpConnectorError[]) {
         counter = counter + 1;
 
         if (counter == 3) {
+            runtime:sleepCurrentWorker(5000);
+        }
+    }
+
+    return responses, errs;
+}
+
+function testHttpStatusCodeFailure () (http:InResponse[], http:HttpConnectorError[]) {
+
+    endpoint<resiliency:CircuitBreaker> circuitBreakerEP {
+        create resiliency:CircuitBreaker((http:HttpClient)create MockHttpClient("http://localhost:8080", {}), circuitBreakerConfig);
+    }
+
+    http:OutRequest request;
+    http:InResponse[] responses = [];
+    http:HttpConnectorError[] errs = [];
+    int counter = 0;
+
+    while (counter < 6) {
+        request = {};
+        request.setHeader(TEST_SCENARIO_HEADER, SCENARIO_HTTP_SC_FAILURE);
+        responses[counter], errs[counter] = circuitBreakerEP.get("/hello", request);
+        counter = counter + 1;
+
+        if (counter == 1) {
             runtime:sleepCurrentWorker(5000);
         }
     }
@@ -97,6 +142,8 @@ connector MockHttpClient (string serviceUri, http:Options connectorOptions) {
             response, err = handleScenario1(actualRequestNumber);
         } else if (scenario == SCENARIO_TRIAL_RUN_FAILURE) {
             response, err = handleScenario2(actualRequestNumber);
+        } else if (scenario == SCENARIO_HTTP_SC_FAILURE) {
+            response, err = handleScenario3(actualRequestNumber);
         }
 
         return response, err;
@@ -133,6 +180,17 @@ function handleScenario2 (int counter) (http:InResponse, http:HttpConnectorError
     return response, null;
 }
 
+function handleScenario3 (int counter) (http:InResponse, http:HttpConnectorError) {
+    // Fail a request. Then, fail the trial request sent while in the HALF_OPEN state as well.
+    if (counter == 2 || counter == 3) {
+        http:HttpConnectorError err = getMockErrorStruct();
+        return null, err;
+    }
+
+    http:InResponse response = getResponse();
+    return response, null;
+}
+
 function getErrorStruct () (http:HttpConnectorError) {
     http:HttpConnectorError err = {};
     err.message = "Connection refused";
@@ -152,4 +210,11 @@ public struct MockInResponse {
     int statusCode;
     string reasonPhrase;
     string server;
+}
+
+function getMockErrorStruct () (http:HttpConnectorError) {
+    http:HttpConnectorError err = {};
+    err.message = "Internal Server Error.";
+    err.statusCode = 500;
+    return err;
 }

--- a/tests/ballerina-test/src/test/resources/test-src/net/http/resiliency/failover-connector-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/net/http/resiliency/failover-connector-test.bal
@@ -1,6 +1,21 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina.net.http;
 import ballerina.net.http.resiliency;
-import ballerina.mime;
 
 http:Retry retryConfiguration = {count:0};
 
@@ -22,14 +37,7 @@ function testSuccessScenario () (http:InResponse, http:HttpConnectorError) {
 
     http:InResponse clientResponse = {};
     http:HttpConnectorError err;
-
-    mime:MediaType contentType = mime:getMediaType("application/xml");
-    mime:Entity requestEntity = {};
-    requestEntity.setXml(xml `<name>Ballerina</name>`);
-    requestEntity.contentType = contentType;
-
     http:OutRequest outReq = {};
-    outReq.setEntity(requestEntity);
 
     int counter = 0;
 
@@ -48,14 +56,7 @@ function testFailureScenario () (http:InResponse, http:HttpConnectorError) {
 
     http:InResponse clientResponse = {};
     http:HttpConnectorError err;
-
-    mime:MediaType contentType = mime:getMediaType("application/xml");
-    mime:Entity requestEntity = {};
-    requestEntity.setXml(xml `<name>Ballerina</name>`);
-    requestEntity.contentType = contentType;
-
     http:OutRequest outReq = {};
-    outReq.setEntity(requestEntity);
 
     int counter = 0;
 
@@ -132,9 +133,6 @@ function generateResponse (int count) (http:InResponse, http:HttpConnectorError)
         return null, err;
     } else {
         inResponse.statusCode = 200;
-        mime:Entity requestEntity = {};
-        requestEntity.setXml(xml `<name>Ballerina</name>`);
-        inResponse.setEntity(requestEntity);
         return inResponse, null;
     }
 }


### PR DESCRIPTION
Adding the support of circuiting handling by looking the at HTTP status code of the response

## Purpose
.Improve the Circuit Breaker functionality to handle states by looking at HTTP status code of the response. Fixes : https://github.com/ballerina-lang/ballerina/issues/4842

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
Introduce new configuration to define HTTP status codes to trip the circuit.


## Automation tests
 - Unit tests - yes.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
```java
import ballerina.io;
import ballerina.net.http;
import ballerina.net.http.resiliency;
import ballerina.runtime;

@http:configuration {basePath:"/cb"}
service<http> circuitBreakerDemo {
    int[] errorCodes = [400, 500, 404];
    resiliency:CircuitBreakerConfig circuitBreakerConfig = {failureThreshold:0.3, resetTimeout:20000, httpStatusCodes:errorCodes};


    @http:resourceConfig {
        methods:["GET"],
        path:"/"
    }
    resource sayHello (http:Connection conn, http:InRequest req) {
        endpoint<resiliency:CircuitBreaker> circuitBreakerEP {
            create resiliency:CircuitBreaker(create http:HttpClient("http://localhost:8080", {endpointTimeout:2000}), circuitBreakerConfig);
         }
        http:InResponse clientRes;
        http:HttpConnectorError err;
        clientRes, err = circuitBreakerEP.forward("/hello", req);
        if (err != null) {
            io:println(err);
            if (clientRes == null) {
                http:OutResponse res = {};
                res.statusCode = 500;
                res.setStringPayload(err.message);
                _ = conn.respond(res);
            }
        } else {
            io:println(clientRes.getStringPayload());
            _ = conn.forward(clientRes);
        }
    }
}

@http:configuration {basePath:"/hello", port:8080}
service<http> helloWorld {
    int counter = 1;
    @http:resourceConfig {
        methods:["GET"],
        path:"/"
    }
    resource sayHello (http:Connection conn, http:InRequest req) {
        if (counter % 10 == 0) {
            runtime:sleepCurrentWorker(5000);
            counter = counter + 1;
            http:OutResponse res = {};
            res.setStringPayload("Hello World!!!");
            _ = conn.respond(res);
        } else if (counter % 10 == 4) {
            counter = counter + 1;
            http:OutResponse res = {};
            res.statusCode = 500;
            res.setStringPayload("Error occured !!");
            _ = conn.respond(res);
        } else {
            counter = counter + 1;
            http:OutResponse res = {};
            res.setStringPayload("Hello World!!!");
            _ = conn.respond(res);
        }
    }
}

```