### PR TITLE
Integrate i/o apis with async functions #4717

### DIFF
--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CloseCharacterChannel.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CloseCharacterChannel.java
@@ -18,23 +18,17 @@
 package org.ballerinalang.nativeimpl.io;
 
 import org.ballerinalang.bre.Context;
-import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
+import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.model.NativeCallableUnit;
 import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.nativeimpl.io.channels.base.CharacterChannel;
 import org.ballerinalang.nativeimpl.io.events.EventContext;
-import org.ballerinalang.nativeimpl.io.events.EventManager;
 import org.ballerinalang.nativeimpl.io.events.EventResult;
-import org.ballerinalang.nativeimpl.io.events.characters.CloseCharacterChannelEvent;
 import org.ballerinalang.nativeimpl.io.utils.IOUtils;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 /**
  * Native function ballerina.io#closeCharacterChannel.
@@ -48,14 +42,26 @@ import java.util.concurrent.ExecutionException;
         returnType = {@ReturnType(type = TypeKind.STRUCT, structType = "IOError", structPackage = "ballerina.io")},
         isPublic = true
 )
-public class CloseCharacterChannel extends BlockingNativeCallableUnit {
+public class CloseCharacterChannel implements NativeCallableUnit {
 
     /**
      * The index of the CharacterChannel in ballerina.io#closeCharacterChannel().
      */
     private static final int CHARACTER_CHANNEL_INDEX = 0;
 
-    private static final Logger log = LoggerFactory.getLogger(CloseCharacterChannel.class);
+    private static EventResult closeResponse(EventResult<Boolean, EventContext> result) {
+        BStruct errorStruct = null;
+        EventContext eventContext = result.getContext();
+        Context context = eventContext.getContext();
+        CallableUnitCallback callback = eventContext.getCallback();
+        Throwable error = eventContext.getError();
+        if (null != error) {
+            errorStruct = IOUtils.createError(context, error.getMessage());
+        }
+        context.setReturnValues(errorStruct);
+        callback.notifySuccess();
+        return result;
+    }
 
     /**
      * <p>
@@ -65,24 +71,15 @@ public class CloseCharacterChannel extends BlockingNativeCallableUnit {
      * {@inheritDoc}
      */
     @Override
-    public void execute(Context context) {
-        BStruct errorStruct = null;
-        try {
-            BStruct channel = (BStruct) context.getRefArgument(CHARACTER_CHANNEL_INDEX);
-            CharacterChannel charChannel = (CharacterChannel) channel.getNativeData(IOConstants.CHARACTER_CHANNEL_NAME);
-            EventContext eventContext = new EventContext(context);
-            CloseCharacterChannelEvent closeEvent = new CloseCharacterChannelEvent(charChannel, eventContext);
-            CompletableFuture<EventResult> future = EventManager.getInstance().publish(closeEvent);
-            EventResult eventResult = future.get();
-            Throwable error = ((EventContext) eventResult.getContext()).getError();
-            if (null != error) {
-                throw new ExecutionException(error);
-            }
-        } catch (Throwable e) {
-            String message = "Failed to close the character channel:" + e.getMessage();
-            log.error(message, e);
-            errorStruct = IOUtils.createError(context, message);
-        }
-        context.setReturnValues(errorStruct);
+    public void execute(Context context, CallableUnitCallback callback) {
+        BStruct channel = (BStruct) context.getRefArgument(CHARACTER_CHANNEL_INDEX);
+        CharacterChannel charChannel = (CharacterChannel) channel.getNativeData(IOConstants.CHARACTER_CHANNEL_NAME);
+        EventContext eventContext = new EventContext(context, callback);
+        IOUtils.close(charChannel, eventContext, CloseCharacterChannel::closeResponse);
+    }
+
+    @Override
+    public boolean isBlocking() {
+        return false;
     }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CloseDelimitedRecordChannel.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CloseDelimitedRecordChannel.java
@@ -18,22 +18,17 @@
 package org.ballerinalang.nativeimpl.io;
 
 import org.ballerinalang.bre.Context;
-import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
+import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.model.NativeCallableUnit;
 import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.nativeimpl.io.channels.base.DelimitedRecordChannel;
 import org.ballerinalang.nativeimpl.io.events.EventContext;
-import org.ballerinalang.nativeimpl.io.events.EventManager;
 import org.ballerinalang.nativeimpl.io.events.EventResult;
-import org.ballerinalang.nativeimpl.io.events.records.CloseDelimitedRecordEvent;
 import org.ballerinalang.nativeimpl.io.utils.IOUtils;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Native function ballerina.io#closeTextRecordChannel.
@@ -49,14 +44,26 @@ import java.util.concurrent.CompletableFuture;
         returnType = {@ReturnType(type = TypeKind.STRUCT, structType = "IOError", structPackage = "ballerina.io")},
         isPublic = true
 )
