### PR TITLE
Support any to string conversion

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BLangVM.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BLangVM.java
@@ -603,6 +603,7 @@ public class BLangVM {
                 case InstructionCodes.S2XML:
                 case InstructionCodes.S2JSONX:
                 case InstructionCodes.XML2S:
+                case InstructionCodes.ANY2SCONV:
                     execTypeConversionOpcodes(sf, opcode, operands);
                     break;
 
@@ -2234,6 +2235,17 @@ public class BLangVM {
                 i = operands[0];
                 j = operands[1];
                 sf.stringRegs[j] = sf.refRegs[i].stringValue();
+                break;
+            case InstructionCodes.ANY2SCONV:
+                i = operands[0];
+                j = operands[1];
+
+                bRefType = sf.refRegs[i];
+                if (bRefType == null) {
+                    sf.stringRegs[j] = STRING_NULL_VALUE;
+                } else {
+                    sf.stringRegs[j] = bRefType.stringValue();
+                }
                 break;
             default:
                 throw new UnsupportedOperationException();

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/InstructionCodes.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/InstructionCodes.java
@@ -197,6 +197,7 @@ public interface InstructionCodes {
     int JSON2XML = 157;
     int S2XML = 158;
     int XML2S = 159;
+    int ANY2SCONV = 175;
 
     // Type cast
     int I2ANY = 160;

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/Mnemonics.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/Mnemonics.java
@@ -185,6 +185,7 @@ public class Mnemonics {
         mnemonics[InstructionCodes.JSON2B] = "json2b";
         mnemonics[InstructionCodes.LENGTHOF] = "lengthof";
         mnemonics[InstructionCodes.NULL2S] = "null2s";
+        mnemonics[InstructionCodes.ANY2SCONV] = "any2sconv";
 
         mnemonics[InstructionCodes.TYPEOF] = "typeof";
         mnemonics[InstructionCodes.TYPELOAD] = "typeload";

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/ProgramFileReader.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/ProgramFileReader.java
@@ -1575,6 +1575,7 @@ public class ProgramFileReader {
                 case InstructionCodes.NULL2S:
                 case InstructionCodes.NEW_INT_RANGE:
                 case InstructionCodes.LENGTHOF:
+                case InstructionCodes.ANY2SCONV:
                     i = codeStream.readInt();
                     j = codeStream.readInt();
                     k = codeStream.readInt();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -349,6 +349,7 @@ public class SymbolTable {
 
     private void defineConversionOperators() {
         // Define conversion operators
+        defineConversionOperator(anyType, stringType, true, InstructionCodes.ANY2SCONV);
         defineConversionOperator(intType, floatType, true, InstructionCodes.I2F);
         defineConversionOperator(intType, stringType, true, InstructionCodes.I2S);
         defineConversionOperator(intType, booleanType, true, InstructionCodes.I2B);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/InstructionCodes.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/InstructionCodes.java
@@ -197,6 +197,7 @@ public interface InstructionCodes {
     int JSON2XML = 157;
     int S2XML = 158;
     int XML2S = 159;
+    int ANY2SCONV = 175;
 
     // Type cast
     int I2ANY = 160;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/Mnemonics.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/Mnemonics.java
@@ -185,6 +185,7 @@ public class Mnemonics {
         mnemonics[InstructionCodes.JSON2F] = "json2f";
         mnemonics[InstructionCodes.JSON2S] = "json2s";
         mnemonics[InstructionCodes.JSON2B] = "json2b";
+        mnemonics[InstructionCodes.ANY2SCONV] = "any2sconv";
         mnemonics[InstructionCodes.LENGTHOF] = "lengthof";
 
         mnemonics[InstructionCodes.TYPEOF] = "typeof";

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
@@ -149,6 +149,17 @@ public class TypeCastExprTest {
         Assert.assertEquals(returns[0].stringValue(), expected);
     }
 
+    @Test
+    public void testAnyToString() {
+        BValue[] returns = BRunUtil.invoke(result, "anyfloattostring", new BValue[]{});
+        Assert.assertTrue(returns[0] instanceof BString);
+        final String expected1 = "5.5";
+        Assert.assertEquals(returns[0].stringValue(), expected1);
+        returns = BRunUtil.invoke(result, "anyjsontostring", new BValue[]{});
+        Assert.assertTrue(returns[0] instanceof BString);
+        final String expected2 = "{\"a\":\"b\"}";
+        Assert.assertEquals(returns[0].stringValue(), expected2);
+    }
 
     @Test
     public void testBooleanAppendToString() {

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
@@ -60,6 +60,22 @@ function booleanappendtostring(boolean value)(string) {
     return result;
 }
 
+function anyfloattostring()(string) {
+    any value = 5.5;
+    string result;
+    //any to string should be a conversion
+    result = <string>value;
+    return result;
+}
+
+function anyjsontostring()(string) {
+    any value = {"a":"b"};
+    string result;
+    //any to string should be a conversion
+    result = <string>value;
+    return result;
+}
+
 function intarrtofloatarr()(float[]) {
     float[] numbers;
     numbers = [999,95,889];


### PR DESCRIPTION
## Purpose
Currently, if you have an int, float, json etc. other than string,
as an any type variable, string conversion fails. This PR allows
you to convert a given any type variable to a string.

## Goals
Support 'any' to 'string' conversion for all the types.

**eg:** 
```
any i = 5.0;
string b = <string>i;
```
## Approach
Introduced a new instruction to support the any to string conversion.
