### PR TITLE
Remove getProperty from request struct

### DIFF
--- a/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
@@ -6,11 +6,13 @@ import ballerina.mime;
 public const string CONTENT_LENGTH = "content-length";
 
 @Description { value:"Represents the HTTP server connector connection"}
-@Field {value:"remoteHost: The server host name"}
+@Field {value:"host: The server host name"}
 @Field {value:"port: The server port"}
+@Field {value:"remoteAddress: The address of the remote host to which the connection is connected."}
 public struct Connection {
-	string remoteHost;
+	string host;
 	int port;
+	string remoteAddress;
 }
 
 @Description { value:"Sends outbound response to the caller"}
@@ -35,17 +37,20 @@ public native function <Connection conn> createSessionIfAbsent () (Session);
 @Return { value:"The HTTP Session struct assoicated with the request" }
 public native function <Connection conn> getSession () (Session);
 
-@Description { value:"Represents an HTTP inbound request message"}
+@Description {value:"Represents an HTTP inbound request message"}
 @Field {value:"path: Resource path of request URI"}
 @Field {value:"method: HTTP request method"}
 @Field {value:"httpVersion: The version of HTTP"}
 @Field {value:"userAgent: User-Agent request header"}
+@Field {value:"extraPathInfo: Additional information associated with the URL sent by the client"}
+@Field {value:"protocol: The protocol of the HTTP request"}
 public struct InRequest {
 	string rawPath;
 	string method;
 	string httpVersion;
 	string userAgent;
-    string extraPathInfo;
+	string extraPathInfo;
+	string protocol;
 }
 
 @Description { value:"Get the entity from the inbound request with the body included"}
@@ -67,12 +72,6 @@ public native function <InRequest req> setEntity (mime:Entity entity);
 @Param { value:"req: The inbound request message" }
 @Return { value:"The map of query params" }
 public native function <InRequest req> getQueryParams () (map);