-public class CloseDelimitedRecordChannel extends BlockingNativeCallableUnit {
+public class CloseDelimitedRecordChannel implements NativeCallableUnit {
 
     /**
      * The index of the DelimitedRecordChannel in ballerina.io#closeDelimitedRecordChannel().
      */
     private static final int RECORD_CHANNEL_INDEX = 0;
 
-    private static final Logger log = LoggerFactory.getLogger(CloseDelimitedRecordChannel.class);
+    private static EventResult closeResponse(EventResult<Boolean, EventContext> result) {
+        BStruct errorStruct = null;
+        EventContext eventContext = result.getContext();
+        Context context = eventContext.getContext();
+        CallableUnitCallback callback = eventContext.getCallback();
+        Throwable error = eventContext.getError();
+        if (null != error) {
+            errorStruct = IOUtils.createError(context, error.getMessage());
+        }
+        context.setReturnValues(errorStruct);
+        callback.notifySuccess();
+        return result;
+    }
 
     /**
      * <p>
@@ -66,25 +73,16 @@ public class CloseDelimitedRecordChannel extends BlockingNativeCallableUnit {
      * {@inheritDoc}
      */
     @Override
-    public void execute(Context context) {
-        BStruct errorStruct = null;
-        try {
-            BStruct channel = (BStruct) context.getRefArgument(RECORD_CHANNEL_INDEX);
-            DelimitedRecordChannel recordChannel = (DelimitedRecordChannel)
-                    channel.getNativeData(IOConstants.TXT_RECORD_CHANNEL_NAME);
-            EventContext eventContext = new EventContext(context);
-            CloseDelimitedRecordEvent closeEvent = new CloseDelimitedRecordEvent(recordChannel, eventContext);
-            CompletableFuture<EventResult> future = EventManager.getInstance().publish(closeEvent);
-            EventResult eventResult = future.get();
-            Throwable error = ((EventContext) eventResult.getContext()).getError();
-            if (null != error) {
-                errorStruct = IOUtils.createError(context, error.getMessage());
-            }
-        } catch (Throwable e) {
-            String message = "Failed to close the text record channel:" + e.getMessage();
-            log.error(message, e);
-            errorStruct = IOUtils.createError(context, message);
-        }
-        context.setReturnValues(errorStruct);
+    public void execute(Context context, CallableUnitCallback callback) {
+        BStruct channel = (BStruct) context.getRefArgument(RECORD_CHANNEL_INDEX);
+        DelimitedRecordChannel recordChannel = (DelimitedRecordChannel)
+                channel.getNativeData(IOConstants.TXT_RECORD_CHANNEL_NAME);
+        EventContext eventContext = new EventContext(context, callback);
+        IOUtils.close(recordChannel, eventContext, CloseDelimitedRecordChannel::closeResponse);
+    }
+
+    @Override
+    public boolean isBlocking() {
+        return false;
     }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/HasNextTextRecord.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/HasNextTextRecord.java
@@ -19,7 +19,8 @@
 package org.ballerinalang.nativeimpl.io;
 
 import org.ballerinalang.bre.Context;
-import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
+import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.model.NativeCallableUnit;
 import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BStruct;
@@ -31,7 +32,6 @@ import org.ballerinalang.nativeimpl.io.events.records.HasNextDelimitedRecordEven
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.ballerinalang.util.exceptions.BallerinaException;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -49,38 +49,47 @@ import java.util.concurrent.CompletableFuture;
         returnType = {@ReturnType(type = TypeKind.BOOLEAN)},
         isPublic = true
 )
-public class HasNextTextRecord extends BlockingNativeCallableUnit {
+public class HasNextTextRecord implements NativeCallableUnit {
     /**
      * Specifies the index which contains the byte channel in ballerina.io#hasNextTextRecord.
      */
     private static final int TXT_RECORD_CHANNEL_INDEX = 0;
 
     /**
+     * Responds whether a next record exists.
+     *
+     * @param result the result processed.
+     * @return result context.
+     */
+    private static EventResult response(EventResult<Boolean, EventContext> result) {
+        EventContext eventContext = result.getContext();
+        Context context = eventContext.getContext();
+        CallableUnitCallback callback = eventContext.getCallback();
+        Boolean response = result.getResponse();
+        context.setReturnValues(new BBoolean(response));
+        callback.notifySuccess();
+        return result;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
-    public void execute(Context context) {
-        try {
-            BBoolean hasNext;
-            BStruct channel = (BStruct) context.getRefArgument(TXT_RECORD_CHANNEL_INDEX);
-            if (channel.getNativeData(IOConstants.TXT_RECORD_CHANNEL_NAME) != null) {
-                DelimitedRecordChannel textRecordChannel =
-                        (DelimitedRecordChannel) channel.getNativeData(IOConstants.TXT_RECORD_CHANNEL_NAME);
-                EventContext eventContext = new EventContext(context);
-                HasNextDelimitedRecordEvent hasNextEvent = new HasNextDelimitedRecordEvent(textRecordChannel,
-                        eventContext);
-                CompletableFuture<EventResult> event = EventManager.getInstance().publish(hasNextEvent);
-                EventResult eventResult = event.get();
-                boolean value = (boolean) eventResult.getResponse();
-                hasNext = new BBoolean(value);
-            } else {
-                String message = "Error occurred while checking the next record availability: Null channel returned.";
-                throw new BallerinaException(message, context);
-            }
-            context.setReturnValues(hasNext);
-        } catch (Throwable e) {
-            String message = "Error occurred while querying for hasNext:" + e.getMessage();
-            throw new BallerinaException(message, context);
+    public void execute(Context context, CallableUnitCallback callback) {
+        BStruct channel = (BStruct) context.getRefArgument(TXT_RECORD_CHANNEL_INDEX);
+        if (channel.getNativeData(IOConstants.TXT_RECORD_CHANNEL_NAME) != null) {
+            DelimitedRecordChannel textRecordChannel =
+                    (DelimitedRecordChannel) channel.getNativeData(IOConstants.TXT_RECORD_CHANNEL_NAME);
+            EventContext eventContext = new EventContext(context, callback);
+            HasNextDelimitedRecordEvent hasNextEvent = new HasNextDelimitedRecordEvent(textRecordChannel,
+                    eventContext);
+            CompletableFuture<EventResult> event = EventManager.getInstance().publish(hasNextEvent);
+            event.thenApply(HasNextTextRecord::response);
         }
+    }
+
+    @Override
+    public boolean isBlocking() {
+        return false;
     }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/NextTextRecord.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/NextTextRecord.java
@@ -18,24 +18,18 @@
 package org.ballerinalang.nativeimpl.io;
 
 import org.ballerinalang.bre.Context;
-import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
+import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.model.NativeCallableUnit;
 import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BStringArray;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.nativeimpl.io.channels.base.DelimitedRecordChannel;
 import org.ballerinalang.nativeimpl.io.events.EventContext;
-import org.ballerinalang.nativeimpl.io.events.EventManager;
 import org.ballerinalang.nativeimpl.io.events.EventResult;
-import org.ballerinalang.nativeimpl.io.events.records.DelimitedRecordReadEvent;
 import org.ballerinalang.nativeimpl.io.utils.IOUtils;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 /**
  * Native function ballerina.io#nextTextRecords.
@@ -52,18 +46,11 @@ import java.util.concurrent.ExecutionException;
                 @ReturnType(type = TypeKind.STRUCT, structType = "IOError", structPackage = "ballerina.io")},
         isPublic = true
 )
-public class NextTextRecord extends BlockingNativeCallableUnit {
+public class NextTextRecord implements NativeCallableUnit {
     /**
      * Specifies the index which contains the byte channel in ballerina.io#nextTextRecord.
      */
     private static final int TXT_RECORD_CHANNEL_INDEX = 0;
-
-    /**
-     * Will be the I/O event handler.
-     */
-    private EventManager eventManager = EventManager.getInstance();
-
-    private static final Logger log = LoggerFactory.getLogger(NextTextRecord.class);
 
     /*
      * Response obtained after reading record.
@@ -71,64 +58,36 @@ public class NextTextRecord extends BlockingNativeCallableUnit {
      * @param result the result obtained after processing the record.
      * @return the response obtained after reading record.
      */
-/*
-    private static EventResult readRecordResponse(EventResult<String[], EventContext> result) {
-        BStruct errorStruct;
+    private static EventResult response(EventResult<String[], EventContext> result) {
+        BStruct errorStruct = null;
         EventContext eventContext = result.getContext();
         Context context = eventContext.getContext();
+        String[] fields = result.getResponse();
+        CallableUnitCallback callback = eventContext.getCallback();
         Throwable error = eventContext.getError();
         if (null != error) {
             errorStruct = IOUtils.createError(context, error.getMessage());
         }
-        String[] fields = result.getResponse();
+        context.setReturnValues(new BStringArray(fields), errorStruct);
+        callback.notifySuccess();
         return result;
-    }
-*/
-
-    /**
-     * Reads bytes asynchronously.
-     *
-     * @param recordChannel channel the bytes should be read from.
-     * @param context       event context.
-     * @return the fields which were read.
-     * @throws ExecutionException   errors which occur during execution.
-     * @throws InterruptedException during interrupt error.
-     */
-    private String[] readRecord(DelimitedRecordChannel recordChannel, EventContext context) throws ExecutionException,
-            InterruptedException {
-        DelimitedRecordReadEvent event = new DelimitedRecordReadEvent(recordChannel, context
-        );
-        CompletableFuture<EventResult> future = eventManager.publish(event);
-        //TODO when async functions are available this should be modified
-        //future.thenApply(NextTextRecord::readRecordResponse);
-        EventResult eventResult = future.get();
-        Throwable error = ((EventContext) eventResult.getContext()).getError();
-        if (null != error) {
-            throw new ExecutionException(error);
-        }
-        return (String[]) eventResult.getResponse();
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public void execute(Context context) {
-        BStringArray record = null;
-        BStruct errorStruct = null;
-        try {
-            BStruct channel = (BStruct) context.getRefArgument(TXT_RECORD_CHANNEL_INDEX);
+    public void execute(Context context, CallableUnitCallback callback) {
+        BStruct channel = (BStruct) context.getRefArgument(TXT_RECORD_CHANNEL_INDEX);
 
-            DelimitedRecordChannel delimitedRecordChannel = (DelimitedRecordChannel) channel.getNativeData(IOConstants
-                    .TXT_RECORD_CHANNEL_NAME);
-            EventContext eventContext = new EventContext(context);
-            String[] recordValue = readRecord(delimitedRecordChannel, eventContext);
-            record = new BStringArray(recordValue);
-        } catch (Throwable e) {
-            String message = "Error occurred while reading text records:" + e.getMessage();
-            log.error(message, e);
-            errorStruct = IOUtils.createError(context, message);
-        }
-        context.setReturnValues(record, errorStruct);
+        DelimitedRecordChannel delimitedRecordChannel = (DelimitedRecordChannel) channel.getNativeData(IOConstants
+                .TXT_RECORD_CHANNEL_NAME);
+        EventContext eventContext = new EventContext(context, callback);
+        IOUtils.read(delimitedRecordChannel, eventContext, NextTextRecord::response);
+    }
+
+    @Override
+    public boolean isBlocking() {
+        return false;
     }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/ReadCharacters.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/ReadCharacters.java
@@ -18,25 +18,19 @@
 package org.ballerinalang.nativeimpl.io;
 
 import org.ballerinalang.bre.Context;
-import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
+import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.model.NativeCallableUnit;
 import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.nativeimpl.io.channels.base.CharacterChannel;
 import org.ballerinalang.nativeimpl.io.events.EventContext;
-import org.ballerinalang.nativeimpl.io.events.EventManager;
 import org.ballerinalang.nativeimpl.io.events.EventResult;
-import org.ballerinalang.nativeimpl.io.events.characters.ReadCharactersEvent;
 import org.ballerinalang.nativeimpl.io.utils.IOUtils;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 /**
  * Native function ballerina.io#readCharacters.
@@ -52,7 +46,7 @@ import java.util.concurrent.ExecutionException;
                 @ReturnType(type = TypeKind.STRUCT, structType = "IOError", structPackage = "ballerina.io")},
         isPublic = true
 )
-public class ReadCharacters extends BlockingNativeCallableUnit {
+public class ReadCharacters implements NativeCallableUnit {
 
     /**
      * Specifies the index which contains the character channel in ballerina.lo#readCharacters.
@@ -64,52 +58,25 @@ public class ReadCharacters extends BlockingNativeCallableUnit {
      */
     private static final int NUMBER_OF_CHARS_INDEX = 0;
 
-    /**
-     * Will be the I/O event handler.
-     */
-    private EventManager eventManager = EventManager.getInstance();
-
-    private static final Logger log = LoggerFactory.getLogger(ReadCharacters.class);
-
     /*
      * Callback method of the read characters response.
      *
      * @param result the result returned as the response.
      * @return the processed event result.
-     *//*
-    private static EventResult readCharactersResponse(EventResult<Boolean, EventContext> result) {
-        BStruct errorStruct;
+     */
+    private static EventResult readCharactersResponse(EventResult<String, EventContext> result) {
+        BStruct errorStruct = null;
         EventContext eventContext = result.getContext();
         Context context = eventContext.getContext();
+        CallableUnitCallback callback = eventContext.getCallback();
+        String readChars = result.getResponse();
         Throwable error = eventContext.getError();
         if (null != error) {
             errorStruct = IOUtils.createError(context, error.getMessage());
         }
-        Boolean numberOfBytes = result.getResponse();
+        context.setReturnValues(new BString(readChars), errorStruct);
+        callback.notifySuccess();
         return result;
-    }
-    */
-
-    /**
-     * Reads characters asynchronously.
-     *
-     * @param numberOfCharacters number of characters which should be read.
-     * @param characterChannel   the channel which the characters will be read.
-     * @param context            context of the event.
-     * @return the content which is read.
-     * @throws ExecutionException   if an error occurs in the async framework.
-     * @throws InterruptedException during interrupt.
-     */
-    private String readCharacter(int numberOfCharacters, CharacterChannel characterChannel, EventContext context) throws
-            ExecutionException, InterruptedException {
-        ReadCharactersEvent event = new ReadCharactersEvent(characterChannel, numberOfCharacters, context);
-        CompletableFuture<EventResult> future = eventManager.publish(event);
-        EventResult eventResult = future.get();
-        Throwable error = ((EventContext) eventResult.getContext()).getError();
-        if (null != error) {
-            throw new ExecutionException(error);
-        }
-        return (String) eventResult.getResponse();
     }
 
     /**
@@ -120,24 +87,17 @@ public class ReadCharacters extends BlockingNativeCallableUnit {
      * {@inheritDoc}
      */
     @Override
-    public void execute(Context context) {
-        BString content = null;
-        BStruct errorStruct = null;
-        try {
-            BStruct channel = (BStruct) context.getRefArgument(CHAR_CHANNEL_INDEX);
-            long numberOfCharacters = context.getIntArgument(NUMBER_OF_CHARS_INDEX);
-            CharacterChannel characterChannel = (CharacterChannel) channel.getNativeData(IOConstants
-                    .CHARACTER_CHANNEL_NAME);
-            EventContext eventContext = new EventContext(context);
-            //TODO when async functions are available enable this
-            // IOUtils.read(characterChannel,numberOfCharacters,ReadCharacters::readCharactersResponse);
-            String readCharacters = readCharacter((int) numberOfCharacters, characterChannel, eventContext);
-            content = new BString(readCharacters);
-        } catch (Throwable e) {
-            String message = "Error occurred while reading characters:" + e.getMessage();
-            log.error(message);
-            errorStruct = IOUtils.createError(context, message);
-        }
-        context.setReturnValues(content, errorStruct);
+    public void execute(Context context, CallableUnitCallback callback) {
+        BStruct channel = (BStruct) context.getRefArgument(CHAR_CHANNEL_INDEX);
+        long numberOfCharacters = context.getIntArgument(NUMBER_OF_CHARS_INDEX);
+        CharacterChannel characterChannel = (CharacterChannel) channel.getNativeData(IOConstants
+                .CHARACTER_CHANNEL_NAME);
+        EventContext eventContext = new EventContext(context, callback);
+        IOUtils.read(characterChannel, (int) numberOfCharacters, eventContext, ReadCharacters::readCharactersResponse);
+    }
+
+    @Override
+    public boolean isBlocking() {
+        return false;
     }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/WriteCharacters.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/WriteCharacters.java
@@ -18,25 +18,19 @@
 package org.ballerinalang.nativeimpl.io;
 
 import org.ballerinalang.bre.Context;
-import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
+import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.model.NativeCallableUnit;
 import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.nativeimpl.io.channels.base.CharacterChannel;
 import org.ballerinalang.nativeimpl.io.events.EventContext;
-import org.ballerinalang.nativeimpl.io.events.EventManager;
 import org.ballerinalang.nativeimpl.io.events.EventResult;
-import org.ballerinalang.nativeimpl.io.events.characters.WriteCharactersEvent;
 import org.ballerinalang.nativeimpl.io.utils.IOUtils;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 /**
  * Native function ballerina.io#writeCharacters.
@@ -53,7 +47,7 @@ import java.util.concurrent.ExecutionException;
                 @ReturnType(type = TypeKind.STRUCT, structType = "IOError", structPackage = "ballerina.io")},
         isPublic = true
 )
-public class WriteCharacters extends BlockingNativeCallableUnit {
+public class WriteCharacters implements NativeCallableUnit {
     /**
      * Index of the content provided in ballerina.io#writeCharacters.
      */
@@ -70,47 +64,24 @@ public class WriteCharacters extends BlockingNativeCallableUnit {
     private static final int START_OFFSET_INDEX = 0;
 
     /**
-     * Will be the I/O event handler.
+     * Processors the response after reading characters.
+     *
+     * @param result the response returned after reading characters.
+     * @return the response returned from the event.
      */
-    private EventManager eventManager = EventManager.getInstance();
-
-    private static final Logger log = LoggerFactory.getLogger(WriteCharacters.class);
-
-/*
-    private static EventResult readCharactersResponse(EventResult<Integer, EventContext> result) {
-        BStruct errorStruct;
+    private static EventResult writeResponse(EventResult<Integer, EventContext> result) {
+        BStruct errorStruct = null;
         EventContext eventContext = result.getContext();
+        Integer numberOfCharactersWritten = result.getResponse();
         Context context = eventContext.getContext();
+        CallableUnitCallback callback = eventContext.getCallback();
         Throwable error = eventContext.getError();
         if (null != error) {
             errorStruct = IOUtils.createError(context, error.getMessage());
         }
-        Integer numberOfBytes = result.getResponse();
+        context.setReturnValues(new BInteger(numberOfCharactersWritten), errorStruct);
+        callback.notifySuccess();
         return result;
-    }
-*/
-
-    /**
-     * Writes characters asynchronously.
-     *
-     * @param characterChannel channel the characters should be written.
-     * @param text             the content which should be written.
-     * @param offset           the index the characters should be written.
-     * @param context          context of the event.
-     * @return the number of characters which was written.
-     * @throws ExecutionException   errors which occur during execution.
-     * @throws InterruptedException during interrupt exception.
-     */
-    private int writeCharacters(CharacterChannel characterChannel, String text, int offset, EventContext context)
-            throws ExecutionException, InterruptedException {
-        WriteCharactersEvent event = new WriteCharactersEvent(characterChannel, text, offset, context);
-        CompletableFuture<EventResult> future = eventManager.publish(event);
-        EventResult eventResult = future.get();
-        Throwable error = ((EventContext) eventResult.getContext()).getError();
-        if (null != error) {
-            throw new ExecutionException(error);
-        }
-        return (int) eventResult.getResponse();
     }
 
     /**
@@ -119,24 +90,18 @@ public class WriteCharacters extends BlockingNativeCallableUnit {
      * {@inheritDoc}
      */
     @Override
-    public void execute(Context context) {
-        int numberOfCharactersWritten = 0;
-        BStruct errorStruct = null;
-        try {
-            BStruct channel = (BStruct) context.getRefArgument(CHAR_CHANNEL_INDEX);
-            String content = context.getStringArgument(CONTENT_INDEX);
-            long startOffset = context.getIntArgument(START_OFFSET_INDEX);
-            CharacterChannel characterChannel = (CharacterChannel) channel.getNativeData(IOConstants
-                    .CHARACTER_CHANNEL_NAME);
-            EventContext eventContext = new EventContext(context);
-            //TODO when async functions are available this should be modified
-//            IOUtils.write(characterChannel,content,startOffset,WriteCharacters::readCharactersResponse);
-            numberOfCharactersWritten = writeCharacters(characterChannel, content, (int) startOffset, eventContext);
-        } catch (Throwable e) {
-            String message = "Error occurred while writing characters:" + e.getMessage();
-            log.error(message, e);
-            errorStruct = IOUtils.createError(context, message);
-        }
-        context.setReturnValues(new BInteger(numberOfCharactersWritten), errorStruct);
+    public void execute(Context context, CallableUnitCallback callback) {
+        BStruct channel = (BStruct) context.getRefArgument(CHAR_CHANNEL_INDEX);
+        String content = context.getStringArgument(CONTENT_INDEX);
+        long startOffset = context.getIntArgument(START_OFFSET_INDEX);
+        CharacterChannel characterChannel = (CharacterChannel) channel.getNativeData(IOConstants
+                .CHARACTER_CHANNEL_NAME);
+        EventContext eventContext = new EventContext(context, callback);
+        IOUtils.write(characterChannel, content, (int) startOffset, eventContext, WriteCharacters::writeResponse);
+    }
+
+    @Override
+    public boolean isBlocking() {
+        return false;
     }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/EventContext.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/EventContext.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.nativeimpl.io.events;
 
 import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.CallableUnitCallback;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -31,6 +32,10 @@ public class EventContext {
      * Holds the context which will be used to set the relevant results.
      */
     private Context context;
+    /**
+     * Callback which will be triggered upon completion.
+     */
+    private CallableUnitCallback callback;
     /**
      * Represents any error which will be thrown.
      */
@@ -45,6 +50,15 @@ public class EventContext {
 
     public EventContext(Context context) {
         this.context = context;
+    }
+
+    public EventContext(Context context, CallableUnitCallback callback) {
+        this.context = context;
+        this.callback = callback;
+    }
+
+    public CallableUnitCallback getCallback() {
+        return callback;
     }
 
     public Context getContext() {

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/bytes/ReadBytesEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/bytes/ReadBytesEvent.java
@@ -36,7 +36,7 @@ public class ReadBytesEvent implements Event {
     /**
      * Holds the name of the property which will hold a reference to the byte content.
      */
-    private static final String CONTENT_PROPERTY = "byte_content";
+    public static final String CONTENT_PROPERTY = "byte_content";
     /**
      * Buffer which will be provided to the channel.
      */

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/utils/IOUtils.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/utils/IOUtils.java
@@ -20,16 +20,23 @@ package org.ballerinalang.nativeimpl.io.utils;
 
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.bre.bvm.BLangVMStructs;
+import org.ballerinalang.model.values.BStringArray;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.nativeimpl.io.channels.base.Channel;
 import org.ballerinalang.nativeimpl.io.channels.base.CharacterChannel;
+import org.ballerinalang.nativeimpl.io.channels.base.DelimitedRecordChannel;
 import org.ballerinalang.nativeimpl.io.events.EventContext;
 import org.ballerinalang.nativeimpl.io.events.EventManager;
 import org.ballerinalang.nativeimpl.io.events.EventResult;
+import org.ballerinalang.nativeimpl.io.events.bytes.CloseByteChannelEvent;
 import org.ballerinalang.nativeimpl.io.events.bytes.ReadBytesEvent;
 import org.ballerinalang.nativeimpl.io.events.bytes.WriteBytesEvent;
+import org.ballerinalang.nativeimpl.io.events.characters.CloseCharacterChannelEvent;
 import org.ballerinalang.nativeimpl.io.events.characters.ReadCharactersEvent;
 import org.ballerinalang.nativeimpl.io.events.characters.WriteCharactersEvent;
+import org.ballerinalang.nativeimpl.io.events.records.CloseDelimitedRecordEvent;
+import org.ballerinalang.nativeimpl.io.events.records.DelimitedRecordReadEvent;
+import org.ballerinalang.nativeimpl.io.events.records.DelimitedRecordWriteEvent;
 import org.ballerinalang.util.codegen.PackageInfo;
 import org.ballerinalang.util.codegen.StructInfo;
 
@@ -149,11 +156,11 @@ public class IOUtils {
      *
      * @param characterChannel   channel the characters should be read.
      * @param numberOfCharacters the number of characters to read.
-     * @param function           the callback function which will be triggered after reading characters.
      * @param context            context of the event.
+     * @param function           the callback function which will be triggered after reading characters.
      */
-    public static void read(CharacterChannel characterChannel, int numberOfCharacters,
-                            Function<EventResult, EventResult> function, EventContext context) {
+    public static void read(CharacterChannel characterChannel, int numberOfCharacters, EventContext context
+            , Function<EventResult, EventResult> function) {
         ReadCharactersEvent event = new ReadCharactersEvent(characterChannel, numberOfCharacters, context);
         CompletableFuture<EventResult> future = EventManager.getInstance().publish(event);
         future.thenApply(function);
@@ -165,11 +172,11 @@ public class IOUtils {
      * @param characterChannel the channel the characters will be written
      * @param content          the content which will be written.
      * @param offset           if an offset should be specified while writing.
-     * @param function         callback function which should be triggered
      * @param context          context of the event.
+     * @param function         callback function which should be triggered
      */
     public static void write(CharacterChannel characterChannel, String content, int offset,
-                             Function<EventResult, EventResult> function, EventContext context) {
+                             EventContext context, Function<EventResult, EventResult> function) {
         WriteCharactersEvent event = new WriteCharactersEvent(characterChannel, content, offset, context);
         CompletableFuture<EventResult> future = EventManager.getInstance().publish(event);
         future.thenApply(function);
@@ -221,4 +228,76 @@ public class IOUtils {
         CompletableFuture<EventResult> future = EventManager.getInstance().publish(event);
         future.thenApply(function);
     }
+
+    /**
+     * Reads delimited records asynchronously.
+     *
+     * @param recordChannel channel the bytes should be read from.
+     * @param context       event context.
+     * @param function      callback function which will be triggered.
+     */
+    public static void read(DelimitedRecordChannel recordChannel, EventContext context,
+                            Function<EventResult, EventResult> function) {
+        DelimitedRecordReadEvent event = new DelimitedRecordReadEvent(recordChannel, context);
+        CompletableFuture<EventResult> future = EventManager.getInstance().publish(event);
+        future.thenApply(function);
+    }
+
+    /**
+     * Asynchronously writes delimited records to the channel.
+     *
+     * @param recordChannel channel the records should be written.
+     * @param records       the record content.
+     * @param context       event context.
+     * @param function      callback function which will be triggered.
+     */
+    public static void write(DelimitedRecordChannel recordChannel, BStringArray records, EventContext context,
+                             Function<EventResult, EventResult> function) {
+        DelimitedRecordWriteEvent recordWriteEvent = new DelimitedRecordWriteEvent(recordChannel, records, context);
+        CompletableFuture<EventResult> future = EventManager.getInstance().publish(recordWriteEvent);
+        future.thenApply(function);
+    }
+
+    /**
+     * Closes the channel asynchronously.
+     *
+     * @param byteChannel  channel which should be closed.
+     * @param eventContext context of the event.
+     * @param function     callback function which will be triggered.
+     */
+    public static void close(Channel byteChannel, EventContext eventContext,
+                      Function<EventResult, EventResult> function) {
+        CloseByteChannelEvent closeEvent = new CloseByteChannelEvent(byteChannel, eventContext);
+        CompletableFuture<EventResult> future = EventManager.getInstance().publish(closeEvent);
+        future.thenApply(function);
+    }
+
+    /**
+     * Closes the character channel asynchronously.
+     *
+     * @param charChannel  channel which should be closed.
+     * @param eventContext context of the event.
+     * @param function     callback function which will be triggered.
+     */
+    public static void close(CharacterChannel charChannel, EventContext eventContext,
+                             Function<EventResult, EventResult> function) {
+        CloseCharacterChannelEvent closeEvent = new CloseCharacterChannelEvent(charChannel, eventContext);
+        CompletableFuture<EventResult> future = EventManager.getInstance().publish(closeEvent);
+        future.thenApply(function);
+    }
+
+    /**
+     * Closes the delimited record channel asynchronously.
+     *
+     * @param charChannel  channel which should be closed.
+     * @param eventContext context of the event.
+     * @param function     callback function which will be triggered.
+     */
+    public static void close(DelimitedRecordChannel charChannel, EventContext eventContext,
+                             Function<EventResult, EventResult> function) {
+        CloseDelimitedRecordEvent closeEvent = new CloseDelimitedRecordEvent(charChannel, eventContext);
+        CompletableFuture<EventResult> future = EventManager.getInstance().publish(closeEvent);
+        future.thenApply(function);
+    }
+
 }


### PR DESCRIPTION
## Purpose
With the capabilities offered #5120 async support was introduced in ballerina level. Hence this PR would integrate the ballerina level async support with I/O APIs  

## Goals
- Introduce async I/O support from Ballerina level.
- Fix issue #4717

## Approach
Implement the existing I/O API native functions inheriting the following interface,
```
org.ballerinalang.nativeimpl.io.NativeCallableUnit
```
The function will be processed asynchronously and would notify the relevant callback.  