### PR TITLE
Implement ref-cursor, multiple resultset return support

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/TableProvider.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/TableProvider.java
@@ -122,7 +122,9 @@ public class TableProvider {
         try {
             stmt = conn.createStatement();
             ResultSet rs = stmt.executeQuery(TableConstants.SQL_SELECT + tableName);
-            itr = new TableIterator(conn, rs, type);
+            TableResourceManager rm = new TableResourceManager(conn, stmt);
+            rm.addResultSet(rs);
+            itr = new TableIterator(rm, rs, type);
         } catch (SQLException e) {
             releaseResources(conn, stmt);
             throw new BallerinaException("error in creating iterator for table : " + e.getMessage());

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/TableResourceManager.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/TableResourceManager.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http:www.wso2.org) All Rights Reserved.
+ *  
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *     http:www.apache.orglicensesLICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.util;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * {@code {@link TableResourceManager }} is a container for a {@code {@link Connection}}, a {@code {@link Statement}}
+ * and a {@code {@link Set}} of {@code {@link ResultSet}} associated with the {@code {@link Connection}}.
+ *
+ * @since 0.965.0
+ */
+public class TableResourceManager {
+    private Connection connection;
+    private Statement statement;
+    private Set<ResultSet> resultSets;
+
+    public TableResourceManager(Connection conn, Statement stmt) {
+        this.connection = conn;
+        this.statement = stmt;
+    }
+
+    /**
+     * Close the connection and the statement.
+     *
+     * @throws SQLException if an issue occur while closing the connection or statement
+     */
+    public void releaseResources() throws SQLException {
+        if (statement != null && !statement.isClosed()) {
+            statement.close();
+            statement = null;
+        }
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+            connection = null;
+        }
+    }
+
+    /**
+     * Add a {@code {@link ResultSet}} to the Set of result sets. This {@code {@link ResultSet}} should be a one
+     * associated with the connection. If an unrelated {@code {@link ResultSet}} is added it may result in undesirable
+     * consequences as when calling {@link #gracefullyReleaseResources(boolean)} releasing resources is based on
+     * whether all the result sets are closed.
+     *
+     * @param rs the result set to be added
+     */
+    public void addResultSet(ResultSet rs) {
+        if (resultSets == null) {
+            resultSets = new HashSet<>(0);
+        }
+        this.resultSets.add(rs);
+    }
+
+    /**
+     * Add a list of {@code {@link ResultSet}} to the Set of result sets. If an unrelated {@code {@link ResultSet}}
+     * is added it may result in undesirable consequences as when calling {@link #gracefullyReleaseResources(boolean)}
+     * releasing resources is based on whether all the result sets are closed.
+     *
+     * @param resultSets the list of result sets to be added
+     */
+    public void addAllResultSets(List<ResultSet> resultSets) {
+        if (this.resultSets == null) {
+            this.resultSets = new HashSet<>(0);
+        }
+        this.resultSets.addAll(resultSets);
+    }
+
+    /**
+     * Close the statement only if all ResultSets are closed, and close the connection only if all ResultSets are
+     * closed and a transaction is not in progress.
+     *
+     * @param isInTransaction Whether a transaction is in progress
+     * @throws SQLException if an issue occur while closing the connection or statement
+     */
+    public void gracefullyReleaseResources(boolean isInTransaction) throws SQLException {
+        boolean allResultSetsClosed = true;
+        for (ResultSet rs : resultSets) {
+            if (rs != null && !rs.isClosed()) {
+                allResultSetsClosed = false;
+                break;
+            }
+        }
+        if (allResultSetsClosed) {
+            if (statement != null && !statement.isClosed()) {
+                statement.close();
+            }
+            if (!isInTransaction && connection != null && !connection.isClosed()) {
+                connection.close();
+            }
+        }
+    }
+}

--- a/composer/modules/js-tests/src/test/resources/failing/tests/ballerina-test/src/test/resources/test-src/connectors/sql/sql-actions.bal
+++ b/composer/modules/js-tests/src/test/resources/failing/tests/ballerina-test/src/test/resources/test-src/connectors/sql/sql-actions.bal
@@ -658,9 +658,9 @@ function testCallProcedureWithResultSet () (string firstName) {
                                                             0, "TEST_SQL_CONNECTOR", "SA", "", {maximumPoolSize:1});
     }
 
