### PR TITLE
Add Injected flag for import package node

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/ImportPackageNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/ImportPackageNode.java
@@ -37,4 +37,8 @@ public interface ImportPackageNode extends Node, TopLevelNode {
     IdentifierNode getAlias();
 
     void setAlias(IdentifierNode aliasNode);
+    
+    boolean isInjected();
+    
+    void setInjected(boolean injected);
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/PackageLoader.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/PackageLoader.java
@@ -114,7 +114,7 @@ public class PackageLoader {
         }
 
         // Add runtime and transaction packages.
-        addImportPkg(bLangPackage, Names.RUNTIME_PACKAGE.value);
+        addImportPkg(bLangPackage, Names.RUNTIME_PACKAGE.value, true);
 
         // Define Package
         definePackage(pkgId, bLangPackage);
@@ -176,7 +176,7 @@ public class PackageLoader {
         return this.parser.parse(pkgSource);
     }
 
-    private void addImportPkg(BLangPackage bLangPackage, String sourcePkgName) {
+    private void addImportPkg(BLangPackage bLangPackage, String sourcePkgName, boolean injected) {
         List<Name> nameComps = getPackageNameComps(sourcePkgName);
         List<BLangIdentifier> pkgNameComps = new ArrayList<>();
         nameComps.forEach(comp -> {
@@ -194,6 +194,7 @@ public class PackageLoader {
         importDcl.pkgNameComps = pkgNameComps;
         importDcl.orgName = orgNameNode;
         importDcl.version = versionNode;
+        importDcl.injected = injected;
         BLangIdentifier alias = (BLangIdentifier) TreeBuilder.createIdentifierNode();
         alias.setValue(names.merge(Names.DOT, nameComps.get(nameComps.size() - 1)).value);
         importDcl.alias = alias;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangImportPackage.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangImportPackage.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
  */
 public class BLangImportPackage extends BLangNode implements ImportPackageNode {
 
+    public boolean injected;
     public List<BLangIdentifier> pkgNameComps;
     public BLangIdentifier version;
     public BLangIdentifier alias;
@@ -76,6 +77,16 @@ public class BLangImportPackage extends BLangNode implements ImportPackageNode {
     @Override
     public void accept(BLangNodeVisitor visitor) {
         visitor.visit(this);
+    }
+
+    @Override
+    public boolean isInjected() {
+        return injected;
+    }
+
+    @Override
+    public void setInjected(boolean injected) {
+        this.injected = injected;
     }
 
     @Override


### PR DESCRIPTION
## Purpose
> Add new flag (injected) to import package node in order to identify packages added implicitly

## Approach
> Via the addImport in Package loader, can specify whether the package is imported implicitly. By default this flag is false