### PR TITLE
 Support standard http access logs

### DIFF
--- a/bvm/ballerina-logging/src/main/java/org/ballerinalang/logging/BLogManager.java
+++ b/bvm/ballerina-logging/src/main/java/org/ballerinalang/logging/BLogManager.java
@@ -19,6 +19,7 @@ package org.ballerinalang.logging;
 
 import org.ballerinalang.config.ConfigRegistry;
 import org.ballerinalang.logging.formatters.HTTPTraceLogFormatter;
+import org.ballerinalang.logging.formatters.HttpAccessLogFormatter;
 import org.ballerinalang.logging.util.BLogLevel;
 
 import java.io.ByteArrayInputStream;
@@ -29,6 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.logging.ConsoleHandler;
+import java.util.logging.FileHandler;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
@@ -38,6 +40,7 @@ import java.util.regex.Pattern;
 
 import static org.ballerinalang.logging.util.Constants.BALLERINA_LOG_INSTANCES;
 import static org.ballerinalang.logging.util.Constants.BALLERINA_USER_LOG;
+import static org.ballerinalang.logging.util.Constants.HTTP_ACCESS_LOG;
 import static org.ballerinalang.logging.util.Constants.HTTP_TRACE_LOG;
 import static org.ballerinalang.logging.util.Constants.LOG_LEVEL;
 
