### PR TITLE
Fix empty return record

### DIFF
--- a/docs/ballerina-by-example/examples/character-i-o/character-i-o.bal
+++ b/docs/ballerina-by-example/examples/character-i-o/character-i-o.bal
@@ -3,10 +3,15 @@ import ballerina.io;
 @Description {value:"This function returns a CharacterChannel from a given file location according to the specified permissions and encoding."}
 function getFileCharacterChannel (string filePath, string permission, string encoding)
 (io:CharacterChannel) {
+    io:IOError err;
+    io:CharacterChannel characterChannel;
     // First we get the ByteChannel representation of the file.
     io:ByteChannel channel = io:openFile(filePath, permission);
     // Then we create a character channel from the byte channel to read content as text.
-    io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
+    characterChannel, err = io:createCharacterChannel(channel, encoding);
+    if(err != null){
+        throw err.cause;
+    }
     return characterChannel;
 }
 

--- a/docs/ballerina-by-example/examples/record-i-o/record-i-o.bal
+++ b/docs/ballerina-by-example/examples/record-i-o/record-i-o.bal
@@ -3,13 +3,22 @@ import ballerina.io;
 @Description{value:"This function will return a DelimitedRecordChannel from a given file location.The encoding is character represenation of the content in file i.e UTF-8 ASCCI. The rs is record seperator i.e newline etc. and fs is field seperator i.e comma etc."}
 function getFileRecordChannel (string filePath, string permission, string encoding,
                                string rs, string fs) (io:DelimitedRecordChannel) {
+    io:IOError err;
+    io:CharacterChannel characterChannel;
+    io:DelimitedRecordChannel delimitedRecordChannel;
     //First we get the ByteChannel representation of the file.
     io:ByteChannel channel = io:openFile(filePath, permission);
     //Then we create a character channel from the byte channel to read content as text.
-    io:CharacterChannel characterChannel = io:createCharacterChannel(channel, encoding);
+    characterChannel,err = io:createCharacterChannel(channel, encoding);
+    if(err != null){
+        throw err.cause;
+    }
     //Finally we convert the character channel to record channel
     //to read content as records.
-    io:DelimitedRecordChannel delimitedRecordChannel = io:createDelimitedRecordChannel(characterChannel, rs, fs);
+    delimitedRecordChannel, err = io:createDelimitedRecordChannel(characterChannel, rs, fs);
+    if(err != null){
+        throw err.cause;
+    }
     return delimitedRecordChannel;
 }
 

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/bytes/CloseByteChannelEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/bytes/CloseByteChannelEvent.java
@@ -59,12 +59,11 @@ public class CloseByteChannelEvent implements Event {
         try {
             channel.close();
             result = new BooleanResult(true, context);
-            return result;
         } catch (IOException e) {
             log.error("Error occurred while closing channel", e);
             context.setError(e);
             result = new BooleanResult(context);
-            return result;
         }
+        return result;
     }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/bytes/ReadBytesEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/bytes/ReadBytesEvent.java
@@ -70,12 +70,11 @@ public class ReadBytesEvent implements Event {
             byte[] content = this.content.array();
             context.getProperties().put(CONTENT_PROPERTY, content);
             result = new NumericResult(numberOfBytesRead, context);
-            return result;
         } catch (IOException e) {
             log.error("Error occurred while reading bytes", e);
             context.setError(e);
             result = new NumericResult(context);
-            return result;
         }
+        return result;
     }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/bytes/WriteBytesEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/bytes/WriteBytesEvent.java
@@ -77,12 +77,11 @@ public class WriteBytesEvent implements Event {
         try {
             int numberOfBytesWritten = byteChannel.write(writeBuffer);
             result = new NumericResult(numberOfBytesWritten, context);
-            return result;
         } catch (IOException e) {
             log.error("Error occurred while reading bytes", e);
             context.setError(e);
             result = new NumericResult(context);
-            return result;
         }
+        return result;
     }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/characters/CloseCharacterChannelEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/characters/CloseCharacterChannelEvent.java
@@ -62,12 +62,11 @@ public class CloseCharacterChannelEvent implements Event {
         try {
             channel.close();
             result = new BooleanResult(true, context);
-            return result;
         } catch (IOException e) {
             log.error("Error occurred while closing character channel", e);
             context.setError(e);
             result = new BooleanResult(context);
-            return result;
         }
+        return result;
     }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/characters/ReadCharactersEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/characters/ReadCharactersEvent.java
