### PR TITLE
Add non listening mock service endpoint

### DIFF
--- a/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/mock/non_listening_service_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/mock/non_listening_service_endpoint.bal
@@ -1,0 +1,25 @@
+package ballerina.net.http.mock;
+
+import ballerina.net.http;
+
+@Description {value:"Mock service endpoint which does not open a listening port."}
+public struct NonListeningService {
+    string epName;
+    http:ServiceEndpointConfiguration config;
+}
+
+public function <NonListeningService ep> init (string epName, http:ServiceEndpointConfiguration config) {
+    ep.epName = epName;
+    ep.config = config;
+    ep.initEndpoint();
+}
+
+public native function <NonListeningService ep> initEndpoint ();
+
+public native function <NonListeningService ep> register (type serviceType);
+
+public native function <NonListeningService ep> start ();
+
+public native function <NonListeningService ep> getConnector () returns (http:ServerConnector);
+
+public native function <NonListeningService ep> stop ();

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/mock/nonlistening/GetConnector.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/mock/nonlistening/GetConnector.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.net.http.mock.nonlistening;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Get the ID of the connection.
+ *
+ * @since 0.966
+ */
+
+@BallerinaFunction(
+        packageName = "ballerina.net.http.mock",
+        functionName = "getConnector",
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = "NonListeningService",
+                structPackage = "ballerina.net.http.mock"),
+        returnType = {@ReturnType(type = TypeKind.CONNECTOR)},
+        isPublic = true
+)
+public class GetConnector extends org.ballerinalang.net.http.serviceendpoint.GetConnector {
+
+    @Override
+    public void execute(Context context) {
+        super.execute(context);
+    }
+}

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/mock/nonlistening/InitEndpoint.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/mock/nonlistening/InitEndpoint.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.net.http.mock.nonlistening;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+
+/**
+ * Get the ID of the connection.
+ *
+ * @since 0.966
+ */
+
+@BallerinaFunction(
+        packageName = "ballerina.net.http.mock",
+        functionName = "initEndpoint",
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = "NonListeningService",
+                structPackage = "ballerina.net.http.mock"),
+        args = {@Argument(name = "epName", type = TypeKind.STRING),
+                @Argument(name = "config", type = TypeKind.STRUCT, structType = "ServiceEndpointConfiguration")},
+        isPublic = true
+)
+public class InitEndpoint extends org.ballerinalang.net.http.serviceendpoint.InitEndpoint {
+    @Override
+    public void execute(Context context) {
+        super.execute(context);
+    }
+}

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/mock/nonlistening/Register.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/mock/nonlistening/Register.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.net.http.mock.nonlistening;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+
+/**
+ * Get the ID of the connection.
+ *
+ * @since 0.966
+ */
+
+@BallerinaFunction(
+        packageName = "ballerina.net.http.mock",
+        functionName = "register",
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = "NonListeningService",
+                structPackage = "ballerina.net.http.mock"),
+        args = {@Argument(name = "serviceType", type = TypeKind.TYPE)},
+        isPublic = true
+)
+public class Register extends org.ballerinalang.net.http.serviceendpoint.Register {
+
+    @Override
+    public void execute(Context context) {
+        super.execute(context);
+    }
+}

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/mock/nonlistening/Start.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/mock/nonlistening/Start.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.net.http.mock.nonlistening;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+
+/**
+ * Get the ID of the connection.
+ *
+ * @since 0.966
+ */
+
+@BallerinaFunction(
+        packageName = "ballerina.net.http.mock",
+        functionName = "start",
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = "NonListeningService",
+                structPackage = "ballerina.net.http.mock"),
+        isPublic = true
+)
+public class Start extends org.ballerinalang.net.http.serviceendpoint.Start {
+
+    @Override
+    public void execute(Context context) {
+        // don't want to open a port to listen, hence nothing to do
+    }
+
+}

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/mock/nonlistening/Stop.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/mock/nonlistening/Stop.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.net.http.mock.nonlistening;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+
+/**
+ * Get the ID of the connection.
+ *
+ * @since 0.966
+ */
+
+@BallerinaFunction(
+        packageName = "ballerina.net.http.mock",
+        functionName = "stop",
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = "NonListeningService",
+                structPackage = "ballerina.net.http.mock"),
+        isPublic = true
+)
+public class Stop extends org.ballerinalang.net.http.serviceendpoint.Stop {
+
+    @Override
+    public void execute(Context context) {
+        super.execute(context);
+    }
+}


### PR DESCRIPTION
## Purpose
> Adds a mock service endpoint type which does not open a port to listen. This is for unit testing purposes.