### PR TITLE
Enable context menu in source view

### DIFF
--- a/composer/modules/web/src/plugins/ballerina/views/source-editor.jsx
+++ b/composer/modules/web/src/plugins/ballerina/views/source-editor.jsx
@@ -329,7 +329,7 @@ class SourceEditor extends React.Component {
                     options={{
                         autoIndent: true,
                         fontSize: 14,
-                        contextmenu: false,
+                        contextmenu: true,
                         renderIndentGuides: true,
                         autoClosingBrackets: true,
                         matchBrackets: true,


### PR DESCRIPTION
## Purpose
Enable monaco editor context menu for ballerina composer. 

## Approach
![selection_132](https://user-images.githubusercontent.com/1552869/36751478-51666ee4-1c26-11e8-9c25-775cbe5fb999.png)