@@ -65,12 +65,11 @@ public class ReadCharactersEvent implements Event {
         try {
             String content = channel.read(numberOfCharacters);
             result = new AlphaResult(content, context);
-            return result;
         } catch (IOException e) {
             log.error("Error occurred while closing character channel", e);
             context.setError(e);
             result = new AlphaResult(context);
-            return result;
         }
+        return result;
     }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/characters/WriteCharactersEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/characters/WriteCharactersEvent.java
@@ -73,12 +73,11 @@ public class WriteCharactersEvent implements Event {
         try {
             int numberOfCharactersWritten = channel.write(content, offset);
             result = new NumericResult(numberOfCharactersWritten, context);
-            return result;
         } catch (IOException e) {
             log.error("Error occurred while writing characters", e);
             context.setError(e);
             result = new NumericResult(context);
-            return result;
         }
+        return result;
     }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/records/CloseDelimitedRecordEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/records/CloseDelimitedRecordEvent.java
@@ -61,12 +61,11 @@ public class CloseDelimitedRecordEvent implements Event {
         try {
             channel.close();
             result = new BooleanResult(true, context);
-            return result;
         } catch (IOException e) {
             log.error("Error occurred while closing delimited record channel", e);
             context.setError(e);
             result = new BooleanResult(context);
-            return result;
         }
+        return result;
     }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/records/DelimitedRecordReadEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/records/DelimitedRecordReadEvent.java
@@ -62,12 +62,11 @@ public class DelimitedRecordReadEvent implements Event {
         try {
             String[] content = channel.read();
             result = new AlphaCollectionResult(content, context);
-            return result;
         } catch (IOException e) {
             log.error("Error occurred while reading from record channel", e);
             context.setError(e);
             result = new AlphaCollectionResult(context);
-            return result;
         }
+        return result;
     }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/records/DelimitedRecordWriteEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/records/DelimitedRecordWriteEvent.java
@@ -68,12 +68,11 @@ public class DelimitedRecordWriteEvent implements Event {
         try {
             channel.write(content);
             result = new NumericResult(-1, context);
-            return result;
         } catch (IOException e) {
             log.error("Error occurred while reading from record channel", e);
             context.setError(e);
             result = new NumericResult(context);
-            return result;
         }
+        return result;
     }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/records/HasNextDelimitedRecordEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/records/HasNextDelimitedRecordEvent.java
@@ -23,6 +23,10 @@ import org.ballerinalang.nativeimpl.io.events.Event;
 import org.ballerinalang.nativeimpl.io.events.EventContext;
 import org.ballerinalang.nativeimpl.io.events.EventResult;
 import org.ballerinalang.nativeimpl.io.events.result.BooleanResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 
 /**
  * Validates whether there's another text record.
@@ -36,6 +40,8 @@ public class HasNextDelimitedRecordEvent implements Event {
      * Holds the context to the event.
      */
     private EventContext context;
+
+    private static final Logger log = LoggerFactory.getLogger(HasNextDelimitedRecordEvent.class);
 
     public HasNextDelimitedRecordEvent(DelimitedRecordChannel channel) {
         this.channel = channel;
@@ -51,7 +57,16 @@ public class HasNextDelimitedRecordEvent implements Event {
      */
     @Override
     public EventResult get() {
-        boolean hasNext = channel.hasNext();
-        return new BooleanResult(hasNext, context);
+        BooleanResult result;
+        try {
+            boolean hasNext = channel.hasNext();
+            result = new BooleanResult(hasNext, context);
+        } catch (IOException e) {
+            String message = "Error occurred while reading bytes for hasNext()";
+            log.error(message, e);
+            context.setError(e);
+            result = new BooleanResult(context);
+        }
+        return result;
     }
 }


### PR DESCRIPTION
## Purpose
When performing the following hasNextTextRecord the hasNextTextRecord function would return true if the last read record didn't return EoF. 

However, the proceeding call which will be made to read the record could result in EoF. In that case in a loop  hasNextTextRecord() would return true and an empty record will be retuned as a result when the Next() operation is called.

This PR would address to correct this behaviour. 

```
while (srcRecordChannel.hasNextTextRecord()) { 
}
```

## Goals
Fix return of an empty record as a result of the hasNext() operation. 

## Approach
When performing hasNextRecord() if there're no characters left in the remaining buffer, a channel I/O operation will be performed. The I/O operation will read the relevant records and update the remaining buffer if there's any content. So that these content could be used in the sequential nextRecord() operation. 

If the channel returns EoF hasNextRecord() will return false, since there's no content left in both the character buffer and the channel.