### PR TITLE
Improve syntax highlighting

### DIFF
--- a/composer/modules/web/src/plugins/ballerina/utils/monarch-grammar.js
+++ b/composer/modules/web/src/plugins/ballerina/utils/monarch-grammar.js
@@ -45,13 +45,14 @@ export default {
                     '@controlKeywords': 'keyword.control.ballerina',
                     '@otherKeywords': 'keyword.other.ballerina',
                     '@typeKeywords': 'type.ballerina',
+                    '(documentation|deprecated)': {token: 'keyword.other.ballerina', next: '@documentation'},
                     '@default': 'identifier',
                 },
             }],
             [/[A-Z][\w\$]*/, 'type.identifier'],  // to show class names nicely
 
-            // whitespace
-            { include: '@whitespace' },
+            // comments
+            ['\s*((//).*$\n?)', 'comment'],
 
             // delimiters and operators
             [/[{}()\[\]]/, '@brackets'],
@@ -77,33 +78,29 @@ export default {
             [/[;,.]/, 'delimiter'],
 
             // strings
-            [/"([^"\\]|\\.)*$/, 'string.invalid'],  // non-teminated string
             [/"/, { token: 'string.quote', bracket: '@open', next: '@string' }],
-
-            // characters
-            [/'[^\\']'/, 'string'],
-            [/(')(@escapes)(')/, ['string', 'string.escape', 'string']],
-            [/'/, 'string.invalid'],
-        ],
-
-        comment: [
-          [/[^\/*]+/, 'comment'],
-          [/\/\*/, 'comment', '@push'], // nested comment
-          ['\\*/', 'comment', '@pop'],
-          [/[\/*]/, 'comment'],
         ],
 
         string: [
-          [/[^\\"]+/, 'string'],
-          [/@escapes/, 'string.escape'],
-          [/\\./, 'string.escape.invalid'],
-          [/"/, { token: 'string.quote', bracket: '@close', next: '@pop' }],
+            [/[^\\"]+/, 'string'],
+            [/@escapes/, 'string.escape'],
+            [/\\./, 'string.escape.invalid'],
+            [/"/, { token: 'string.quote', bracket: '@close', next: '@pop' }],
         ],
 
-        whitespace: [
-          [/[ \t\r\n]+/, 'white'],
-          [/\/\*/, 'comment', '@comment'],
-          [/\/\/.*$/, 'comment'],
-        ],
+        documentation: [
+            ['(P|R|T|F|V)({{)(.+)(}})', 
+                ['keyword.other.documentation', 'keyword.other.documentation',
+                'variable.parameter.documentation', 'keyword.other.documentation' ]
+            ],
+            ['```(.+)```', 'comment.code.documentation'],
+            ['``(.+)``', 'comment.code.documentation'],
+            ['`(.+)`', 'comment.code.documentation'],
+            ['\\\\{', 'comment.documentation'], // escaped bracket
+            ['\\\\}', 'comment.documentation'], // escaped bracket
+            ['{', '@brackets'],
+            ['}', { token: '@brackets', next: '@pop'}],
+            ['.', 'comment.documentation'],
+        ]
     },
 };

--- a/composer/modules/web/src/plugins/ballerina/utils/monarch-grammar.js
+++ b/composer/modules/web/src/plugins/ballerina/utils/monarch-grammar.js
@@ -15,7 +15,7 @@ export default {
     ],
 
     typeKeywords: [
-        'boolean', 'int', 'float', 'string', 'var', 'any', 'datatable', 'blob',
+        'boolean', 'int', 'float', 'string', 'var', 'any', 'datatable', 'table', 'blob',
         'map', 'exception', 'json', 'xml', 'xmlns', 'error', 'type',
     ],
 

--- a/tool-plugins/vscode/syntaxes/ballerina.YAML-tmLanguage
+++ b/tool-plugins/vscode/syntaxes/ballerina.YAML-tmLanguage
@@ -67,13 +67,13 @@ repository:
   keywords:
     patterns:
     - name: keyword.control.ballerina
-      match: \b(if|else|iterator|try|catch|finally|fork|join|all|some|while|throw|return|returns|break|timeout|transaction|aborted|abort|committed|failed|retries|next|bind|with|lengthof|typeof|enum)\b
+      match: \b(if|else|iterator|try|catch|finally|fork|join|all|some|while|foreach|in|throw|return|returns|break|timeout|transaction|aborted|abort|committed|failed|retries|next|bind|with|lengthof|typeof|enum)\b
 
     - name: keyword.other.ballerina
       match: \b(import|version|public|attach|as|native|documentation|lock)\b
 
     - name: storage.type.ballerina
-      match: \b(boolean|int|float|string|var|any|datatable|blob)\b
+      match: \b(boolean|int|float|string|var|any|datatable|table|blob)\b
 
     - name: storage.type.ballerina
       match: \b(map|exception|json|xml|xmlns|error)\b

--- a/tool-plugins/vscode/syntaxes/ballerina.YAML-tmLanguage
+++ b/tool-plugins/vscode/syntaxes/ballerina.YAML-tmLanguage
@@ -14,15 +14,34 @@ patterns:
     - name: entity.name.function.ballerina
       match: '([_$[:alpha:]][_$[:alnum:]]*) | (\|.+\|)'
 
-- begin: \b(documentation)\s*(\{)
+- begin: \b(documentation|deprecated)\s*(\{)
   beginCaptures:
-    '1': { name: keyword.other.ballerina }
-    '2': { name: punctuation.definition.block.ballerina }
+    '1': { name: keyword.other.ballerina.documentation }
+    '2': { name: punctuation.definition.block.ballerina.documentation }
   end: \}
   endCaptures:
-    '0': { name: punctuation.definition.block.ballerina }
+    '0': { name: punctuation.definition.block.ballerina.documentation }
   patterns:
-    - name: string.quoted.double.ballerina
+    - match: (P|R|T|F|V)({{)(.+)(}})
+      captures:
+        '1': {name: keyword.other.ballerina.documentation}
+        '2': {name: keyword.other.ballerina.documentation}
+        '3': {name: variable.parameter.ballerina.documentation}
+        '4': {name: keyword.other.ballerina.documentation}
+
+    - name: comment.block.code.ballerina.documentation
+      begin: \```
+      end: \```
+
+    - name: comment.block.code.ballerina.documentation
+      begin: \``
+      end: \``
+
+    - name: comment.block.code.ballerina.documentation
+      begin: \`
+      end: \`
+
+    - name: comment.block.ballerina.documentation
       match: .
 
 - include: '#keywords'

--- a/tool-plugins/vscode/syntaxes/ballerina.tmLanguage
+++ b/tool-plugins/vscode/syntaxes/ballerina.tmLanguage
@@ -184,7 +184,7 @@
             <key>name</key>
             <string>keyword.control.ballerina</string>
             <key>match</key>
-            <string>\b(if|else|iterator|try|catch|finally|fork|join|all|some|while|throw|return|returns|break|timeout|transaction|aborted|abort|committed|failed|retries|next|bind|with|lengthof|typeof|enum)\b</string>
+            <string>\b(if|else|iterator|try|catch|finally|fork|join|all|some|while|foreach|in|throw|return|returns|break|timeout|transaction|aborted|abort|committed|failed|retries|next|bind|with|lengthof|typeof|enum)\b</string>
           </dict>
           <dict>
             <key>name</key>
@@ -196,7 +196,7 @@
             <key>name</key>
             <string>storage.type.ballerina</string>
             <key>match</key>
-            <string>\b(boolean|int|float|string|var|any|datatable|blob)\b</string>
+            <string>\b(boolean|int|float|string|var|any|datatable|table|blob)\b</string>
           </dict>
           <dict>
             <key>name</key>

--- a/tool-plugins/vscode/syntaxes/ballerina.tmLanguage
+++ b/tool-plugins/vscode/syntaxes/ballerina.tmLanguage
@@ -39,18 +39,18 @@
       </dict>
       <dict>
         <key>begin</key>
-        <string>\b(documentation)\s*(\{)</string>
+        <string>\b(documentation|deprecated)\s*(\{)</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
           <dict>
             <key>name</key>
-            <string>keyword.other.ballerina</string>
+            <string>keyword.other.ballerina.documentation</string>
           </dict>
           <key>2</key>
           <dict>
             <key>name</key>
-            <string>punctuation.definition.block.ballerina</string>
+            <string>punctuation.definition.block.ballerina.documentation</string>
           </dict>
         </dict>
         <key>end</key>
@@ -60,14 +60,65 @@
           <key>0</key>
           <dict>
             <key>name</key>
-            <string>punctuation.definition.block.ballerina</string>
+            <string>punctuation.definition.block.ballerina.documentation</string>
           </dict>
         </dict>
         <key>patterns</key>
         <array>
           <dict>
+            <key>match</key>
+            <string>(P|R|T|F|V)({{)(.+)(}})</string>
+            <key>captures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.other.ballerina.documentation</string>
+              </dict>
+              <key>2</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.other.ballerina.documentation</string>
+              </dict>
+              <key>3</key>
+              <dict>
+                <key>name</key>
+                <string>variable.parameter.ballerina.documentation</string>
+              </dict>
+              <key>4</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.other.ballerina.documentation</string>
+              </dict>
+            </dict>
+          </dict>
+          <dict>
             <key>name</key>
-            <string>string.quoted.double.ballerina</string>
+            <string>comment.block.code.ballerina.documentation</string>
+            <key>begin</key>
+            <string>\```</string>
+            <key>end</key>
+            <string>\```</string>
+          </dict>
+          <dict>
+            <key>name</key>
+            <string>comment.block.code.ballerina.documentation</string>
+            <key>begin</key>
+            <string>\``</string>
+            <key>end</key>
+            <string>\``</string>
+          </dict>
+          <dict>
+            <key>name</key>
+            <string>comment.block.code.ballerina.documentation</string>
+            <key>begin</key>
+            <string>\`</string>
+            <key>end</key>
+            <string>\`</string>
+          </dict>
+          <dict>
+            <key>name</key>
+            <string>comment.block.ballerina.documentation</string>
             <key>match</key>
             <string>.</string>
           </dict>


### PR DESCRIPTION
## Purpose
Improve syntax highlighting on composer text editor and vscode

* Add support for documentation syntax
* Remove block comment style syntax highlighting as ballerina does not have those
* Remove unnecessary highlighting of identifiers with a capital first letter
* Multiline strings are highlighted properly. Fixes #4869
* Remove unnecessary single character highlighting
* `table` type and `foreach` `in` keywords are highlighted. Fixes #4871

![screenshot from 2018-03-08 16-45-43](https://user-images.githubusercontent.com/3872221/37149369-b5713800-22f3-11e8-9d91-c2fc0ef0691f.png)