-
-@Description { value:"Retrieves the named property from the request"}
-@Param { value:"req: The inbound request message" }
-@Param { value:"propertyName: The name of the property" }
-@Return { value:"The property value" }
-public native function <InRequest req> getProperty (string propertyName) (string);
 
 @Description { value: "Get matrix parameters from the request"}
 @Param { value:"req: The inbound request message" }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -190,6 +190,7 @@ public class HttpConstants {
     //Connection struct indexes
     public static final int CONNECTION_HOST_INDEX = 0;
     public static final int CONNECTION_PORT_INDEX = 0;
+    public static final int CONNECTION_REMOTE_ADDRESS_INDEX = 1;
 
     //InRequest struct indexes
     public static final int IN_REQUEST_RAW_PATH_INDEX = 0;
@@ -197,6 +198,7 @@ public class HttpConstants {
     public static final int IN_REQUEST_VERSION_INDEX = 2;
     public static final int IN_REQUEST_USER_AGENT_INDEX = 3;
     public static final int IN_REQUEST_EXTRA_PATH_INFO_INDEX = 4;
+    public static final int IN_REQUEST_PROTOCOL_INDEX = 5;
 
     //InResponse struct indexes
     public static final int IN_RESPONSE_STATUS_CODE_INDEX = 0;

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -397,17 +397,19 @@ public class HttpUtil {
     }
 
     private static void enrichWithInboundRequestInfo(BStruct inboundRequestStruct,
-                                                     HTTPCarbonMessage inboundRequestMsg) {
+            HTTPCarbonMessage inboundRequestMsg) {
         inboundRequestStruct.setStringField(HttpConstants.IN_REQUEST_RAW_PATH_INDEX,
                 (String) inboundRequestMsg.getProperty(HttpConstants.REQUEST_URL));
         inboundRequestStruct.setStringField(HttpConstants.IN_REQUEST_METHOD_INDEX,
                 (String) inboundRequestMsg.getProperty(HttpConstants.HTTP_METHOD));
         inboundRequestStruct.setStringField(HttpConstants.IN_REQUEST_VERSION_INDEX,
                 (String) inboundRequestMsg.getProperty(HttpConstants.HTTP_VERSION));
-        Map<String, String> resourceArgValues =
-                (Map<String, String>) inboundRequestMsg.getProperty(HttpConstants.RESOURCE_ARGS);
+        Map<String, String> resourceArgValues = (Map<String, String>) inboundRequestMsg
+                .getProperty(HttpConstants.RESOURCE_ARGS);
         inboundRequestStruct.setStringField(HttpConstants.IN_REQUEST_EXTRA_PATH_INFO_INDEX,
                 resourceArgValues.get(HttpConstants.EXTRA_PATH_INFO));
+        inboundRequestStruct.setStringField(HttpConstants.IN_REQUEST_PROTOCOL_INDEX,
+                (String) inboundRequestMsg.getProperty(HttpConstants.PROTOCOL));
     }
 
     public static void enrichConnectionInfo(BStruct connection, HTTPCarbonMessage cMsg) {
@@ -416,6 +418,10 @@ public class HttpUtil {
                 ((InetSocketAddress) cMsg.getProperty(HttpConstants.LOCAL_ADDRESS)).getHostName());
         connection.setIntField(HttpConstants.CONNECTION_PORT_INDEX,
                 (Integer) cMsg.getProperty(HttpConstants.LISTENER_PORT));
+        if (cMsg.getProperty(HttpConstants.REMOTE_ADDRESS) != null) {
+            connection.setStringField(HttpConstants.CONNECTION_REMOTE_ADDRESS_INDEX,
+                    ((InetSocketAddress) cMsg.getProperty(HttpConstants.REMOTE_ADDRESS)).getAddress().toString());
+        }
     }
 
     /**

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/inbound/request/InRequestNativeFunctionNegativeTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/inbound/request/InRequestNativeFunctionNegativeTest.java
@@ -108,17 +108,6 @@ public class InRequestNativeFunctionNegativeTest {
         Assert.assertTrue(error.contains("error occurred while extracting json data from entity"));
     }
 
-    @Test
-    public void testGetProperty() {
-        BStruct inRequest = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageHttp, inReqStruct);
-        BString propertyName = new BString("wso2");
-        BValue[] inputArg = {inRequest, propertyName};
-        BValue[] returnVals = BRunUtil.invoke(result, "testGetProperty", inputArg);
-        Assert.assertFalse(returnVals == null || returnVals.length == 0 || returnVals[0] == null,
-                "Invalid Return Values.");
-        Assert.assertNull(returnVals[0].stringValue());
-    }
-
     @Test(description = "Test getEntity method on a inRequest without a entity")
     public void testGetEntityNegative() {
         BStruct inRequest = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageHttp, inReqStruct);

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/inbound/request/InRequestNativeFunctionSuccessTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/inbound/request/InRequestNativeFunctionSuccessTest.java
@@ -82,6 +82,19 @@ public class InRequestNativeFunctionSuccessTest {
         serviceResult = BServiceUtil.setupProgramFile(this, sourceFilePath);
     }
 
+    @Test(description = "Test the protocol value of request struct within a service")
+    public void testGetProtocolFromRequest() {
+        String protocolValue = "http";
+        String path = "/hello/getProtocol";
+        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
+        inRequestMsg.setProperty(HttpConstants.PROTOCOL, protocolValue);
+        HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        BJSON bJson = new BJSON(new HttpMessageDataStreamer(response).getInputStream());
+        Assert.assertEquals(bJson.value().get("protocol").asText(), protocolValue);
+    }
+
     @Test(description = "Test getBinaryPayload method of the request")
     public void testGetBinaryPayloadMethod() {
         BStruct inRequest = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageHttp, inReqStruct);
@@ -219,36 +232,6 @@ public class InRequestNativeFunctionSuccessTest {
         HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
         Assert.assertNotNull(response, "Response message not found");
         Assert.assertEquals(new BJSON(ResponseReader.getReturnValue(response)).value().stringValue(), value);
-    }
-
-    @Test
-    public void testGetProperty() {
-        BStruct inRequest = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageHttp, inReqStruct);
-        HTTPCarbonMessage inRequestMsg = HttpUtil.createHttpCarbonMessage(true);
-        String propertyName = "wso2";
-        String propertyValue = "Ballerina";
-        inRequestMsg.setProperty(propertyName, propertyValue);
-        HttpUtil.addCarbonMsg(inRequest, inRequestMsg);
-        BString name = new BString(propertyName);
-        BValue[] inputArg = {inRequest, name};
-        BValue[] returnVals = BRunUtil.invoke(result, "testGetProperty", inputArg);
-        Assert.assertFalse(returnVals == null || returnVals.length == 0 || returnVals[0] == null,
-                "Invalid Return Values.");
-        Assert.assertEquals(returnVals[0].stringValue(), propertyValue);
-    }
-
-    @Test(description = "Test GetProperty function within a service")
-    public void testServiceGetProperty() {
-        String propertyName = "wso2";
-        String propertyValue = "Ballerina";
-        String path = "/hello/GetProperty";
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
-        inRequestMsg.setProperty(propertyName, propertyValue);
-        HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
-
-        Assert.assertNotNull(response, "Response message not found");
-        BJSON bJson = new BJSON(new HttpMessageDataStreamer(response).getInputStream());
-        Assert.assertEquals(bJson.value().get("value").asText(), propertyValue);
     }
 
     @Test

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/outbound/request/OutRequestNativeFunctionSuccessTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/outbound/request/OutRequestNativeFunctionSuccessTest.java
@@ -251,35 +251,6 @@ public class OutRequestNativeFunctionSuccessTest {
         Assert.assertEquals(new BJSON(ResponseReader.getReturnValue(response)).value().stringValue(), value);
     }
 
-    @Test
-    public void testGetProperty() {
-        BStruct outRequest = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageHttp, outReqStruct);
-        HTTPCarbonMessage outRequestMsg = HttpUtil.createHttpCarbonMessage(true);
-        String propertyName = "wso2";
-        String propertyValue = "Ballerina";
-        outRequestMsg.setProperty(propertyName, propertyValue);
-        HttpUtil.addCarbonMsg(outRequest, outRequestMsg);
-        BString name = new BString(propertyName);
-
-        BValue[] inputArg = {outRequest, name};
-        BValue[] returnVals = BRunUtil.invoke(result, "testGetProperty", inputArg);
-        Assert.assertFalse(returnVals == null || returnVals.length == 0 || returnVals[0] == null,
-                "Invalid Return Values.");
-        Assert.assertEquals(returnVals[0].stringValue(), propertyValue);
-    }
-
-    @Test(description = "Test GetProperty function within a service")
-    public void testServiceGetProperty() {
-        String propertyValue = "Ballerina";
-        String path = "/hello/GetProperty";
-        HTTPTestRequest inRequestMsg = MessageUtils.generateHTTPMessage(path, HttpConstants.HTTP_METHOD_GET);
-        HTTPCarbonMessage response = Services.invokeNew(serviceResult, inRequestMsg);
-
-        Assert.assertNotNull(response, "Response message not found");
-        BJSON bJson = new BJSON(new HttpMessageDataStreamer(response).getInputStream());
-        Assert.assertEquals(bJson.value().get("value").asText(), propertyValue);
-    }
-
     @Test(description = "Test GetStringPayload within a function")
     public void testGetStringPayload() {
         BStruct outRequest = BCompileUtil.createAndGetStruct(result.getProgFile(), protocolPackageHttp, outReqStruct);

--- a/tests/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/connection/connection-native-function.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/connection/connection-native-function.bal
@@ -12,4 +12,16 @@ service<http> helloServer {
         http:OutResponse res = {};
         _ = conn.redirect(res, http:RedirectCode.MOVED_PERMANENTLY_301, ["location1"]);
     }
+
+    @http:resourceConfig {
+        path:"/connection",
+        methods:["GET"]
+    }
+    resource connection (http:Connection conn, http:InRequest req) {
+        http:OutResponse res = {};
+        json connectionJson = {host:conn.host, port:conn.port, remoteAddress:conn.remoteAddress};
+        res.statusCode = 200;
+        res.setJsonPayload(connectionJson);
+        _ = conn.respond(res);
+    }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/inbound/request/in-request-native-function-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/inbound/request/in-request-native-function-negative.bal
@@ -24,11 +24,6 @@ function testGetMethod (http:InRequest req) (string ) {
     return method;
 }
 
-function testGetProperty (http:InRequest req, string propertyName) (string) {
-    string payload = req.getProperty(propertyName);
-    return payload;
-}
-
 function testGetRequestURL (http:InRequest req) (string) {
     string url = req.rawPath;
     if (url == "") {

--- a/tests/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/inbound/request/in-request-native-function.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/inbound/request/in-request-native-function.bal
@@ -24,11 +24,6 @@ function testGetMethod (http:InRequest req) (string) {
     return method;
 }
 
-function testGetProperty (http:InRequest req, string propertyName) (string) {
-    string payload = req.getProperty(propertyName);
-    return payload;
-}
-
 function testGetStringPayload (http:InRequest req) (string) {
     string payload = req.getStringPayload();
     return payload;
@@ -46,6 +41,16 @@ function testGetXmlPayload (http:InRequest req) (xml) {
 
 @http:configuration{basePath:"/hello"}
 service<http> helloServer {
+
+    @http:resourceConfig {
+        path:"/getProtocol"
+    }
+    resource GetProperty (http:Connection conn, http:InRequest req) {
+        http:OutResponse res = {};
+        string protocol = req.protocol;
+        res.setJsonPayload({protocol:protocol});
+        _ = conn.respond(res);
+    }
 
     @http:resourceConfig {
         path:"/11"
@@ -105,16 +110,6 @@ service<http> helloServer {
         json value = req.getJsonPayload();
         json lang = value.lang;
         res.setJsonPayload(lang);
-        _ = conn.respond(res);
-    }
-
-    @http:resourceConfig {
-        path:"/GetProperty"
-    }
-    resource GetProperty (http:Connection conn, http:InRequest req) {
-        http:OutResponse res = {};
-        string property = req.getProperty("wso2");
-        res.setJsonPayload({value:property});
         _ = conn.respond(res);
     }
 

--- a/tests/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/outbound/request/out-request-native-function.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/outbound/request/out-request-native-function.bal
@@ -28,11 +28,6 @@ function testGetJsonPayload (http:OutRequest req) (json) {
     return payload;
 }
 
-function testGetProperty (http:InRequest req, string propertyName) (string) {
-    string payload = req.getProperty(propertyName);
-    return payload;
-}
-
 function testGetStringPayload (http:InRequest req) (string) {
     string payload = req.getStringPayload();
     return payload;
@@ -154,19 +149,6 @@ service<http> helloServer {
 
         http:OutResponse res = {};
         res.setJsonPayload(lang);
-        _ = conn.respond(res);
-    }
-
-    @http:resourceConfig {
-        path:"/GetProperty"
-    }
-    resource GetProperty (http:Connection conn, http:InRequest inReq) {
-        http:OutRequest req = {};
-        req.setProperty("wso2", "Ballerina");
-        string property = req.getProperty("wso2");
-
-        http:OutResponse res = {};
-        res.setJsonPayload({value:property});
         _ = conn.respond(res);
     }
 


### PR DESCRIPTION
At the moment get- property function of the request is used to retrieve information like localAddress, RemoteAddress, port, protocol, etc.. Instead of using get property it is better to refactor request and connection structs in a way that required information can be accessed without using the get-property function. Fixes: https://github.com/ballerina-lang/ballerina/issues/5013

## Goals
Get rid of the getProperty function of the request.

## Approach
Populate relevant structs including missing fields.

## Automation tests
 - Unit tests -Yes 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes