### PR TITLE
Remove mutualssl test case

### DIFF
--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http/sample/MutualSSLTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/service/http/sample/MutualSSLTestCase.java
@@ -36,7 +36,7 @@ public class MutualSSLTestCase extends IntegrationTestCase {
     private ServerInstance ballerinaClient;
     private String serverZipPath;
 
-    @Test
+    @Test (enabled = false)
     public void setUp() throws BallerinaTestException {
         String serverBal = new File(
                 "src" + File.separator + "test" + File.separator + "resources" + File.separator + "MutualSSL"
@@ -45,7 +45,7 @@ public class MutualSSLTestCase extends IntegrationTestCase {
         ballerinaServer.startBallerinaServer(serverBal);
     }
 
-    @Test(description = "Test mutual ssl")
+    @Test(enabled = false, description = "Test mutual ssl")
     public void testMutualSSL() throws Exception {
         serverZipPath = System.getProperty(Constant.SYSTEM_PROP_SERVER_ZIP);
         String serverMessage = "successful";
@@ -65,7 +65,7 @@ public class MutualSSLTestCase extends IntegrationTestCase {
         clientLeecher.waitForText(20000);
     }
 
-    @AfterClass
+    @AfterClass(enabled = false)
     private void cleanup() throws Exception {
         ballerinaServer.stopServer();
         ballerinaClient.stopServer();


### PR DESCRIPTION
## Purpose
Remove this test case for the moment as it is intermittently failing on mac.
Related Issue : https://github.com/ballerina-lang/ballerina/issues/4874
## Goals
> N/A

## Approach
> N/A.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

