### PR TITLE
Support Any to Table type cast

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BLangVM.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BLangVM.java
@@ -570,6 +570,7 @@ public class BLangVM {
                 case InstructionCodes.ANY2E:
                 case InstructionCodes.ANY2T:
                 case InstructionCodes.ANY2C:
+                case InstructionCodes.ANY2DT:
                 case InstructionCodes.NULL2JSON:
                 case InstructionCodes.CHECKCAST:
                 case InstructionCodes.B2JSON:

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BTable.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BTable.java
@@ -130,7 +130,9 @@ public class BTable implements BRefType<Object>, BCollection {
     }
 
     public BStruct getNext() {
+        // Make next row the current row
         next();
+        // Create BStruct from current row
         return iterator.generateNext();
     }
 

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/ProgramFileReader.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/ProgramFileReader.java
@@ -1540,6 +1540,7 @@ public class ProgramFileReader {
                 case InstructionCodes.ANY2XML:
                 case InstructionCodes.ANY2MAP:
                 case InstructionCodes.ANY2TYPE:
+                case InstructionCodes.ANY2DT:
                 case InstructionCodes.NULL2JSON:
                 case InstructionCodes.I2F:
                 case InstructionCodes.I2S:

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -729,6 +729,10 @@ public class Types {
 
         @Override
         public BSymbol visit(BTableType t, BType s) {
+            if (s == symTable.anyType) {
+                return createCastOperatorSymbol(s, t, false, InstructionCodes.ANY2DT);
+            }
+
             return symTable.notFoundSymbol;
         }
 

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
@@ -31,6 +31,7 @@ import org.ballerinalang.model.values.BJSON;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStruct;
+import org.ballerinalang.model.values.BTable;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.util.exceptions.BLangRuntimeException;
 import org.testng.Assert;
@@ -465,6 +466,15 @@ public class TypeCastExprTest {
         Assert.assertEquals(((BJSON) returns[0]).value().toString(), "{\"home\":\"SriLanka\"}");
     }
 
+    @Test(description = "Test casting a any to table")
+    public void testAnyToTable() {
+        BValue[] returns = BRunUtil.invoke(result, "testAnyToTable", new BValue[]{});
+        Assert.assertNull(returns[1]);
+        Assert.assertTrue(returns[0] instanceof BTable);
+        Assert.assertEquals(returns[0].stringValue(), "{data: [{id:1, name:\"Jane\"}, {id:2, "
+                + "name:\"Anne\"}]}");
+    }
+
     @Test(description = "Test casting a null as any type to json")
     public void testAnyNullToJson() {
         BValue[] returns = BRunUtil.invoke(result, "testAnyNullToJson", new BValue[]{});
@@ -826,6 +836,17 @@ public class TypeCastExprTest {
         BStruct error = (BStruct) returns[1];
         String errorMsg = error.getStringField(0);
         Assert.assertEquals(errorMsg, "'string' cannot be cast to 'map'");
+    }
+
+    @Test(description = "Test error scenario in casting any to table")
+    public void testAnyToTableWithErrors() {
+        BValue[] returns = BRunUtil.invoke(result, "testAnyToTableWithErrors", new BValue[] {});
+
+        Assert.assertNull(returns[0]);
+        Assert.assertTrue(returns[1] instanceof BStruct);
+        BStruct error = (BStruct) returns[1];
+        String errorMsg = error.getStringField(0);
+        Assert.assertEquals(errorMsg, "'string' cannot be cast to 'table'");
     }
 
     // TODO:

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/any/BAnyTypeSuccessScenariosTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/any/BAnyTypeSuccessScenariosTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.model.values.BFloat;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BJSON;
 import org.ballerinalang.model.values.BRefValueArray;
+import org.ballerinalang.model.values.BTable;
 import org.ballerinalang.model.values.BValue;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -51,6 +52,24 @@ public class BAnyTypeSuccessScenariosTest {
         Assert.assertSame(returns[0].getClass(), BJSON.class);
         BJSON json = (BJSON) returns[0];
         Assert.assertEquals(json.stringValue(), "{\"PropertyName\":\"Value\"}", "Invalid json value returned.");
+    }
+
+    @Test(description = "Test any type as a return value with actual table returning")
+    public void testAnyReturnWithTable() {
+        BValue[] returns = BRunUtil.invoke(result, "tableReturnTestAsAny");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BTable.class);
+        BTable table = (BTable) returns[0];
+        Assert.assertEquals(table.stringValue(), "{data: [{id:1, name:\"Jane\"}, {id:2, name:\"Anne\"}]}");
+    }
+
+    @Test(description = "Test any type as a return value with actual table returning")
+    public void testInputAnyAsTable() {
+        BValue[] returns = BRunUtil.invoke(result, "inputAnyAsTableTest");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BTable.class);
+        BTable table = (BTable) returns[0];
+        Assert.assertEquals(table.stringValue(), "{data: [{id:1, name:\"Jane\"}, {id:2, name:\"Anne\"}]}");
     }
 
 //TODO fix below scenario - basically need to rewrite the tree in method visit(ReturnStmt returnStmt) in

--- a/tests/ballerina-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
@@ -580,3 +580,31 @@ function testErrorOnCasting() (error, error, error, error) {
 
     return err1, err2, err3, err4;
 }
+
+function testAnyToTable() (table, any) {
+    table < Employee> tb = {};
+
+    Employee e1 = {id:1, name:"Jane"};
+    Employee e2 = {id:2, name:"Anne"};
+    tb.add(e1);
+    tb.add(e2);
+
+    any anyValue = tb;
+    table casted;
+    error err;
+    casted, err = (table) anyValue;
+    return casted, err;
+}
+
+function testAnyToTableWithErrors() (table, error) {
+    any stringValue = "SomeString";
+    table casted;
+    error err;
+    casted, err = (table) stringValue;
+    return casted, err;
+}
+
+struct Employee {
+    int id;
+    string name;
+}

--- a/tests/ballerina-test/src/test/resources/test-src/types/any/any-type-success.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/any/any-type-success.bal
@@ -8,6 +8,35 @@ function jsonReturnFunction()(json) {
   return val;
 }
 
+function tableReturnTestAsAny () (any) {
+    any abc = tableReturnFunction();
+    return abc;
+}
+
+function inputAnyAsTableTest () (table) {
+    return anyToTableCastFunction(tableReturnFunction());
+}
+
+function anyToTableCastFunction (any aTable) (table) {
+    var casted, err = (table) aTable;
+    return casted;
+}
+
+function tableReturnFunction () (table) {
+    table < Employee> tb = {};
+    Employee e1 = {id:1, name:"Jane"};
+    Employee e2 = {id:2, name:"Anne"};
+    tb.add(e1);
+    tb.add(e2);
+
+    return tb;
+}
+
+struct Employee {
+    int id;
+    string name;
+}
+
 
 function anyMethodParameter() (any) {
   int i = 9;


### PR DESCRIPTION
## Purpose
Support Any to Table cast. Fixes #5039 

## Automation tests
 - Unit tests 
Provided

## Samples
```ballerina
function testCast () {
    table < Employee> tb = {};

    Employee e1 = {id:1, name:"Jane"};
    Employee e2 = {id:2, name:"Anne"};
    tb.add(e1);
    tb.add(e2);

    any something = tb;
    var t, err = (table) something;
    io:println(t);
}

```

## Test environment
JDK 8, Ubuntu 14.04
 