### PR TITLE
Add native functions to access addresses

### DIFF
--- a/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
@@ -97,6 +97,16 @@ public native function <InRequest req> getProperty (string propertyName) (string
 @Return {value:"A map of matrix paramters which can be found for a given path"}
 public native function <InRequest req> getMatrixParams (string path) (map);
 
+@Description {value:" Gets the string representation of the address of the remote host"}
+@Param {value:"req: The inbound request message"}
+@Return {value:" String representation of the address of the remote server"}
+public native function <InRequest req> getRemoteAddress () (string);
+
+@Description {value:" Gets the string representation of the address of the local server host"}
+@Param {value:"req: The inbound request message"}
+@Return {value:" String representation of the address of the local server"}
+public native function <InRequest req> getLocalAddress () (string);
+
 @Description {value:"Represents an HTTP outbound request message"}
 public struct OutRequest {
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/inbound/request/GetLocalAddress.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/inbound/request/GetLocalAddress.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.net.http.nativeimpl.inbound.request;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BString;
+import org.ballerinalang.model.values.BStruct;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.natives.annotations.ReturnType;
+import org.ballerinalang.net.http.HttpConstants;
+import org.ballerinalang.net.http.HttpUtil;
+import org.ballerinalang.util.exceptions.BallerinaException;
+import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+
+import java.net.InetSocketAddress;
+
+/**
+ * Get the local server address from the request.
+ *
+ * @since 0.965.0
+ */
+@BallerinaFunction(packageName = "ballerina.net.http",
+                   functionName = "getLocalAddress",
+                   receiver = @Receiver(type = TypeKind.STRUCT,
+                                        structType = "InRequest",
+                                        structPackage = "ballerina.net.http"),
+                   returnType = { @ReturnType(type = TypeKind.STRING) },
+                   isPublic = true)
+public class GetLocalAddress extends AbstractNativeFunction {
+    @Override
+    public BValue[] execute(Context context) {
+        BStruct httpMessageStruct = (BStruct) this.getRefArgument(context, 0);
+        HTTPCarbonMessage httpCarbonMessage = HttpUtil
+                .getCarbonMsg(httpMessageStruct, HttpUtil.createHttpCarbonMessage(true));
+
+        Object localAddress = httpCarbonMessage.getProperty(HttpConstants.LOCAL_ADDRESS);
+
+        if (localAddress == null) {
+            return AbstractNativeFunction.VOID_RETURN;
+        }
+
+        if (localAddress instanceof InetSocketAddress) {
+            return this.getBValues(new BString(
+                    ((InetSocketAddress) localAddress).getAddress().getHostAddress() + ":"
+                            + ((InetSocketAddress) localAddress).getPort()));
+        } else {
+            throw new BallerinaException(
+                    localAddress.getClass().getName() + " class is not valid address implementation found.");
+        }
+    }
+}

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/inbound/request/GetRemoteAddress.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/inbound/request/GetRemoteAddress.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.net.http.nativeimpl.inbound.request;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BString;
+import org.ballerinalang.model.values.BStruct;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.natives.annotations.ReturnType;
+import org.ballerinalang.net.http.HttpConstants;
+import org.ballerinalang.net.http.HttpUtil;
+import org.ballerinalang.util.exceptions.BallerinaException;
+import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+
+import java.net.InetSocketAddress;
+
+/**
+ * Get the remote address from the request.
+ *
+ * @since 0.965.0
+ */
+@BallerinaFunction(packageName = "ballerina.net.http",
+                   functionName = "getRemoteAddress",
+                   receiver = @Receiver(type = TypeKind.STRUCT,
+                                        structType = "InRequest",
+                                        structPackage = "ballerina.net.http"),
+                   returnType = { @ReturnType(type = TypeKind.STRING) },
+                   isPublic = true)
+public class GetRemoteAddress extends AbstractNativeFunction {
+    @Override
+    public BValue[] execute(Context context) {
+        BStruct httpMessageStruct = (BStruct) this.getRefArgument(context, 0);
+        HTTPCarbonMessage httpCarbonMessage = HttpUtil
+                .getCarbonMsg(httpMessageStruct, HttpUtil.createHttpCarbonMessage(true));
+
+        Object remoteAddress = httpCarbonMessage.getProperty(HttpConstants.REMOTE_ADDRESS);
+
+        if (remoteAddress == null) {
+            return AbstractNativeFunction.VOID_RETURN;
+        }
+
+        if (remoteAddress instanceof InetSocketAddress) {
+            return this.getBValues(new BString(((InetSocketAddress) remoteAddress).getAddress().getHostAddress() + ":"
+                    + ((InetSocketAddress) remoteAddress).getPort()));
+        } else {
+            throw new BallerinaException(
+                    remoteAddress.getClass().getName() + " class is not valid address implementation found.");
+        }
+    }
+}

--- a/tests/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/inbound/request/in-request-native-function.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/inbound/request/in-request-native-function.bal
@@ -156,4 +156,28 @@ service<http> helloServer {
         res.setByteChannel(byteChannel);
         _ = conn.respond(res);
     }
+
+    @http:resourceConfig {
+        path:"/remoteAddress",
+        methods:["GET"]
+    }
+    resource remoteAddress (http:Connection conn, http:InRequest req) {
+        http:OutResponse res = {};
+        string remoteAddr = req.getRemoteAddress();
+        json remoteAddressJson = {remoteAddress:remoteAddr};
+        res.setJsonPayload(remoteAddressJson);
+        _ = conn.respond(res);
+    }
+
+    @http:resourceConfig {
+        path:"/localAddress",
+        methods:["GET"]
+    }
+    resource localAddress (http:Connection conn, http:InRequest req) {
+        http:OutResponse res = {};
+        string localAddr = req.getLocalAddress();
+        json remoteAddressJson = {localAddress:localAddr};
+        res.setJsonPayload(remoteAddressJson);
+        _ = conn.respond(res);
+    }
 }


### PR DESCRIPTION
Currently, there is no way to access remote address, local address at ballerina level. This will add required native functions to access addresses from ballerina level. Fixes: https://github.com/ballerina-lang/ballerina/issues/4950

## Goals
Provide a mechanism to access remote address, local address at ballerina level.

## Approach
Add native functions to access remote address, local address at ballerina level.

## Automation tests
 - Unit tests 
   > yes

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
```java
import ballerina.net.http;

@http:configuration {
    basePath:"/hello"
}
service<http> helloServer {

    @http:resourceConfig {
        path:"/remoteAddress",
        methods:["GET"]
    }
    resource remoteAddress (http:Connection conn, http:InRequest req) {
        http:OutResponse res = {};
        string remoteAddr = req.getRemoteAddress();
        json remoteAddressJson = {remoteAddress:remoteAddr};
        res.setJsonPayload(remoteAddressJson);
        _ = conn.respond(res);
    }

    @http:resourceConfig {
        path:"/localAddress",
        methods:["GET"]
    }
    resource localAddress (http:Connection conn, http:InRequest req) {
        http:OutResponse res = {};
        string localAddr = req.getLocalAddress();
        json remoteAddressJson = {localAddress:localAddr};
        res.setJsonPayload(remoteAddressJson);
        _ = conn.respond(res);
    }
}
```