### PR TITLE
Fix references not loading issue

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/util/ReferenceUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/util/ReferenceUtil.java
@@ -51,8 +51,13 @@ public class ReferenceUtil {
 
         for (Object o : packages) {
             PackageID packageID = (PackageID) o;
-            BLangPackage bLangPackage = getPackageOfTheOwner(packageID.name, referencesContext, bLangPackageContext);
-            bLangPackage.accept(referencesTreeVisitor);
+            // TODO: remove the following condition after fixing the issue when loading runtime package it imports
+            //       itself cause a stackOverFlow in semantic analyzer.
+            if (!packageID.getName().getValue().equals("ballerina.runtime")) {
+                BLangPackage bLangPackage = getPackageOfTheOwner(packageID.name, referencesContext,
+                        bLangPackageContext);
+                bLangPackage.accept(referencesTreeVisitor);
+            }
         }
 
         // If the current package is default package continue.


### PR DESCRIPTION
## Purpose
> Fix #4991

## Goals
>On request of find all references stackOverFlow error has thrown as semantic analyzer cannot resolve ballerina.runtime package's imports. This commit will provide a temporary solution.