### PR TITLE
Improve struct initializer invocation order

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BLangVM.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BLangVM.java
@@ -3337,8 +3337,14 @@ public class BLangVM {
             return false;
         }
 
+        // Adjust the number of the attached functions of the lhs struct based on
+        //  the availability of the initializer function.
+        int lhsAttachedFunctionCount = lhsType.initializer != null ?
+                lhsType.getAttachedFunctions().length - 1 :
+                lhsType.getAttachedFunctions().length;
+
         if (lhsType.getStructFields().length > rhsType.getStructFields().length ||
-                lhsType.getAttachedFunctions().length > rhsType.getAttachedFunctions().length) {
+                lhsAttachedFunctionCount > rhsType.getAttachedFunctions().length) {
             return false;
         }
 
@@ -3362,6 +3368,10 @@ public class BLangVM {
         BStructType.AttachedFunction[] lhsFuncs = lhsType.getAttachedFunctions();
         BStructType.AttachedFunction[] rhsFuncs = rhsType.getAttachedFunctions();
         for (BStructType.AttachedFunction lhsFunc : lhsFuncs) {
+            if (lhsFunc == lhsType.initializer) {
+                continue;
+            }
+
             BStructType.AttachedFunction rhsFunc = getMatchingInvokableType(rhsFuncs, lhsFunc);
             if (rhsFunc == null) {
                 return false;
@@ -3398,6 +3408,10 @@ public class BLangVM {
         BStructType.AttachedFunction[] lhsFuncs = lhsType.getAttachedFunctions();
         BStructType.AttachedFunction[] rhsFuncs = rhsType.getAttachedFunctions();
         for (BStructType.AttachedFunction lhsFunc : lhsFuncs) {
+            if (lhsFunc == lhsType.initializer) {
+                continue;
+            }
+
             if (!Flags.isFlagOn(lhsFunc.flags, Flags.PUBLIC)) {
                 return false;
             }

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/types/BStructType.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/types/BStructType.java
@@ -31,6 +31,7 @@ public class BStructType extends BType {
     public StructInfo structInfo;
     private StructField[] structFields;
     private AttachedFunction[] attachedFunctions;
+    public AttachedFunction initializer;
     private int[] fieldTypeCount;
     public int flags;
 

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/ProgramFileReader.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/ProgramFileReader.java
@@ -416,15 +416,21 @@ public class ProgramFileReader {
                 // Read function name
                 int nameCPIndex = dataInStream.readInt();
                 UTF8CPEntry nameUTF8Entry = (UTF8CPEntry) packageInfo.getCPEntry(nameCPIndex);
+                String attachedFuncName = nameUTF8Entry.getValue();
 
                 // Read function type signature
                 int typeSigCPIndex = dataInStream.readInt();
                 UTF8CPEntry typeSigUTF8Entry = (UTF8CPEntry) packageInfo.getCPEntry(typeSigCPIndex);
 
                 int funcFlags = dataInStream.readInt();
-                AttachedFunctionInfo functionInfo = new AttachedFunctionInfo(nameCPIndex, nameUTF8Entry.getValue(),
+                AttachedFunctionInfo functionInfo = new AttachedFunctionInfo(nameCPIndex, attachedFuncName,
                         typeSigCPIndex, typeSigUTF8Entry.getValue(), funcFlags);
                 structInfo.funcInfoEntries.put(functionInfo.name, functionInfo);
+
+                // Setting the initializer function info, if any.
+                if (structName.equals(attachedFuncName)) {
+                    structInfo.initializer = functionInfo;
+                }
             }
 
             // Read attributes of the struct info
@@ -1757,6 +1763,9 @@ public class ProgramFileReader {
                 BStructType.AttachedFunction attachedFunction = new BStructType.AttachedFunction(
                         attachedFuncInfo.name, funcType, attachedFuncInfo.flags);
                 attachedFunctions[count++] = attachedFunction;
+                if (structInfo.initializer == attachedFuncInfo) {
+                    structType.initializer = attachedFunction;
+                }
             }
             structType.setAttachedFunctions(attachedFunctions);
         }

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/StructInfo.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/StructInfo.java
@@ -35,6 +35,7 @@ public class StructInfo extends StructureTypeInfo {
     private BStructType structType;
     private List<StructFieldInfo> fieldInfoEntries = new ArrayList<>();
     public Map<String, AttachedFunctionInfo> funcInfoEntries = new HashMap<>();
+    public AttachedFunctionInfo initializer;
 
     public StructInfo(int pkgPathCPIndex, String packagePath, int nameCPIndex, String name, int flags) {
         super(pkgPathCPIndex, packagePath, nameCPIndex, name, flags);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
@@ -712,6 +712,19 @@ public class CodeGenerator extends BLangNodeVisitor {
         RegIndex structRegIndex = calcAndGetExprRegIndex(structLiteral);
         emit(InstructionCodes.NEWSTRUCT, structCPIndex, structRegIndex);
 
+        // Invoke the struct initializer here.
+        if (structLiteral.initializer != null) {
+            int funcRefCPIndex = getFuncRefCPIndex(structLiteral.initializer.symbol);
+            // call funcRefCPIndex 1 structRegIndex 0
+            Operand[] operands = new Operand[4];
+            operands[0] = getOperand(funcRefCPIndex);
+            operands[1] = getOperand(1);
+            operands[2] = structRegIndex;
+            operands[3] = getOperand(0);
+            emit(InstructionCodes.CALL, operands);
+        }
+
+        // Generate code the struct literal.
         for (BLangRecordKeyValue keyValue : structLiteral.keyValuePairs) {
             BLangRecordKey key = keyValue.key;
             Operand fieldIndex = key.fieldSymbol.varIndex;
@@ -721,20 +734,6 @@ public class CodeGenerator extends BLangNodeVisitor {
             int opcode = getOpcode(key.fieldSymbol.type.tag, InstructionCodes.IFIELDSTORE);
             emit(opcode, structRegIndex, fieldIndex, keyValue.valueExpr.regIndex);
         }
-
-        // Invoke the struct initializer here.
-        if (structLiteral.initializer == null) {
-            return;
-        }
-
-        int funcRefCPIndex = getFuncRefCPIndex(structLiteral.initializer.symbol);
-        // call funcRefCPIndex 1 structRegIndex 0
-        Operand[] operands = new Operand[4];
-        operands[0] = getOperand(funcRefCPIndex);
-        operands[1] = getOperand(1);
-        operands[2] = structRegIndex;
-        operands[3] = getOperand(0);
-        emit(InstructionCodes.CALL, operands);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -322,10 +322,7 @@ public class Types {
         //RHS type should have at least all the fields as well attached functions of LHS type.
         BStructType lhsStructType = (BStructType) lhsType;
         BStructType rhsStructType = (BStructType) rhsType;
-
-        if (lhsStructType.fields.size() > rhsStructType.fields.size() ||
-                ((BStructSymbol) lhsStructType.tsymbol).attachedFuncs.size() >
-                        ((BStructSymbol) rhsStructType.tsymbol).attachedFuncs.size()) {
+        if (lhsStructType.fields.size() > rhsStructType.fields.size()) {
             return false;
         }
 
@@ -943,9 +940,19 @@ public class Types {
             return false;
         }
 
-        List<BAttachedFunction> lhsFuncs = ((BStructSymbol) lhsType.tsymbol).attachedFuncs;
+        BStructSymbol lhsStructSymbol = (BStructSymbol) lhsType.tsymbol;
+        List<BAttachedFunction> lhsFuncs = lhsStructSymbol.attachedFuncs;
         List<BAttachedFunction> rhsFuncs = ((BStructSymbol) rhsType.tsymbol).attachedFuncs;
+        int lhsAttachedFuncCount = lhsStructSymbol.initializerFunc != null ? lhsFuncs.size() - 1 : lhsFuncs.size();
+        if (lhsAttachedFuncCount > rhsFuncs.size()) {
+            return false;
+        }
+
         for (BAttachedFunction lhsFunc : lhsFuncs) {
+            if (lhsFunc == lhsStructSymbol.initializerFunc) {
+                continue;
+            }
+
             BAttachedFunction rhsFunc = getMatchingInvokableType(rhsFuncs, lhsFunc);
             if (rhsFunc == null) {
                 return false;
@@ -978,9 +985,19 @@ public class Types {
             }
         }
 
-        List<BAttachedFunction> lhsFuncs = ((BStructSymbol) lhsType.tsymbol).attachedFuncs;
+        BStructSymbol lhsStructSymbol = (BStructSymbol) lhsType.tsymbol;
+        List<BAttachedFunction> lhsFuncs = lhsStructSymbol.attachedFuncs;
         List<BAttachedFunction> rhsFuncs = ((BStructSymbol) rhsType.tsymbol).attachedFuncs;
+        int lhsAttachedFuncCount = lhsStructSymbol.initializerFunc != null ? lhsFuncs.size() - 1 : lhsFuncs.size();
+        if (lhsAttachedFuncCount > rhsFuncs.size()) {
+            return false;
+        }
+
         for (BAttachedFunction lhsFunc : lhsFuncs) {
+            if (lhsFunc == lhsStructSymbol.initializerFunc) {
+                continue;
+            }
+
             if (Symbols.isPrivate(lhsFunc.symbol)) {
                 return false;
             }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/structs/StructInitializerTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/structs/StructInitializerTest.java
@@ -43,7 +43,7 @@ public class StructInitializerTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testStructInitializerInSamePackage1");
 
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 10);
-        Assert.assertEquals(returns[1].stringValue(), "Charles");
+        Assert.assertEquals(returns[1].stringValue(), "Peter");
     }
 
     @Test(description = "Test struct initializers that are in different packages")
@@ -51,7 +51,15 @@ public class StructInitializerTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testStructInitializerInAnotherPackage");
 
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 10);
-        Assert.assertEquals(returns[1].stringValue(), "James");
+        Assert.assertEquals(returns[1].stringValue(), "Peter");
+    }
+
+    @Test(description = "Test struct initializer order, 1) default values, 2) initializer, 3) literal ")
+    public void testStructInitializerOrder() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testStructInitializerOrder");
+
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 40);
+        Assert.assertEquals(returns[1].stringValue(), "AB");
     }
 
     @Test(description = "Test negative structs initializers scenarios")

--- a/tests/ballerina-test/src/test/resources/test-src/structs/eq/eq1.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/eq/eq1.bal
@@ -36,6 +36,9 @@ public struct employee {
     int employeeId = 123456;
 }
 
+public function <employee e> employee() {
+}
+
 public function <employee e> getName() returns (string) {
     return e.name;
 }

--- a/tests/ballerina-test/src/test/resources/test-src/structs/req2/eq2.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/req2/eq2.bal
@@ -6,6 +6,9 @@ public struct userPB {
     string address;
 }
 
+public function <userPB ub> userPB() {
+}
+
 public function <userPB ub> getName () returns (string) {
     return ub.name;
 }

--- a/tests/ballerina-test/src/test/resources/test-src/structs/struct-equivalency.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/struct-equivalency.bal
@@ -12,6 +12,9 @@ public struct person1 {
     int id;
 }
 
+public function <person1 p>  person1 () {
+}
+
 public function <person1 p> getName () returns (string) {
     return p.name;
 }
@@ -36,6 +39,9 @@ public struct employee1 {
     string ssn;
     int id;
     int employeeId = 123456;
+}
+
+public function <employee1 p>  employee1 () {
 }
 
 public function <employee1 e> getName () returns (string) {

--- a/tests/ballerina-test/src/test/resources/test-src/structs/struct-initializer.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/structs/struct-initializer.bal
@@ -25,3 +25,20 @@ function testStructInitializerInAnotherPackage() returns (int, string){
     return e.age, e.name;
 }
 
+// testStructInitializerOrder
+
+struct employee {
+    int age = 20;
+    string name = "A";
+}
+
+function <employee p> employee() {
+    p.age = 30;
+    p.name = p.name + "B";
+}
+
+function testStructInitializerOrder() returns (int, string){
+    employee p = {age: 40};
+    return p.age, p.name;
+}
+


### PR DESCRIPTION
## Purpose
This PR addresses following points. 

1) Update the struct initializer invocation order. Now the default literal values are initialized first, then the initializer function, and then the struct literal
2) Improve the type checking algorithm to consider the struct initializers when checking the equivalency of two structs. 

```ballerina
struct employee {
    int age = 20;
    string name = "A";
}

function <employee p> employee() {
    p.age = 30;
    p.name = p.name + "B";
}

// This function should return 40 and "AB"
function testStructInitializerOrder() returns (int, string){
    employee p = {age: 40};
    return p.age, p.name;
}
```
