### PR TITLE
Update documentation highlighting

### DIFF
--- a/tool-plugins/intellij/src/main/java/org/ballerinalang/plugins/idea/BallerinaASTFactory.java
+++ b/tool-plugins/intellij/src/main/java/org/ballerinalang/plugins/idea/BallerinaASTFactory.java
@@ -60,9 +60,6 @@ public class BallerinaASTFactory extends CoreASTFactory {
         if (type == BallerinaTypes.FLOATING_POINT) {
             return new FloatingPointLiteral(type, text);
         }
-        if (type == BallerinaTypes.DOCUMENTATION_TEMPLATE_ATTRIBUTE_END) {
-            return new IdentifierPSINode(type, text);
-        }
         if (type instanceof TokenIElementType &&
                 ((TokenIElementType) type).getANTLRTokenType() == BallerinaLexer.Identifier) {
             // found an ID node; here we do not distinguish between definitions and references

--- a/tool-plugins/intellij/src/main/java/org/ballerinalang/plugins/idea/BallerinaParserDefinition.java
+++ b/tool-plugins/intellij/src/main/java/org/ballerinalang/plugins/idea/BallerinaParserDefinition.java
@@ -64,6 +64,7 @@ import org.ballerinalang.plugins.idea.psi.DefinitionNode;
 import org.ballerinalang.plugins.idea.psi.DeprecatedAttachmentNode;
 import org.ballerinalang.plugins.idea.psi.DeprecatedTextNode;
 import org.ballerinalang.plugins.idea.psi.DocumentationAttachmentNode;
+import org.ballerinalang.plugins.idea.psi.DocumentationTemplateAttributeDescriptionNode;
 import org.ballerinalang.plugins.idea.psi.DocumentationTemplateInlineCodeNode;
 import org.ballerinalang.plugins.idea.psi.DoubleBackTickDeprecatedInlineCodeNode;
 import org.ballerinalang.plugins.idea.psi.DoubleBackTickInlineCodeNode;
@@ -513,6 +514,8 @@ public class BallerinaParserDefinition implements ParserDefinition {
                 return new DoubleBackTickDeprecatedInlineCodeNode(node);
             case BallerinaParser.RULE_tripleBackTickDeprecatedInlineCode:
                 return new TripleBackTickDeprecatedInlineCodeNode(node);
+            case BallerinaParser.RULE_documentationTemplateAttributeDescription:
+                return new DocumentationTemplateAttributeDescriptionNode(node);
             default:
                 return new ANTLRPsiNode(node);
         }

--- a/tool-plugins/intellij/src/main/java/org/ballerinalang/plugins/idea/codeinsight/daemon/impl/BallerinaAnnotator.java
+++ b/tool-plugins/intellij/src/main/java/org/ballerinalang/plugins/idea/codeinsight/daemon/impl/BallerinaAnnotator.java
@@ -38,6 +38,7 @@ import org.ballerinalang.plugins.idea.psi.AnnotationReferenceNode;
 import org.ballerinalang.plugins.idea.psi.ConstantDefinitionNode;
 import org.ballerinalang.plugins.idea.psi.DeprecatedTextNode;
 import org.ballerinalang.plugins.idea.psi.DocumentationAttachmentNode;
+import org.ballerinalang.plugins.idea.psi.DocumentationTemplateAttributeDescriptionNode;
 import org.ballerinalang.plugins.idea.psi.DoubleBackTickDeprecatedInlineCodeNode;
 import org.ballerinalang.plugins.idea.psi.DoubleBackTickInlineCodeNode;
 import org.ballerinalang.plugins.idea.psi.GlobalVariableDefinitionNode;
@@ -211,11 +212,33 @@ public class BallerinaAnnotator implements Annotator {
             annotateStringLiteralTemplateEnd(element, holder);
         } else if (elementType == BallerinaTypes.DOCUMENTATION_TEMPLATE_ATTRIBUTE_START) {
             // Doc type.
+            String msg = null;
+            switch (element.getText().charAt(0)) {
+                case 'T':
+                    msg = "Receiver";
+                    break;
+                case 'P':
+                    msg = "Parameter";
+                    break;
+                case 'R':
+                    msg = "Return Value";
+                    break;
+                case 'F':
+                    msg = "Field";
+                    break;
+                case 'V':
+                    msg = "Variable";
+                    break;
+            }
             TextRange textRange = element.getTextRange();
             TextRange newTextRange = new TextRange(textRange.getStartOffset(), textRange.getEndOffset() - 2);
-            Annotation annotation = holder.createInfoAnnotation(newTextRange, null);
+            Annotation annotation = holder.createInfoAnnotation(newTextRange, msg);
             annotation.setTextAttributes(BallerinaSyntaxHighlightingColors.DOCUMENTATION_INLINE_CODE);
         } else if (element instanceof IdentifierPSINode) {
+            if (element.getParent() instanceof DocumentationTemplateAttributeDescriptionNode) {
+                Annotation annotation = holder.createInfoAnnotation(element, null);
+                annotation.setTextAttributes(BallerinaSyntaxHighlightingColors.DOCUMENTATION_INLINE_CODE);
+            }
             PsiReference reference = element.getReference();
             if (reference == null || reference instanceof RecordKeyReference) {
                 return;


### PR DESCRIPTION
## Purpose
This PR updates documentation syntax highlighting so that the parameter name is now getting highlighted.

Additionally, moving mouse over to the the attribute name will show a popup with the full name of the attribute.

![workspace 1_397](https://user-images.githubusercontent.com/4003115/37197079-3a32053c-239f-11e8-9331-c562e0bfa6dc.png)