-    table dt = testDB.call("{call SelectPersonData()}", null, typeof ResultCustomers);
-    while (dt.hasNext()) {
-        var rs, err = (ResultCustomers)dt.getNext();
+    table[] dtArray = testDB.call("{call SelectPersonData()}", null, typeof ResultCustomers);
+    while (dtArray[0].hasNext()) {
+        var rs, err = (ResultCustomers)dtArray[0].getNext();
         firstName = rs.FIRSTNAME;
     }
     testDB.close();

--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/data/sql/natives.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/data/sql/natives.bal
@@ -20,10 +20,13 @@ package ballerina.data.sql;
 @Field {value:"sqlType: The data type of the corresponding SQL parameter"}
 @Field {value:"value: Value of paramter pass into the SQL query"}
 @Field {value:"direction: Direction of the SQL Parameter IN, OUT, or INOUT"}
+@Field {value:"structType: In case of OUT direction, if the sqlType is REFCURSOR, this represents the struct type to
+map a result row"}
 public struct Parameter {
 	Type sqlType;
 	any value;
 	Direction direction;
+	type structType;
 }
 
 @Description { value: "ConnectionProperties structs represents the properties which are used to configure DB connection pool"}
@@ -167,7 +170,8 @@ public enum Type {
 	DATETIME,
 	TIMESTAMP,
 	ARRAY,
-	STRUCT
+	STRUCT,
+	REFCURSOR
 }
 
 @Description { value:"The direction of the parameter"}
@@ -198,8 +202,8 @@ public connector ClientConnector (DB dbType, string hostOrPath, int port, string
 	@Description { value:"The call action implementation for SQL connector to invoke stored procedures/functions."}
 	@Param { value:"query: SQL query to execute" }
 	@Param { value:"parameters: Parameter array used with the SQL query" }
-	@Return { value:"Result set for the given query" }
-	native action call (string query, Parameter[] parameters, type structType) (table);
+	@Return { value:"Result set(s) for the given query" }
+	native action call (string query, Parameter[] parameters, type structType) (table[]);
 
 	@Description { value:"The select action implementation for SQL connector to select data from tables."}
 	@Param { value:"query: SQL query to execute" }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/Constants.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/Constants.java
@@ -57,6 +57,7 @@ public final class Constants {
         public static final String TIMESTAMP = "TIMESTAMP";
         public static final String ARRAY = "ARRAY";
         public static final String STRUCT = "STRUCT";
+        public static final String REFCURSOR = "REFCURSOR";
     }
 
     /**

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/SQLTransactionContext.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/SQLTransactionContext.java
@@ -38,6 +38,10 @@ public class SQLTransactionContext implements BallerinaTransactionContext {
         this.xaResource = resource;
     }
 
+    public SQLTransactionContext(Connection conn) {
+        this.conn = conn;
+    }
+
     public Connection getConnection() {
         return this.conn;
     }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/actions/AbstractSQLAction.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/actions/AbstractSQLAction.java
@@ -46,6 +46,7 @@ import org.ballerinalang.nativeimpl.actions.data.sql.Constants;
 import org.ballerinalang.nativeimpl.actions.data.sql.SQLDataIterator;
 import org.ballerinalang.nativeimpl.actions.data.sql.SQLDatasource;
 import org.ballerinalang.nativeimpl.actions.data.sql.SQLTransactionContext;
+import org.ballerinalang.util.TableResourceManager;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.ballerinalang.util.transactions.BallerinaTransactionContext;
 import org.ballerinalang.util.transactions.LocalTransactionInfo;
@@ -76,7 +77,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.TimeZone;
-
 import javax.sql.XAConnection;
 import javax.transaction.xa.XAResource;
 
@@ -105,7 +105,9 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
             stmt = getPreparedStatement(conn, datasource, processedQuery);
             createProcessedStatement(conn, stmt, parameters);
             rs = stmt.executeQuery();
-            context.setReturnValues(constructTable(context, rs, stmt, conn, structType));
+            TableResourceManager rm  = new TableResourceManager(conn, stmt);
+            rm.addResultSet(rs);
+            context.setReturnValues(constructTable(rm, context, rs, structType));
         } catch (Throwable e) {
             SQLDatasourceUtils.cleanupConnection(rs, stmt, conn, isInTransaction);
             throw new BallerinaException("execute query failed: " + e.getMessage(), e);
@@ -175,16 +177,28 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
         Connection conn = null;
         CallableStatement stmt = null;
         ResultSet rs = null;
+        List<ResultSet> resultSets;
         boolean isInTransaction = context.isInTransaction();
         try {
            conn = getDatabaseConnection(context, datasource, isInTransaction);
             stmt = getPreparedCall(conn, datasource, query, parameters);
-            createProcessedStatement(conn, stmt, parameters);
-            rs = executeStoredProc(stmt);
-            setOutParameters(stmt, parameters);
-            if (rs != null) {
-                context.setReturnValues(constructTable(context, rs, stmt, conn, structType));
-            } else {
+            createProcessedStatement(conn, stmt, parameters, datasource.getDatabaseName());
+            resultSets = executeStoredProc(stmt);
+            boolean refCursorOutParamsPresent = parameters != null && isRefCursorOutParamPresent(parameters);
+            boolean resultSetsReturned = !resultSets.isEmpty();
+            TableResourceManager rm = null;
+            if (resultSetsReturned || refCursorOutParamsPresent) {
+                rm = new TableResourceManager(conn, stmt);
+            }
+            setOutParameters(context, stmt, parameters, rm);
+            if (resultSetsReturned) {
+                rm.addAllResultSets(resultSets);
+                // If a result set has been returned from the stored procedure it needs to be pushed in to return values
+                context.setReturnValues(createBRefValueArray(resultSets, rm, context, structType));
+            } else if (!refCursorOutParamsPresent) {
+                // Even if there aren't any result sets returned from the procedure there could be ref cursors
+                // returned as OUT params. If there are present we cannot clean up the connection. If there is no
+                // returned result set or ref cursor OUT params we should cleanup the connection.
                 SQLDatasourceUtils.cleanupConnection(null, stmt, conn, isInTransaction);
                 context.setReturnValues();
             }
@@ -192,6 +206,15 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
             SQLDatasourceUtils.cleanupConnection(rs, stmt, conn, isInTransaction);
             throw new BallerinaException("execute stored procedure failed: " + e.getMessage(), e);
         }
+    }
+
+    private BRefValueArray createBRefValueArray(List<ResultSet> resultSets, TableResourceManager rm, Context context,
+            BStructType structType) throws SQLException {
+        BRefValueArray bTableRefArray = new BRefValueArray();
+        for (int i = 0; i < resultSets.size(); i++) {
+            bTableRefArray.add(i, constructTable(rm, context, resultSets.get(i), structType));
+        }
+        return bTableRefArray;
     }
 
     protected void executeBatchUpdate(Context context, SQLDatasource datasource,
@@ -212,7 +235,6 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
                     stmt.addBatch();
                 }
             } else {
-                createProcessedStatement(conn, stmt, null);
                 stmt.addBatch();
             }
             updatedCount = stmt.executeBatch();
@@ -435,7 +457,12 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
         return generatedKeys;
     }
 
-    private void createProcessedStatement(Connection conn, PreparedStatement stmt, BRefValueArray params) {
+    private void createProcessedStatement(Connection conn, PreparedStatement stmt, BRefValueArray param) {
+        createProcessedStatement(conn, stmt, param, null);
+    }
+
+    private void createProcessedStatement(Connection conn, PreparedStatement stmt, BRefValueArray params, String
+            dataSourceName) {
         if (params == null) {
             return;
         }
@@ -473,11 +500,19 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
                         default:
                             throw new BallerinaException("unsupported array type for parameter index " + index);
                         }
-                        setParameter(conn, stmt, sqlType, paramValue, direction, currentOrdinal);
+                        if (Constants.SQLDataTypes.REFCURSOR.equals(sqlType)) {
+                            setParameter(conn, stmt, sqlType, paramValue, direction, currentOrdinal, dataSourceName);
+                        } else {
+                            setParameter(conn, stmt, sqlType, paramValue, direction, currentOrdinal);
+                        }
                         currentOrdinal++;
                     }
                 } else {
-                    setParameter(conn, stmt, sqlType, value, direction, currentOrdinal);
+                    if (Constants.SQLDataTypes.REFCURSOR.equals(sqlType)) {
+                        setParameter(conn, stmt, sqlType, value, direction, currentOrdinal, dataSourceName);
+                    } else {
+                        setParameter(conn, stmt, sqlType, value, direction, currentOrdinal);
+                    }
                     currentOrdinal++;
                 }
             } else {
@@ -489,6 +524,11 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
 
     private void setParameter(Connection conn, PreparedStatement stmt, String sqlType, BValue value, int direction,
             int index) {
+        setParameter(conn, stmt, sqlType, value, direction, index, null);
+    }
+
+    private void setParameter(Connection conn, PreparedStatement stmt, String sqlType, BValue value, int direction,
+            int index, String databaseName) {
         if (sqlType == null || sqlType.isEmpty()) {
             SQLDatasourceUtils.setStringValue(stmt, value, index, direction, Types.VARCHAR);
         } else {
@@ -572,13 +612,35 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
                 SQLDatasourceUtils
                         .setUserDefinedValue(conn, stmt, value, index, direction, Types.STRUCT);
                 break;
+            case Constants.SQLDataTypes.REFCURSOR:
+                SQLDatasourceUtils.setRefCursorValue(conn, stmt, index, direction, databaseName);
+                break;
             default:
                 throw new BallerinaException("unsupported datatype as parameter: " + sqlType + " index:" + index);
             }
         }
     }
 
-    private void setOutParameters(CallableStatement stmt, BRefValueArray params) {
+    private boolean isRefCursorOutParamPresent(BRefValueArray params) {
+        boolean refCursorOutParamPresent = false;
+        int paramCount = (int) params.size();
+        for (int index = 0; index < paramCount; index++) {
+            BStruct paramValue = (BStruct) params.get(index);
+            if (paramValue != null) {
+                String sqlType = getSQLType(paramValue);
+                int direction = getParameterDirection(paramValue);
+                if (direction == Constants.QueryParamDirection.OUT && Constants.SQLDataTypes.REFCURSOR
+                        .equals(sqlType)) {
+                    refCursorOutParamPresent = true;
+                    break;
+                }
+            }
+        }
+        return refCursorOutParamPresent;
+    }
+
+    private void setOutParameters(Context context, CallableStatement stmt, BRefValueArray
+            params, TableResourceManager rm) {
         if (params == null) {
             return;
         }
@@ -590,7 +652,7 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
                 int direction = getParameterDirection(paramValue);
                 if (direction == Constants.QueryParamDirection.INOUT
                         || direction == Constants.QueryParamDirection.OUT) {
-                    setOutParameterValue(stmt, sqlType, index, paramValue);
+                    setOutParameterValue(context, stmt, sqlType, index, paramValue, rm);
                 }
             } else {
                 throw new BallerinaException("out value cannot set for null parameter with index: " + index);
@@ -598,7 +660,8 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
         }
     }
 
-    private void setOutParameterValue(CallableStatement stmt, String sqlType, int index, BStruct paramValue) {
+    private void setOutParameterValue(Context context, CallableStatement stmt, String sqlType,
+            int index, BStruct paramValue, TableResourceManager resourceManager) {
         try {
             String sqlDataType = sqlType.toUpperCase(Locale.getDefault());
             switch (sqlDataType) {
@@ -703,6 +766,19 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
                 paramValue.setRefField(1, new BString(stringValue));
             }
             break;
+            case Constants.SQLDataTypes.REFCURSOR: {
+                ResultSet rs = (ResultSet) stmt.getObject(index + 1);
+                BStructType structType = getStructType(paramValue);
+                if (structType !=  null) {
+                    resourceManager.addResultSet(rs);
+                    paramValue.setRefField(1,
+                            constructTable(resourceManager, context, rs, getStructType(paramValue)));
+                } else {
+                    throw new BallerinaException("The Struct Type for the result set pointed by the Ref Cursor cannot"
+                            + " be null");
+                }
+                break;
+            }
             default:
                 throw new BallerinaException(
                         "unsupported datatype as out/inout parameter: " + sqlType + " index:" + index);
@@ -724,26 +800,32 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
         return false;
     }
 
-    private ResultSet executeStoredProc(CallableStatement stmt) throws SQLException {
+    private List<ResultSet> executeStoredProc(CallableStatement stmt) throws SQLException {
         boolean resultAndNoUpdateCount = stmt.execute();
+        List<ResultSet> resultSets = new ArrayList<>();
         ResultSet result = null;
         while (true) {
             if (!resultAndNoUpdateCount) {
+                // Current result is an update count(not a ResultSet) or there is no result at all
                 int updateCount = stmt.getUpdateCount();
                 if (updateCount == -1) {
+                    // There is no result at all
                     break;
                 }
             } else {
+                // Current result is a ResultSet
                 result = stmt.getResultSet();
-                break;
+                resultSets.add(result);
             }
+            // This point reaches if current result was an update count. So it is needed to capture any remaining
+            // results
             try {
                 resultAndNoUpdateCount = stmt.getMoreResults(Statement.KEEP_CURRENT_RESULT);
             } catch (SQLException e) {
                 break;
             }
         }
-        return result;
+        return resultSets;
     }
 
     private Connection getDatabaseConnection(Context context, SQLDatasource datasource, boolean isInTransaction)
@@ -776,7 +858,7 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
             } else {
                 conn = datasource.getSQLConnection();
                 conn.setAutoCommit(false);
-                txContext = new SQLTransactionContext(conn, null);
+                txContext = new SQLTransactionContext(conn);
             }
             localTransactionInfo.registerTransactionContext(connectorId, txContext);
             TransactionResourceManager.getInstance().register(globalTxId, currentTxBlockId, txContext);
@@ -786,10 +868,10 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
         return conn;
     }
 
-    private BTable constructTable(Context context, ResultSet rs, Statement stmt, Connection conn,
-            BStructType structType) throws SQLException {
+    private BTable constructTable(TableResourceManager rm, Context context, ResultSet rs, BStructType structType)
+            throws SQLException {
         List<ColumnDefinition> columnDefinitions = getColumnDefinitions(rs);
-        return new BTable(new SQLDataIterator(conn, stmt, rs, utcCalendar, columnDefinitions, structType,
+        return new BTable(new SQLDataIterator(rm, rs, utcCalendar, columnDefinitions, structType,
                 Utils.getTimeStructInfo(context), Utils.getTimeZoneStructInfo(context)));
     }
 
@@ -801,6 +883,15 @@ public abstract class AbstractSQLAction extends BlockingNativeCallableUnit {
         }
         return sqlType;
 
+    }
+
+    private BStructType getStructType(BStruct parameter) {
+        BTypeValue type = (BTypeValue) parameter.getRefField(3);
+        BStructType structType = null;
+        if (type != null) {
+            structType = (BStructType) type.value();
+        }
+        return structType;
     }
 
     private int getParameterDirection(BStruct parameter) {

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/sql/SQLActionsTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/sql/SQLActionsTest.java
@@ -140,6 +140,17 @@ public class SQLActionsTest {
     }
 
     @Test(groups = "ConnectorTest")
+    public void testCallProcedureWithMultipleResultSets() {
+        BValue[] returns = BRunUtil.invoke(result, "testCallProcedureWithMultipleResultSets");
+        BString retValue = (BString) returns[0];
+        final String expected = "Peter";
+        BString retValue2 = (BString) returns[1];
+        final String expected2 = "John";
+        Assert.assertEquals(retValue.stringValue(), expected);
+        Assert.assertEquals(retValue2.stringValue(), expected2);
+    }
+
+    @Test(groups = "ConnectorTest")
     public void testQueryParameters() {
         BValue[] returns = BRunUtil.invoke(result, "testQueryParameters");
         BString retValue = (BString) returns[0];

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/table/TableTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/table/TableTest.java
@@ -588,7 +588,6 @@ public class TableTest {
     public void testTableRemoveInvalid() {
         BRunUtil.invoke(result, "testTableRemoveInvalid");
     }
-
     @AfterSuite
     public void cleanup() {
         SQLDBUtils.deleteDirectory(new File(SQLDBUtils.DB_DIRECTORY));

--- a/tests/ballerina-test/src/test/resources/datafiles/sql/SQLConnectorDataFile.sql
+++ b/tests/ballerina-test/src/test/resources/datafiles/sql/SQLConnectorDataFile.sql
@@ -49,6 +49,9 @@ insert into DataTypeTable (row_id) values (2);
 insert into Customers (firstName,lastName,registrationID,creditLimit,country)
   values ('Peter', 'Stuart', 1, 5000.75, 'USA');
 /
+insert into Customers (firstName,lastName,registrationID,creditLimit,country)
+  values ('John', 'Watson', 2, 2348.93, 'UK');
+/
 CREATE PROCEDURE InsertPersonData(IN p_RegID INTEGER, IN p_PersonName VARCHAR(50))
   MODIFIES SQL DATA
   BEGIN ATOMIC
@@ -61,6 +64,15 @@ CREATE PROCEDURE SelectPersonData()
   BEGIN ATOMIC
   DECLARE result CURSOR WITH RETURN FOR SELECT firstName FROM Customers where registrationID = 1 FOR READ ONLY;
   open result;
+  END
+/
+CREATE PROCEDURE SelectPersonDataMultiple()
+  READS SQL DATA DYNAMIC RESULT SETS 2
+  BEGIN ATOMIC
+  DECLARE result1 CURSOR WITH RETURN FOR SELECT firstName FROM Customers where registrationID = 1 FOR READ ONLY;
+  DECLARE result2 CURSOR WITH RETURN FOR SELECT firstName FROM Customers where registrationID = 2 FOR READ ONLY;
+  open result1;
+  open result2;
   END
 /
 CREATE PROCEDURE TestOutParams (IN id INT, OUT paramInt INT, OUT paramBigInt BIGINT, OUT paramFloat FLOAT,

--- a/tests/ballerina-test/src/test/resources/test-src/connectors/sql/sql-actions-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/connectors/sql/sql-actions-test.bal
@@ -221,14 +221,45 @@ function testCallProcedureWithResultSet () (string firstName) {
     var testDB = testDBEP.getConnector();
 
 
-    table dt = testDB -> call("{call SelectPersonData()}", null, typeof ResultCustomers);
-    while (dt.hasNext()) {
-    var rs, err = (ResultCustomers)dt.getNext();
+    table[] dtArray = testDB -> call("{call SelectPersonData()}", null, typeof ResultCustomers);
+    while (dtArray[0].hasNext()) {
+    var rs, err = (ResultCustomers)dtArray[0].getNext();
         firstName = rs.FIRSTNAME;
     }
     testDB -> close();
     return;
 }
+
+function testCallProcedureWithMultipleResultSets () (string firstName1, string firstName2) {
+    endpoint<sql:Client> testDBEP {
+        database: sql:DB.HSQLDB_FILE,
+        host: "./target/tempdb/",
+        port: 0,
+        name: "TEST_SQL_CONNECTOR",
+        username: "SA",
+        password: "",
+        options: {maximumPoolSize:1}
+    }
+
+    var testDB = testDBEP.getConnector();
+
+    table[] dtArray = testDB -> call("{call SelectPersonDataMultiple()}", null, typeof ResultCustomers);
+    while (dtArray[0].hasNext()) {
+        var rs, err = (ResultCustomers)dtArray[0].getNext();
+        firstName1 = rs.FIRSTNAME;
+    }
+
+    while (dtArray[1].hasNext()) {
+        var rs, err = (ResultCustomers)dtArray[1].getNext();
+        firstName2 = rs.FIRSTNAME;
+    }
+
+    testDB -> close();
+    return;
+}
+
+
+
 
 function testQueryParameters () (string firstName) {
     endpoint<sql:Client> testDBEP {


### PR DESCRIPTION
## Purpose
Provide support for REF CURSOR SQL type
Provide support for returning multiple Result Sets from a stored procedure
Fixes https://github.com/ballerina-lang/ballerina/issues/5015 and https://github.com/ballerina-lang/ballerina/issues/4069

## Approach
1. REF CUROSR Impl
A new type "REFCURSOR" was added to natives. Also for the Parameter struct which is used to pass IN/OUT/INOUT parameters, a new variable "structType" was added in order to map the result sets returned through the ref cursor.
```ballerina
public struct Parameter {
	Type sqlType;
	any value;
	Direction direction;
        type structType;
}
```

2. Returning multiple result sets from stored procedure
Previous function signature for "call" action was,
```ballerina
	native action call (string query, Parameter[] parameters, type structType) (table);
```
which returns a table representing a result set.

In order to support returning multiple result sets, the function signature was changed to the below
```ballerina
	native action call (string query, Parameter[] parameters, type structType) (table[]);
```
which returns an array of tables.

## Release note
Support for SQL Ref Cursor
Support for returning multiple Result Sets from a stored procedure

## Automation tests
 - Unit tests 
   Added for multiple result sets

## Samples

PostgreSQL ref cursor sample
```bash
CREATE FUNCTION multipleOutParamRefCursorFunction (rc_out OUT refcursor, rc_out2 OUT refcursor) RETURNS  record   
AS
'
BEGIN
    OPEN rc_out FOR SELECT * FROM employee where id=1;
    OPEN rc_out2 FOR SELECT * FROM employee where id=2;
END;
' LANGUAGE plpgsql;
```
```ballerina
struct Employee {
    float id;
    string name;
}

function multipleOutParamRefCursorFunction () {
endpoint<sql:ClientConnector> testDB {
          create sql:ClientConnector(sql:DB.POSTGRES, "localhost", 5432,
            "employeedb", "postgres", "123", {});
    }

sql:Parameter para1 = {sqlType:sql:Type.REFCURSOR, direction:sql:Direction.OUT, structType: typeof Employee};
sql:Parameter para2 = {sqlType:sql:Type.REFCURSOR, direction:sql:Direction.OUT, structType: typeof Employee};

sql:Parameter[] parameters = [para1, para2];

transaction {
any _ = testDB.call("{call multipleOutParamRefCursorFunction(?, ?)}", parameters, null);
}
var dt, err = (table) para1.value;

    while (dt.hasNext()) {
        var rs, err = (EmployeePostgre)dt.getNext();
        io:println(rs.id);
        io:println(rs.name);
    }

var dt2, err = (table) para2.value;

    while (dt2.hasNext()) {
        var rs, err = (EmployeePostgre)dt2.getNext();
        io:println(rs.id);
        io:println(rs.name);
    }

testDB.close();
}
```

Oracle ref cursor sample

```bash
create or replace procedure multipleRefCursorProc(rc out sys_refcursor, rc2 out sys_refcursor) as
begin
open rc for 'select * from employee where id = 1';
open rc2 for 'select * from employee where id = 2';
end;
```

```ballerina
struct Employee {
    float id;
    string name;
}

function testMultipleRefCursorOutParameters () {
    endpoint<sql:ClientConnector> testDB {
        create sql:ClientConnector(sql:DB.ORACLE, "localhost", 49161, "xe", "system", "oracle", {maximumPoolSize:2});
    }
    sql:Parameter para1 = {sqlType:sql:Type.REFCURSOR, direction:sql:Direction.OUT, structType: typeof Employee};
   sql:Parameter para2 = {sqlType:sql:Type.REFCURSOR, direction:sql:Direction.OUT, structType: typeof Employee};

    sql:Parameter[] parameters = [para1, para2];
    any _ = testDB.call("{call multipleRefCursorProc(?,?)}", parameters, null);

var dt, err = (table)para1.value;

    while (dt.hasNext()) {
        var rs, err = (Employee)dt.getNext();
        io:println(rs.id);
        io:println(rs.name);
    }

var dt2, err = (table)para2.value;
    while (dt2.hasNext()) {
        var rs, err = (Employee)dt2.getNext();
        io:println(rs.id);
        io:println(rs.name);
    }

    testDB.close();
}
```

## Test environment
JDK 8
PostgreSQL 10.3
Oracle 11g 