### PR TITLE
Change secret key length in AESCipherTool to 16

### DIFF
--- a/stdlib/ballerina-config/src/main/java/org/ballerinalang/config/cipher/AESCipherTool.java
+++ b/stdlib/ballerina-config/src/main/java/org/ballerinalang/config/cipher/AESCipherTool.java
@@ -37,7 +37,7 @@ import javax.crypto.spec.SecretKeySpec;
 /**
  * This tools is used to encrypt and decrypt data using AES Algorithm CBC mode and PKCS #5 padding.
  *
- * @since 0.964.0
+ * @since 0.965.0
  */
 public class AESCipherTool {
 
@@ -45,7 +45,7 @@ public class AESCipherTool {
     private static final String ALGORITHM_AES = "AES";
     private static final String ALGORITHM_SHA_256 = "SHA-256";
     private static final int IV_SIZE = 16;
-    private static final int SECRET_KEY_LENGTH = 32;
+    private static final int SECRET_KEY_LENGTH = 16; // TODO: Make this 32 again after switching to Java 9
 
     private final SecretKey secretKey;
     private final SecureRandom secureRandom;

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/config/AESCipherToolNegativeTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/config/AESCipherToolNegativeTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 /**
  * Test the AES Cipher tool negative scenarios.
  *
- * @since 0.964.0
+ * @since 0.965.0
  */
 public class AESCipherToolNegativeTest {
 

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/config/AESCipherToolTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/config/AESCipherToolTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 /**
  * Test the AES Cipher tool.
  *
- * @since 0.964.0
+ * @since 0.965.0
  */
 public class AESCipherToolTest {
 


### PR DESCRIPTION
## Purpose
> In JDK versions prior to 1.8.0_151, when using key sizes >16, the users have to download separate policy jar files to make it work. Our cipher tool uses a key size of 32. This causes test failures when the required JDK version is not present. Temporarily changing the key size to 16, until we move to Java 9. Created issue #5114 to track this.
> [https://stackoverflow.com/a/6481658/4329912](https://stackoverflow.com/a/6481658/4329912)

