### PR TITLE
Cache transaction IDs

### DIFF
--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/caching/caching.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/caching/caching.bal
@@ -84,6 +84,10 @@ public function createCache (string name, int expiryTimeMillis, int capacity, fl
     return cache;
 }
 
+public function <Cache cache> hasKey (string key) returns (boolean) {
+    return cache.entries.hasKey(key);
+}
+
 @Description {value:"Returns the size of the cache."}
 @Return {value:"int: The size of the cache"}
 public function <Cache cache> size () returns (int) {
@@ -121,7 +125,7 @@ function <Cache cache> evictCache () {
 
 @Description {value:"Returns the cached value associated with the given key. Returns null if the provided key does not exist in the cache."}
 @Param {value:"key: key which is used to retrieve the cached value"}
-@Return { value:"The cached value associated with the given key" }
+@Return {value:"The cached value associated with the given key"}
 public function <Cache cache> get (string key) returns (any) {
     any value = cache.entries[key];
     if (value == null) {

--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/transactions/coordinator/2pc_commons.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/transactions/coordinator/2pc_commons.bal
@@ -418,7 +418,7 @@ function abortLocalParticipantTransaction (string transactionId, int transaction
         if (err == null) {
             txn.state = TransactionState.ABORTED;
             log:printInfo("Local participant aborted transaction: " + participatedTxnId);
-            //participatedTransactions.remove(participatedTxnId);// TODO: do not remove since we may get a msg from the initiator
+            // do not remove the transaction since we may get a msg from the initiator
         } else {
             log:printErrorCause("Local participant transaction: " + participatedTxnId + " failed to abort", err);
         }
@@ -478,7 +478,7 @@ function endTransaction (string transactionId, int transactionBlockId) returns (
         if (txn.state != TransactionState.ABORTED) {
             msg, err = commitTransaction(transactionId, transactionBlockId);
             if (err == null) {
-                //initiatedTransactions.remove(transactionId); // TODO Do not remove because we may receive an abort later
+                // do not remove the transaction since we may get a msg from the initiator
                 txn.state = TransactionState.COMMITTED;
             }
         }
@@ -512,7 +512,7 @@ function abortTransaction (string transactionId, int transactionBlockId) returns
                 return;
             }
             string participantId = getParticipantId(transactionBlockId);
-            //participatedTransactions.remove(participatedTxnId); // TODO: Do not remove since we may get a message from initiator
+            // do not remove the transaction since we may get a msg from the initiator
             txn.participants.remove(participantId);
             msg, err = abortInitiatorTransaction(transactionId, transactionBlockId);
             if(err == null) {
@@ -524,10 +524,7 @@ function abortTransaction (string transactionId, int transactionBlockId) returns
     } else {
         msg, err = abortLocalParticipantTransaction(transactionId, transactionBlockId);
     }
-    //if (err == null) {
-    //    initiatedTransactions.remove(transactionId); // TODO: Do not remove since we may get a message from a participant
-    //}
-
+    // do not remove the transaction since we may get a msg from the initiator
     return;
 }
 

--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/transactions/coordinator/2pc_commons.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/transactions/coordinator/2pc_commons.bal
@@ -336,7 +336,7 @@ function notifyRemoteParticipant (TwoPhaseCommitTransaction txn,
 
 // This function will be called by the initiator
 function commitTransaction (string transactionId, int transactionBlockId) returns (string message, error e) {
-    var txn, _ = (TwoPhaseCommitTransaction)initiatedTransactions[transactionId];
+    var txn, _ = (TwoPhaseCommitTransaction)initiatedTransactions.get(transactionId);
     if (txn == null) {
         string msg = "Transaction-Unknown. Invalid TID:" + transactionId;
         log:printError(msg);
@@ -356,7 +356,7 @@ function commitTransaction (string transactionId, int transactionBlockId) return
 
 // This function will be called by the initiator
 function abortInitiatorTransaction (string transactionId, int transactionBlockId) returns (string message, error e) {
-    var txn, _ = (TwoPhaseCommitTransaction)initiatedTransactions[transactionId];
+    var txn, _ = (TwoPhaseCommitTransaction)initiatedTransactions.get(transactionId);
     if (txn == null) {
         string msg = "Transaction-Unknown. Invalid TID:" + transactionId;
         log:printError(msg);
@@ -398,7 +398,7 @@ function abortLocalParticipantTransaction (string transactionId, int transaction
         err = {message:"Aborting local resource managers failed for transaction:" + participatedTxnId};
         return;
     }
-    var txn, _ = (TwoPhaseCommitTransaction)participatedTransactions[participatedTxnId];
+    var txn, _ = (TwoPhaseCommitTransaction)participatedTransactions.get(participatedTxnId);
     if (txn == null) {
         string msg = "Transaction-Unknown. Invalid TID:" + transactionId;
         log:printError(msg);
@@ -418,7 +418,7 @@ function abortLocalParticipantTransaction (string transactionId, int transaction
         if (err == null) {
             txn.state = TransactionState.ABORTED;
             log:printInfo("Local participant aborted transaction: " + participatedTxnId);
-            participatedTransactions.remove(participatedTxnId);
+            //participatedTransactions.remove(participatedTxnId);// TODO: do not remove since we may get a msg from the initiator
         } else {
             log:printErrorCause("Local participant transaction: " + participatedTxnId + " failed to abort", err);
         }
@@ -473,12 +473,13 @@ function endTransaction (string transactionId, int transactionBlockId) returns (
 
     // Only the initiator can end the transaction. Here we check whether the entity trying to end the transaction is
     // an initiator or just a local participant
-    if (participatedTransactions[participatedTxnId] == null && initiatedTransactions.hasKey(transactionId)) {
-        var txn, _ = (TwoPhaseCommitTransaction)initiatedTransactions[transactionId];
+    if (initiatedTransactions.hasKey(transactionId) && !participatedTransactions.hasKey(participatedTxnId)) {
+        var txn, _ = (TwoPhaseCommitTransaction)initiatedTransactions.get(transactionId);
         if (txn.state != TransactionState.ABORTED) {
             msg, err = commitTransaction(transactionId, transactionBlockId);
             if (err == null) {
-                initiatedTransactions.remove(transactionId);
+                //initiatedTransactions.remove(transactionId); // TODO Do not remove because we may receive an abort later
+                txn.state = TransactionState.COMMITTED;
             }
         }
     } // Nothing to do on endTransaction if you are a participant
@@ -501,29 +502,31 @@ documentation {
 function abortTransaction (string transactionId, int transactionBlockId) returns (string msg, error err) {
     if (initiatedTransactions.hasKey(transactionId)) {
         string participatedTxnId = getParticipatedTransactionId(transactionId, transactionBlockId);
-        if (participatedTransactions[participatedTxnId] != null) {
+        if (participatedTransactions.hasKey(participatedTxnId)) {
             // if I am a local participant, then I will remove myself because I don't want to be notified on abort,
             // and then call abort on the initiator
-            var txn, _ = (Transaction)initiatedTransactions[transactionId];
+            var txn, _ = (TwoPhaseCommitTransaction )initiatedTransactions.get(transactionId);
             boolean successful = abortResourceManagers(transactionId, transactionBlockId);
             if (!successful) {
                 err = {message:"Aborting local resource managers failed for transaction:" + participatedTxnId};
                 return;
             }
             string participantId = getParticipantId(transactionBlockId);
-            txn.participants.remove(participantId);
-            participatedTransactions.remove(participatedTxnId);
+            //participatedTransactions.remove(participatedTxnId); // TODO: Do not remove since we may get a message from initiator
             txn.participants.remove(participantId);
             msg, err = abortInitiatorTransaction(transactionId, transactionBlockId);
+            if(err == null) {
+                txn.state = TransactionState.ABORTED;
+            }
         } else {
             msg, err = abortInitiatorTransaction(transactionId, transactionBlockId);
         }
     } else {
         msg, err = abortLocalParticipantTransaction(transactionId, transactionBlockId);
     }
-    if (err == null) {
-        initiatedTransactions.remove(transactionId);
-    }
+    //if (err == null) {
+    //    initiatedTransactions.remove(transactionId); // TODO: Do not remove since we may get a message from a participant
+    //}
 
     return;
 }

--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/transactions/coordinator/service_initiator.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/transactions/coordinator/service_initiator.bal
@@ -97,7 +97,7 @@ service<http> InitiatorService {
             RegistrationRequest regReq = <RegistrationRequest, jsonToRegRequest()>(payload);
             string participantId = regReq.participantId;
             string txnId = regReq.transactionId;
-            var txn, _ = (Transaction)initiatedTransactions[txnId];
+            var txn, _ = (Transaction)initiatedTransactions.get(txnId);
 
             if (txn == null) {
                 res = respondToBadRequest("Transaction-Unknown. Invalid TID:" + txnId);

--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/transactions/coordinator/service_initiator_2pc.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/transactions/coordinator/service_initiator_2pc.bal
@@ -56,7 +56,7 @@ service<http> Initiator2pcService {
             string participantId = abortReq.participantId;
             log:printInfo("Abort received for transaction: " + transactionId + " from participant:" + participantId);
             AbortResponse abortRes;
-            var txn, _ = (TwoPhaseCommitTransaction)initiatedTransactions[transactionId];
+            var txn, _ = (TwoPhaseCommitTransaction)initiatedTransactions.get(transactionId);
             if (txn == null) {
                 res = {statusCode:404};
                 abortRes = {message:"Transaction-Unknown"};

--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/transactions/coordinator/service_participant_2pc.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/transactions/coordinator/service_participant_2pc.bal
@@ -62,7 +62,7 @@ service<http> Participant2pcService {
             string participatedTxnId = getParticipatedTransactionId(transactionId, txnBlockId);
             log:printInfo("Prepare received for transaction: " + participatedTxnId);
             PrepareResponse prepareRes;
-            var txn, _ = (TwoPhaseCommitTransaction)participatedTransactions[participatedTxnId];
+            var txn, _ = (TwoPhaseCommitTransaction)participatedTransactions.get(participatedTxnId);
             if (txn == null) {
                 res = {statusCode:404};
                 prepareRes = {message:"Transaction-Unknown"};
@@ -78,7 +78,8 @@ service<http> Participant2pcService {
                 } else {
                     res = {statusCode:500};
                     prepareRes = {message:"aborted"};
-                    participatedTransactions.remove(participatedTxnId);
+                    //participatedTransactions.remove(participatedTxnId); //TODO: do not remove since we may get a msg from the initiator
+                    txn.state = TransactionState.ABORTED;
                     log:printInfo("Aborted transaction: " + transactionId);
                 }
             }
@@ -125,7 +126,7 @@ service<http> Participant2pcService {
             log:printInfo("Notify(" + notifyReq.message + ") received for transaction: " + participatedTxnId);
 
             NotifyResponse notifyRes;
-            var txn, _ = (TwoPhaseCommitTransaction)participatedTransactions[participatedTxnId];
+            var txn, _ = (TwoPhaseCommitTransaction)participatedTransactions.get(participatedTxnId);
             if (txn == null) {
                 res = {statusCode:404};
                 notifyRes = {message:"Transaction-Unknown"};
@@ -141,6 +142,7 @@ service<http> Participant2pcService {
                         if (commitSuccessful) {
                             res = {statusCode:200};
                             notifyRes = {message:"Committed"};
+                            txn.state = TransactionState.COMMITTED;
                         } else {
                             res = {statusCode:500};
                             log:printError("Committing resource managers failed. Transaction:" + participatedTxnId);
@@ -153,13 +155,14 @@ service<http> Participant2pcService {
                     if (abortSuccessful) {
                         res = {statusCode:200};
                         notifyRes = {message:"Aborted"};
+                        txn.state = TransactionState.ABORTED;
                     } else {
                         res = {statusCode:500};
                         log:printError("Aborting resource managers failed. Transaction:" + participatedTxnId);
                         notifyRes = {message:"Failed-EOT"};
                     }
                 }
-                participatedTransactions.remove(participatedTxnId);
+                //participatedTransactions.remove(participatedTxnId);// TODO: do not remove since we may get a msg from the initiator
             }
             var j, _ = <json>notifyRes;
             res.setJsonPayload(j);

--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/transactions/coordinator/service_participant_2pc.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/transactions/coordinator/service_participant_2pc.bal
@@ -78,7 +78,7 @@ service<http> Participant2pcService {
                 } else {
                     res = {statusCode:500};
                     prepareRes = {message:"aborted"};
-                    //participatedTransactions.remove(participatedTxnId); //TODO: do not remove since we may get a msg from the initiator
+                    // do not remove the transaction since we may get a msg from the initiator
                     txn.state = TransactionState.ABORTED;
                     log:printInfo("Aborted transaction: " + transactionId);
                 }
@@ -162,7 +162,7 @@ service<http> Participant2pcService {
                         notifyRes = {message:"Failed-EOT"};
                     }
                 }
-                //participatedTransactions.remove(participatedTxnId);// TODO: do not remove since we may get a msg from the initiator
+                // do not remove the transaction since we may get a msg from the initiator
             }
             var j, _ = <json>notifyRes;
             res.setJsonPayload(j);


### PR DESCRIPTION
## Purpose
Transaction protocol messages can be received out of order and hence instead of removing the transaction, we place it in a cache for 10 minutes, and the transaction will get removed from the system after 10 minutes.