### PR TITLE
Fix invalid completion with succeeding characters

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -182,12 +182,61 @@ public class CommonUtil {
      * @return {@link Token}    Previous default token
      */
     public static Token getPreviousDefaultToken(TokenStream tokenStream, int startIndex) {
+        return getDefaultTokenToLeftOrRight(tokenStream, startIndex, -1);
+    }
+
+    /**
+     * Get the next default token from the given start index.
+     * @param tokenStream       Token Stream
+     * @param startIndex        Start token index
+     * @return {@link Token}    Previous default token
+     */
+    public static Token getNextDefaultToken(TokenStream tokenStream, int startIndex) {
+        return getDefaultTokenToLeftOrRight(tokenStream, startIndex, 1);
+    }
+
+    /**
+     * Get the Nth Default token to the left of current token index.
+     * @param tokenStream       Token Stream to traverse
+     * @param startIndex        Start position of the token stream
+     * @param offset            Number of tokens to traverse left
+     * @return {@link Token}    Nth Token
+     */
+    public static Token getNthDefaultTokensToLeft(TokenStream tokenStream, int startIndex, int offset) {
+        Token token = null;
+        int indexCounter = startIndex;
+        for (int i = 0; i < offset; i++) {
+            token = getPreviousDefaultToken(tokenStream, indexCounter);
+            indexCounter = token.getTokenIndex();
+        }
+        
+        return token;
+    }
+
+    /**
+     * Get the Nth Default token to the right of current token index.
+     * @param tokenStream       Token Stream to traverse
+     * @param startIndex        Start position of the token stream
+     * @param offset            Number of tokens to traverse right
+     * @return {@link Token}    Nth Token
+     */
+    public static Token getNthDefaultTokensToRight(TokenStream tokenStream, int startIndex, int offset) {
+        Token token = null;
+        int indexCounter = startIndex;
+        for (int i = 0; i < offset; i++) {
+            token = getNextDefaultToken(tokenStream, indexCounter);
+            indexCounter = token.getTokenIndex();
+        }
+        
+        return token;
+    }
+    
+    private static Token getDefaultTokenToLeftOrRight(TokenStream tokenStream, int startIndex, int direction) {
         Token token;
         while (true) {
+            startIndex += direction;
             token = tokenStream.get(startIndex);
-            if (token.getChannel() != Token.DEFAULT_CHANNEL) {
-                startIndex--;
-            } else {
+            if (token.getChannel() == Token.DEFAULT_CHANNEL) {
                 break;
             }
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/AbstractItemResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/AbstractItemResolver.java
@@ -21,6 +21,7 @@ import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.TokenStream;
 import org.ballerinalang.langserver.DocumentServiceKeys;
 import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
 import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
@@ -220,20 +221,16 @@ public abstract class AbstractItemResolver {
      * @return {@link Boolean}
      */
     protected boolean isInvocationOrFieldAccess(TextDocumentServiceContext documentServiceContext) {
-        ArrayList<String> terminalTokens = new ArrayList<>(Arrays.asList(new String[]{";", "}", "{"}));
+        ArrayList<String> terminalTokens = new ArrayList<>(Arrays.asList(new String[]{";", "}", "{", "(", ")"}));
         TokenStream tokenStream = documentServiceContext.get(DocumentServiceKeys.TOKEN_STREAM_KEY);
         int searchTokenIndex = documentServiceContext.get(DocumentServiceKeys.TOKEN_INDEX_KEY);
-        String currentTokenStr = tokenStream.get(searchTokenIndex).getText();
-
-        if (terminalTokens.contains(currentTokenStr)) {
-            searchTokenIndex -= 1;
-            while (true) {
-                if (tokenStream.get(searchTokenIndex).getChannel() == Token.DEFAULT_CHANNEL) {
-                    break;
-                } else {
-                    searchTokenIndex -= 1;
-                }
-            }
+        
+        /*
+        In order to avoid the token index inconsistencies, current token index offsets from two default tokens
+         */
+        Token offsetToken = CommonUtil.getNthDefaultTokensToLeft(tokenStream, searchTokenIndex, 2);
+        if (!terminalTokens.contains(offsetToken.getText())) {
+            searchTokenIndex = offsetToken.getTokenIndex();
         }
 
         while (true) {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/CompletionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/CompletionTest.java
@@ -74,7 +74,7 @@ public abstract class CompletionTest {
         position.setCharacter(positionObj.get("character").getAsInt());
         TextDocumentPositionParams positionParams =
                 CompletionTestUtil.getPositionParams(position, balPath);
-            WorkspaceDocumentManagerImpl documentManager = CompletionTestUtil.prepareDocumentManager(balPath, content);
+        WorkspaceDocumentManagerImpl documentManager = CompletionTestUtil.prepareDocumentManager(balPath, content);
         List<CompletionItem> responseItemList = CompletionTestUtil.getCompletions(documentManager, positionParams);
         List<CompletionItem> expectedList = CompletionTestUtil.getExpectedItemList(expectedItems);
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/definitions/ActionDefinition.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/definitions/ActionDefinition.java
@@ -49,6 +49,7 @@ public class ActionDefinition extends CompletionTest {
                 {"enumSuggestVarDef2.json", "action"},
                 {"structFields.json", "action"},
                 {"structBoundFunctionsAndFields.json", "action"},
+                {"packageContentWithSucceedingCharacter1.json", "action"}
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/definitions/FunctionDefinition.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/definitions/FunctionDefinition.java
@@ -48,7 +48,8 @@ public class FunctionDefinition extends CompletionTest {
                 {"enumSuggestVarDef1.json", "function"},
                 {"enumSuggestVarDef2.json", "function"},
                 {"structFields.json", "function"},
-                {"structBoundFunctionsAndFields.json", "function"}
+                {"structBoundFunctionsAndFields.json", "function"},
+                {"packageContentWithSucceedingCharacter1.json", "function"}
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/definitions/ResourceDefinition.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/definitions/ResourceDefinition.java
@@ -49,7 +49,8 @@ public class ResourceDefinition extends CompletionTest {
                 {"enumSuggestVarDef1.json", "resource"},
                 {"enumSuggestVarDef2.json", "resource"},
                 {"structFields.json", "resource"},
-                {"structBoundFunctionsAndFields.json", "resource"}
+                {"structBoundFunctionsAndFields.json", "resource"},
+                {"packageContentWithSucceedingCharacter1.json", "resource"}
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/action/packageContentWithSucceedingCharacter1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action/packageContentWithSucceedingCharacter1.json
@@ -1,0 +1,25 @@
+{
+  "position": {
+    "line": 5,
+    "character": 26
+  },
+  "source": "action/source/packageContentWithSucceedingCharacter1.bal",
+  "items": [
+    {
+      "label":"getGlobalValue(string property)(string)",
+      "kind":"Function",
+      "detail":"Function",
+      "sortText":"119",
+      "insertText":"getGlobalValue(${1:property})",
+      "insertTextFormat":"Snippet"
+    },
+    {
+      "label":"getInstanceValue(string instanceId, string property)(string)",
+      "kind":"Function",
+      "detail":"Function",
+      "sortText":"119",
+      "insertText":"getInstanceValue(${1:instanceId}, ${2:property})",
+      "insertTextFormat":"Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/action/source/packageContentWithSucceedingCharacter1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/action/source/packageContentWithSucceedingCharacter1.bal
@@ -1,0 +1,8 @@
+import ballerina.io;
+import ballerina.config;
+
+connector testConnector () {
+    action testAction() {
+        string a = config:("property");
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/packageContentWithSucceedingCharacter1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/packageContentWithSucceedingCharacter1.json
@@ -1,0 +1,25 @@
+{
+  "position": {
+    "line": 4,
+    "character": 22
+  },
+  "source": "function/source/packageContentWithSucceedingCharacter1.bal",
+  "items": [
+    {
+      "label":"getGlobalValue(string property)(string)",
+      "kind":"Function",
+      "detail":"Function",
+      "sortText":"119",
+      "insertText":"getGlobalValue(${1:property})",
+      "insertTextFormat":"Snippet"
+    },
+    {
+      "label":"getInstanceValue(string instanceId, string property)(string)",
+      "kind":"Function",
+      "detail":"Function",
+      "sortText":"119",
+      "insertText":"getInstanceValue(${1:instanceId}, ${2:property})",
+      "insertTextFormat":"Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/source/packageContentWithSucceedingCharacter1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/source/packageContentWithSucceedingCharacter1.bal
@@ -1,0 +1,6 @@
+import ballerina.io;
+import ballerina.config;
+
+function testFunction () {
+    string a = config:("property");
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/resource/packageContentWithSucceedingCharacter1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/resource/packageContentWithSucceedingCharacter1.json
@@ -1,0 +1,25 @@
+{
+  "position": {
+    "line": 6,
+    "character": 26
+  },
+  "source": "resource/source/packageContentWithSucceedingCharacter1.bal",
+  "items": [
+    {
+      "label":"getGlobalValue(string property)(string)",
+      "kind":"Function",
+      "detail":"Function",
+      "sortText":"119",
+      "insertText":"getGlobalValue(${1:property})",
+      "insertTextFormat":"Snippet"
+    },
+    {
+      "label":"getInstanceValue(string instanceId, string property)(string)",
+      "kind":"Function",
+      "detail":"Function",
+      "sortText":"119",
+      "insertText":"getInstanceValue(${1:instanceId}, ${2:property})",
+      "insertTextFormat":"Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/resource/source/packageContentWithSucceedingCharacter1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/resource/source/packageContentWithSucceedingCharacter1.bal
@@ -1,0 +1,9 @@
+import ballerina.io;
+import ballerina.config;
+import ballerina.net.http;
+
+service<http> serviceName{
+    resource resourceName (http:Connection conn, http:InRequest req) {
+        string a = config:("property");
+    }
+}


### PR DESCRIPTION
## Purpose
> With this resolve suggesting invalid completion items when there are succeeding characters after an
invocation symbol such as ":" or ".". Resolves #4870 

## Approach
> 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/1329674/36945377-213f587e-1fd3-11e8-9d74-6aedaa876bfc.gif)