### PR TITLE
Add multiple compiler plugin support

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -157,10 +157,6 @@ public enum DiagnosticCode {
     ITERABLE_LAMBDA_INCOMPATIBLE_TYPES("iterable.lambda.incompatible.types"),
     ITERABLE_RETURN_TYPE_MISMATCH("iterable.return.type.mismatch"),
 
-    //Error code related to annotation processors
-    COMPILER_PLUGIN_NO_PACKAGE_FOUND("compiler.plugin.no.package.found"),
-    COMPILER_PLUGIN_NO_ANNOTATIONS_FOUND_IN_PACKAGE("compiler.plugin.no.annotations.found.in.package"),
-
     // Parser error diagnostic codes
     INVALID_TOKEN("invalid.token"),
     MISSING_TOKEN("missing.token"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CompilerPluginRunner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CompilerPluginRunner.java
@@ -22,7 +22,6 @@ import org.ballerinalang.compiler.plugins.CompilerPlugin;
 import org.ballerinalang.compiler.plugins.SupportedAnnotationPackages;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.tree.AnnotationAttachmentNode;
-import org.ballerinalang.util.diagnostic.DiagnosticCode;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolEnv;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAnnotationSymbol;
@@ -231,19 +230,11 @@ public class CompilerPluginRunner extends BLangNodeVisitor {
         List<BAnnotationSymbol> annotationSymbols = new ArrayList<>();
         PackageID pkdID = new PackageID(Names.ANON_ORG, names.fromString(annPackage), Names.EMPTY);
         BPackageSymbol pkgSymbol = this.symTable.pkgSymbolMap.get(pkdID);
-        if (pkgSymbol == null) {
-            dlog.error(defaultPos, DiagnosticCode.COMPILER_PLUGIN_NO_PACKAGE_FOUND,
-                    annPackage, plugin.getClass().getName());
-            return annotationSymbols;
-        }
-
         SymbolEnv pkgEnv = symTable.pkgEnvMap.get(pkgSymbol);
-        for (BLangAnnotation annotationNode : pkgEnv.enclPkg.annotations) {
-            annotationSymbols.add((BAnnotationSymbol) annotationNode.symbol);
-        }
-
-        if (annotationSymbols.isEmpty()) {
-            dlog.error(defaultPos, DiagnosticCode.COMPILER_PLUGIN_NO_ANNOTATIONS_FOUND_IN_PACKAGE);
+        if (pkgEnv != null) {
+            for (BLangAnnotation annotationNode : pkgEnv.enclPkg.annotations) {
+                annotationSymbols.add((BAnnotationSymbol) annotationNode.symbol);
+            }
         }
         return annotationSymbols;
     }

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -367,12 +367,6 @@ error.transformer.conflicts.with.conversion=\
 error.transformer.unsupported.types=\
   incompatible types: ''{0}'' is not supported by the transformer
 
-error.compiler.plugin.no.package.found=\
-  cannot find package ''{0}'' specified in compiler plugin ''{1}''
-
-error.compiler.plugin.no.annotations.found.in.package=\
-  no annotations found in package ''{0}'' specified in compiler plugin ''{1}''
-
 # Compiler warn messages
 
 warning.redeclared.import.package=\


### PR DESCRIPTION
## Purpose
> It is not possible to register multiple compiler plugins due to validations done at current implementation.
```
cannot find package ballerinax.docker specified in the compiler plugin 
```

## Goals
> This PR removes the unnecessary validations and allow multiple compiler plugins to execute.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK 1.8, Mac OS High Sierra
 