### PR TITLE
Disable resolving source root at BCompileUtil.compile 

### DIFF
--- a/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/util/BCompileUtil.java
+++ b/cli/ballerina-launcher/src/main/java/org/ballerinalang/launcher/util/BCompileUtil.java
@@ -192,7 +192,7 @@ public class BCompileUtil {
     public static CompileResult compile(String sourceRoot, String packageName, CompilerPhase compilerPhase) {
         CompilerContext context = new CompilerContext();
         CompilerOptions options = CompilerOptions.getInstance(context);
-        options.put(SOURCE_ROOT, resourceDir.resolve(sourceRoot).toString());
+        options.put(SOURCE_ROOT, sourceRoot);
         options.put(COMPILER_PHASE, compilerPhase.toString());
         options.put(PRESERVE_WHITESPACE, "false");
 


### PR DESCRIPTION
## Purpose
BCompileUtil.compile(String sourceRoot, String packageName,
CompilerPhase compilerPhase) method currently tries to resolve the
source root which is not needed as it is already an absolute path. Without this fix, Testerina cannot leverage BCompileUtil.

## Goals
This fix gets rid of the unnecessary path resolving step w.r.t. source root.