### PR TITLE
Fix 4994: Add a new method to retrieve log messages which also allows 'null'

### DIFF
--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/AbstractLogFunction.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/AbstractLogFunction.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.nativeimpl.log;
 
+import org.ballerinalang.bre.Context;
 import org.ballerinalang.logging.BLogManager;
 import org.ballerinalang.natives.AbstractNativeFunction;
 import org.slf4j.Logger;
@@ -43,5 +44,9 @@ public abstract class AbstractLogFunction extends AbstractNativeFunction {
             // TODO: Refactor this later
             return LoggerFactory.getLogger(ballerinaRootLogger.getName() + "." + pkg);
         }
+    }
+
+    protected String getLogMessage(Context context, int index) {
+        return String.valueOf(context.getControlStack().getCurrentFrame().getStringRegs()[index]);
     }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogDebug.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogDebug.java
@@ -43,7 +43,7 @@ public class LogDebug extends AbstractLogFunction {
                                                     .getCallableUnitInfo().getPackageInfo().getPkgPath();
 
         if (LOG_MANAGER.getPackageLogLevel(pkg).value() <= BLogLevel.DEBUG.value()) {
-            getLogger(pkg).debug(getStringArgument(ctx, 0));
+            getLogger(pkg).debug(getLogMessage(ctx, 0));
         }
         return VOID_RETURN;
     }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogError.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogError.java
@@ -43,7 +43,7 @@ public class LogError extends AbstractLogFunction {
                                                     .getCallableUnitInfo().getPackageInfo().getPkgPath();
 
         if (LOG_MANAGER.getPackageLogLevel(pkg).value() <= BLogLevel.ERROR.value()) {
-            getLogger(pkg).error(getStringArgument(ctx, 0));
+            getLogger(pkg).error(getLogMessage(ctx, 0));
         }
         return VOID_RETURN;
     }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogErrorCause.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogErrorCause.java
@@ -44,7 +44,7 @@ public class LogErrorCause extends AbstractLogFunction {
                 .getCallableUnitInfo().getPackageInfo().getPkgPath();
 
         if (LOG_MANAGER.getPackageLogLevel(pkg).value() <= BLogLevel.ERROR.value()) {
-            String msg = getStringArgument(ctx, 0);
+            String msg = getLogMessage(ctx, 0);
             BStruct err = (BStruct) getRefArgument(ctx, 0);
             getLogger(pkg).error(msg + " : " + err.stringValue());
         }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogInfo.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogInfo.java
@@ -43,7 +43,7 @@ public class LogInfo extends AbstractLogFunction {
                                                 .getCallableUnitInfo().getPackageInfo().getPkgPath();
 
         if (LOG_MANAGER.getPackageLogLevel(pkg).value() <= BLogLevel.INFO.value()) {
-            getLogger(pkg).info(getStringArgument(ctx, 0));
+            getLogger(pkg).info(getLogMessage(ctx, 0));
         }
         return VOID_RETURN;
     }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogTrace.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogTrace.java
@@ -43,7 +43,7 @@ public class LogTrace extends AbstractLogFunction {
                                                     .getCallableUnitInfo().getPackageInfo().getPkgPath();
 
         if (LOG_MANAGER.getPackageLogLevel(pkg).value() <= BLogLevel.TRACE.value()) {
-            getLogger(pkg).trace(getStringArgument(ctx, 0));
+            getLogger(pkg).trace(getLogMessage(ctx, 0));
         }
         return VOID_RETURN;
     }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogWarn.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogWarn.java
@@ -43,7 +43,7 @@ public class LogWarn extends AbstractLogFunction {
                                                     .getCallableUnitInfo().getPackageInfo().getPkgPath();
 
         if (LOG_MANAGER.getPackageLogLevel(pkg).value() <= BLogLevel.WARN.value()) {
-            getLogger(pkg).warn(getStringArgument(ctx, 0));
+            getLogger(pkg).warn(getLogMessage(ctx, 0));
         }
         return VOID_RETURN;
     }


### PR DESCRIPTION
## Purpose
> Add an alternative to `getStringArgument()` method to retrieve the log messages from the `Context`. Fix #4994 

## Goals
> To allow `null` as a valid log message value.

## Samples
```ballerina
import ballerina.log;

function main(string[] args) {
    error err = {msg: "error occurred"};

    log:printDebug("debug log");
    log:printError("error log");
    log:printErrorCause("error log with cause", err);
    log:printInfo("info log");
    log:printTrace("trace log");
    log:printWarn("warn log");

    log:printDebug(null);
    log:printError(null);
    log:printErrorCause(null, err);
    log:printInfo(null);
    log:printTrace(null);
    log:printWarn(null);
}
```
Running the above sample as follows:
```
$ ballerina run log-example.bal -B[ballerina.log].level=TRACE
2018-03-05 12:58:59,664 DEBUG [] - debug log 
2018-03-05 12:58:59,669 ERROR [] - error log 
2018-03-05 12:58:59,669 ERROR [] - error log with cause : {message:"error occurred", cause:null} 
2018-03-05 12:58:59,670 INFO  [] - info log 
2018-03-05 12:58:59,671 TRACE [] - trace log 
2018-03-05 12:58:59,671 WARN  [] - warn log 
2018-03-05 12:58:59,672 DEBUG [] - null 
2018-03-05 12:58:59,673 ERROR [] - null 
2018-03-05 12:58:59,673 ERROR [] - null : {message:"error occurred", cause:null} 
2018-03-05 12:58:59,674 INFO  [] - null 
2018-03-05 12:58:59,674 TRACE [] - null 
2018-03-05 12:58:59,675 WARN  [] - null
```