@@ -59,6 +62,7 @@ public class BLogManager extends LogManager {
     private Map<String, BLogLevel> loggerLevels = new HashMap<>();
     private BLogLevel ballerinaUserLogLevel;
     private Logger httpTraceLogger;
+    private Logger httpAccessLogger;
 
     @Override
     public void readConfiguration(InputStream ins) throws IOException, SecurityException {
@@ -112,7 +116,7 @@ public class BLogManager extends LogManager {
         return loggerLevels.containsKey(pkg) ? loggerLevels.get(pkg) : ballerinaUserLogLevel;
     }
 
-    public void setHttpTraceLogHandler() throws IOException {
+    public void setHttpTraceLogHandler() {
         Handler handler = new ConsoleHandler();
         handler.setFormatter(new HTTPTraceLogFormatter());
         handler.setLevel(Level.FINEST);
@@ -125,6 +129,31 @@ public class BLogManager extends LogManager {
         removeHandlers(httpTraceLogger);
         httpTraceLogger.addHandler(handler);
         httpTraceLogger.setLevel(Level.FINEST);
+    }
+
+    /**
+     * Sets the Http access log
+     * @param arg the argument for access logging
+     * @throws IOException if there are IO problems opening the files.
+     */
+    public void setHttpAccessLogHandler(String arg) throws IOException {
+        Handler handler;
+        if (arg.equalsIgnoreCase("console")) {
+            handler = new ConsoleHandler();
+        } else {
+            handler = new FileHandler(arg, true);
+        }
+        handler.setFormatter(new HttpAccessLogFormatter());
+        handler.setLevel(Level.INFO);
+
+        if (httpAccessLogger == null) {
+            // keep a reference to prevent this logger from being garbage collected
+            httpAccessLogger = Logger.getLogger(HTTP_ACCESS_LOG);
+        }
+
+        removeHandlers(httpAccessLogger);
+        httpAccessLogger.addHandler(handler);
+        httpAccessLogger.setLevel(Level.INFO);
     }
 
     private static void removeHandlers(Logger logger) {

--- a/bvm/ballerina-logging/src/main/java/org/ballerinalang/logging/formatters/HttpAccessLogFormatter.java
+++ b/bvm/ballerina-logging/src/main/java/org/ballerinalang/logging/formatters/HttpAccessLogFormatter.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.logging.formatters;
+
+import org.ballerinalang.logging.BLogManager;
+
+import java.util.logging.Formatter;
+import java.util.logging.LogRecord;
+
+/**
+ * A custom log formatter for formatting the HTTP access logs.
+ *
+ * @since 0.965
+ */
+public class HttpAccessLogFormatter extends Formatter {
+
+    private static final String format = BLogManager.getLogManager().getProperty(
+            HttpAccessLogFormatter.class.getCanonicalName() + ".format");
+
+    @Override
+    public String format(LogRecord record) {
+        return String.format(format, record.getMessage());
+    }
+}

--- a/bvm/ballerina-logging/src/main/java/org/ballerinalang/logging/util/Constants.java
+++ b/bvm/ballerina-logging/src/main/java/org/ballerinalang/logging/util/Constants.java
@@ -26,9 +26,11 @@ package org.ballerinalang.logging.util;
 public class Constants {
 
     public static final String HTTP_TRACE_LOG = "tracelog.http";
+    public static final String HTTP_ACCESS_LOG = "accesslog.http";
     public static final String BALLERINA_USER_LOG = "ballerina.log";
 
     public static final String BALLERINA_LOG_INSTANCES = "ballerina.log.instances";
     public static final String LOG_LEVEL = "level";
+    public static final String LOG_TO = "logto";
     public static final String LOG_FORMAT = "format";
 }

--- a/bvm/ballerina-logging/src/main/resources/logging.properties
+++ b/bvm/ballerina-logging/src/main/resources/logging.properties
@@ -33,6 +33,9 @@ org.ballerinalang.logging.formatters.DefaultLogFormatter.format=[%1$tY-%1$tm-%1$
 # Log formatter for HTTP trace logs
 org.ballerinalang.logging.formatters.HTTPTraceLogFormatter.format=[%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS,%1$tL] %2$-5s {%3$s} - %4$s %5$s %n
 
+# Log formatter for HTTP access logs
+org.ballerinalang.logging.formatters.HttpAccessLogFormatter.format=%1$s %n
+
 ####################### LOGGERS #######################
 # Root logger
 handlers=org.ballerinalang.logging.handlers.DefaultLogFileHandler
@@ -46,3 +49,7 @@ ballerina.useParentHandlers=false
 # HTTP tracing logger - This is turned off by default, to turn on, set level to 'FINE' or lower
 tracelog.http.level=OFF
 tracelog.http.useParentHandlers=false
+
+# HTTP access logger
+accesslog.http.level=OFF
+accesslog.http.useParentHandlers=false

--- a/docs/ballerina-by-example/examples/http-access-logs/http-access-logs.bal
+++ b/docs/ballerina-by-example/examples/http-access-logs/http-access-logs.bal
@@ -1,0 +1,16 @@
+import ballerina.net.http;
+@http:configuration {
+    basePath:"/hello",
+    port:9095
+}
+service<http> helloService {
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"/"
+    }
+    resource aGetRequest (http:Connection conn, http:InRequest requ) {
+        http:OutResponse res = {};
+        res.setStringPayload("Successful");
+        _ = conn.respond(res);
+    }
+}

--- a/docs/ballerina-by-example/examples/http-access-logs/http-access-logs.bal.client.sh
+++ b/docs/ballerina-by-example/examples/http-access-logs/http-access-logs.bal.client.sh
@@ -1,0 +1,3 @@
+#Invoke the service.
+$ curl -k http://localhost:9095/hello
+  Successful~

--- a/docs/ballerina-by-example/examples/http-access-logs/http-access-logs.bal.description
+++ b/docs/ballerina-by-example/examples/http-access-logs/http-access-logs.bal.description
@@ -1,0 +1,1 @@
+// The server access log records all requests processed by the server.

--- a/docs/ballerina-by-example/examples/http-access-logs/http-access-logs.bal.server.sh
+++ b/docs/ballerina-by-example/examples/http-access-logs/http-access-logs.bal.server.sh
@@ -1,0 +1,10 @@
+#Run the service by setting '-B[accesslog.http].logto=console' to log to console
+$ ballerina run http-access-logs.bal -B[accesslog.http].logto=console
+ballerina: deploying service(s) in 'http-access-logs.bal'
+ballerina: started HTTP/WS server connector 0.0.0.0:9095
+127.0.0.1 - - [05/Mar/2018:10:16:38 +0530] "GET /hello HTTP/1.1" 200 10 "-" "curl/7.55.1"
+
+#Or Run the service by setting '-B[accesslog.http].logto=path/to/file.txt' to log to the specified file
+$ ballerina run http-access-logs.bal -B[accesslog.http].logto=path/to/file.txt
+ballerina: deploying service(s) in 'http-access-logs.bal'
+ballerina: started HTTP/WS server connector 0.0.0.0:9095

--- a/pom.xml
+++ b/pom.xml
@@ -1180,7 +1180,7 @@
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
         <carbon.kernel.version>5.1.0</carbon.kernel.version>
-        <transport.http.version>6.0.100</transport.http.version>
+        <transport.http.version>6.0.102</transport.http.version>
         <carbon.messaging.version>2.3.7</carbon.messaging.version>
         <carbon.deployment.version>5.0.0</carbon.deployment.version>
         <carbon.config.version>2.1.2</carbon.config.version>

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConnectionManager.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConnectionManager.java
@@ -17,6 +17,7 @@
  */
 package org.ballerinalang.net.http;
 
+import org.ballerinalang.config.ConfigRegistry;
 import org.ballerinalang.connector.api.BallerinaConnectorException;
 import org.ballerinalang.logging.BLogManager;
 import org.ballerinalang.logging.util.BLogLevel;
@@ -36,13 +37,15 @@ import org.wso2.transport.http.netty.listener.ServerBootstrapConfiguration;
 import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.LogManager;
+
+import static org.ballerinalang.logging.util.Constants.HTTP_ACCESS_LOG;
+import static org.ballerinalang.logging.util.Constants.LOG_TO;
 
 /**
  * {@code HttpConnectionManager} is responsible for managing all the server connectors with ballerina runtime.
@@ -67,11 +70,7 @@ public class HttpConnectionManager {
                 .getServerBootstrapConfiguration(trpConfig.getTransportProperties());
 
         if (isHTTPTraceLoggerEnabled()) {
-            try {
-                ((BLogManager) BLogManager.getLogManager()).setHttpTraceLogHandler();
-            } catch (IOException e) {
-                throw new BallerinaConnectorException("Error in configuring HTTP trace log");
-            }
+            ((BLogManager) BLogManager.getLogManager()).setHttpTraceLogHandler();
         }
     }
 
@@ -104,6 +103,9 @@ public class HttpConnectionManager {
 
         if (isHTTPTraceLoggerEnabled()) {
             listenerConfig.setHttpTraceLogEnabled(true);
+        }
+        if (getHttpAccessLoggerConfig() != null) {
+            listenerConfig.setHttpAccessLogEnabled(true);
         }
 
         serverBootstrapConfiguration = HTTPConnectorUtil
@@ -243,6 +245,14 @@ public class HttpConnectionManager {
         // TODO: Take a closer look at this since looking up from the Config Registry here caused test failures
         return ((BLogManager) LogManager.getLogManager()).getPackageLogLevel(
                 org.ballerinalang.logging.util.Constants.HTTP_TRACE_LOG) == BLogLevel.TRACE;
+    }
+
+    /**
+     * Gets the access logto value if available.
+     * @return the access logto value from the ConfigRegistry
+     */
+    public String getHttpAccessLoggerConfig() {
+        return ConfigRegistry.getInstance().getInstanceConfigValue(HTTP_ACCESS_LOG, LOG_TO);
     }
 
     private String makeFirstLetterLowerCase(String str) {


### PR DESCRIPTION
## Purpose
> Related issue: https://github.com/ballerina-lang/ballerina/issues/4444

## Goals
> Access logs will be printed in the console

## Approach
> The access logs are supported as per https://httpd.apache.org/docs/current/logs.html#combined

## Related PRs
> https://github.com/wso2/transport-http/pull/67
