### PR TITLE
 Add taint checking for file and IO functions

### DIFF
--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/file/natives.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/file/natives.bal
@@ -75,7 +75,7 @@ public native function <File file> close ();
 @Description { value:"Retrieves the stream from a local file"}
 @Param { value:"file: The file which needs to be opened" }
 @Param { value:"accessMode: The file access mode used when opening the file" }
-public native function <File file> open (string accessMode);
+public native function <File file> open (@sensitive string accessMode);
 
 @Description { value:"Copies a file from a given location to another"}
 @Param { value:"source: File/Directory that should be copied" }
@@ -148,4 +148,4 @@ public native function <File file> list () (File[], AccessDeniedError, IOError);
 @Param { value: "file: The file to which a channel needs to be opened"}
 @Param {value:"accessMode: Specifies whether the file should be opened for reading or writing (r/w)"}
 @Return{value:"ByteChannel which will allow to perform I/O operations"}
-public native function <File file>  openChannel (string accessMode)(io:ByteChannel);
+public native function <File file>  openChannel (@sensitive string accessMode)(@tainted io:ByteChannel);

--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/io/natives.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/io/natives.bal
@@ -74,7 +74,7 @@ public struct SocketProperties {
 @Param {value:"path: path to the file location"}
 @Param {value:"accessMode: whether the file should be opened for read,write or append"}
 @Return {value:"Channel which will allow to source/sink"}
-public native function openFile (string path, string accessMode) (ByteChannel);
+public native function openFile (@sensitive string path, @sensitive string accessMode) (@tainted ByteChannel);
 
 @Description {value:"Opens a socket from a specified network location"}
 @Param {value:"host: Remote server domain/IP"}
@@ -82,14 +82,16 @@ public native function openFile (string path, string accessMode) (ByteChannel);
 @Param {value:"options: Connection stream that bridge the client and the server"}
 @Return {value:"Socket which will allow to communicate with a remote server"}
 @Return {value:"Returns an IOError if unable to open the socket connection"}
-public native function openSocket (string host, int port, SocketProperties options) (Socket, IOError);
+public native function openSocket (@sensitive string host, @sensitive int port,
+                                   SocketProperties options) (@tainted Socket, IOError);
 
 @Description {value:"Function to create a CharacterChannel from ByteChannel"}
 @Param {value:"channel: The ByteChannel to be converted"}
 @Param {value:"encoding: The charset/encoding of the content (i.e UTF-8, ASCII)"}
 @Return {value:"CharacterChannel converted from ByteChannel"}
 @Return {value:"Returns an IOError if CharacterChannel could not be created"}
-public native function createCharacterChannel (ByteChannel byteChannel, string encoding) (CharacterChannel, IOError);
+public native function createCharacterChannel (ByteChannel byteChannel,
+                                               string encoding) (@tainted CharacterChannel, IOError);
 
 @Description {value:"Function to create a CharacterChannel to DelimitedRecordChannel"}
 @Param {value:"channel: The CharacterChannel to be converted"}
@@ -98,7 +100,7 @@ public native function createCharacterChannel (ByteChannel byteChannel, string e
 @Return {value:"DelimitedRecordChannel converted from CharacterChannel"}
 @Return {value:"Returns an IOError if DelimitedRecordChannel could not be created"}
 public native function createDelimitedRecordChannel (CharacterChannel channel, string recordSeparator,
-                                                     string fieldSeparator) (DelimitedRecordChannel, IOError);
+                                                     string fieldSeparator) (@tainted DelimitedRecordChannel, IOError);
 
 @Description {value:"Function to read bytes"}
 @Param {value:"channel: The ByteChannel to read bytes from"}
@@ -106,7 +108,8 @@ public native function createDelimitedRecordChannel (CharacterChannel channel, s
 @Return {value:"The bytes which were read"}
 @Return {value:"Number of bytes read"}
 @Return {value:"Returns if there's any error while performaing I/O operation"}
-public native function <ByteChannel channel> read (int numberOfBytes, int offset) (blob, int, IOError);
+public native function <ByteChannel channel> read (@sensitive int numberOfBytes, @sensitive int offset) (blob, int,
+                                                                                                         IOError);
 
 @Description {value:"Function to write bytes"}
 @Param {value:"channel: The ByteChannel to write bytes to"}
@@ -114,14 +117,14 @@ public native function <ByteChannel channel> read (int numberOfBytes, int offset
 @Param {value:"startOffset: If the bytes need to be written with an offset, the value of that offset"}
 @Return {value:"Number of bytes written"}
 @Return {value:"Returns if there's any error while performaing I/O operation"}
-public native function <ByteChannel channel> write (blob content, int startOffset, int numberOfBytes) (int, IOError);
+public native function <ByteChannel channel> write (blob content, int startOffset, int numberOfBytes)(int, IOError);
 
 @Description {value:"Function to read characters"}
 @Param {value:"channel: The CharacterChannel to read characters from"}
 @Param {value:"numberOfChars: Number of characters which should be read"}
 @Return {value:"The character sequence which was read"}
 @Return {value:"Returns if there's any error while performaing I/O operation"}
-public native function <CharacterChannel channel> readCharacters (int numberOfChars) (string, IOError);
+public native function <CharacterChannel channel> readCharacters (@sensitive int numberOfChars) (string, IOError);
 
 @Description {value:"Function to write characters"}
 @Param {value:"channel: The CharacterChannel which will allow writing characters"}
@@ -169,7 +172,8 @@ public native function <CharacterChannel channel> closeCharacterChannel () (IOEr
 @Param {value:"options: Connection stream that bridge the client and the server"}
 @Return {value:"Socket which will allow to communicate with a remote server"}
 @Return {value:"Returns an IOError if unable to open the socket connection"}
-public native function openSecureSocket (string host, int port, SocketProperties options) (Socket, IOError);
+public native function openSecureSocket (@sensitive string host, @sensitive int port,
+                                         SocketProperties options) (@tainted Socket, IOError);
 
 @Description {value:"Close the socket connection with the remote server"}
 @Param {value:"socket: The client socket connection to be to be closed"}
@@ -185,5 +189,5 @@ public native function <Socket socket> closeSocket () (IOError);
 @Param {value:"structType: Name of the struct that each record need to populate"}
 @Return {value:"table of delimited values"}
 @Return {value:"Returns if there's any error while performaing I/O operation"}
-public native function loadToTable(string filePath, string recordSeparator, string fieldSeparator,
+public native function loadToTable(@sensitive string filePath, string recordSeparator, string fieldSeparator,
                                    string encoding, boolean headerLineIncluded, type structType) (table, IOError);

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/taintchecking/connectors/IOTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/taintchecking/connectors/IOTest.java
@@ -1,0 +1,43 @@
+package org.ballerinalang.test.taintchecking.connectors;
+
+import org.ballerinalang.launcher.util.BAssertUtil;
+import org.ballerinalang.launcher.util.BCompileUtil;
+import org.ballerinalang.launcher.util.CompileResult;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Test IO related natives for taint checking operations.
+ */
+public class IOTest {
+
+    @Test
+    public void testCharacterIO() {
+        CompileResult result = BCompileUtil
+                .compile("test-src/taintchecking/connectors/character-io.bal");
+        Assert.assertTrue(result.getDiagnostics().length == 0);
+    }
+
+    @Test
+    public void testCharacterIONegative() {
+        CompileResult result = BCompileUtil
+                .compile("test-src/taintchecking/connectors/character-io-negative.bal");
+        Assert.assertTrue(result.getDiagnostics().length == 4);
+        BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'path'", 8, 43);
+        BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'accessMode'", 8, 53);
+        BAssertUtil.validateError(result, 2, "tainted value passed to sensitive parameter 'numberOfChars'", 20, 40);
+        BAssertUtil.validateError(result, 3, "tainted value passed to sensitive parameter 'sensitiveValue'", 22, 18);
+    }
+    
+    @Test
+    public void testFileIONegative() {
+        CompileResult result = BCompileUtil
+                .compile("test-src/taintchecking/connectors/file-read-negative.bal");
+        Assert.assertTrue(result.getDiagnostics().length == 5);
+        BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'accessMode'", 6, 17);
+        BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'accessMode'", 8, 50);
+        BAssertUtil.validateError(result, 2, "tainted value passed to sensitive parameter 'numberOfBytes'", 14, 34);
+        BAssertUtil.validateError(result, 3, "tainted value passed to sensitive parameter 'offset'", 14, 42);
+        BAssertUtil.validateError(result, 4, "tainted value passed to sensitive parameter 'sensitiveValue'", 16, 18);
+    }
+}

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/taintchecking/connectors/IOTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/taintchecking/connectors/IOTest.java
@@ -1,3 +1,21 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 package org.ballerinalang.test.taintchecking.connectors;
 
 import org.ballerinalang.launcher.util.BAssertUtil;

--- a/tests/ballerina-test/src/test/resources/test-src/taintchecking/connectors/character-io-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/taintchecking/connectors/character-io-negative.bal
@@ -1,0 +1,27 @@
+import ballerina.io;
+
+function main (string[] args) {
+    string filePath = args[0];
+    string permission = args[0];
+    string chars = args[0];
+
+    io:ByteChannel bchannel = io:openFile(filePath, permission);
+    io:CharacterChannel channel;
+    channel, _ = io:createCharacterChannel(bchannel, "UTF-8");
+
+    int len;
+    len, _ = channel.writeCharacters(chars, 0);
+
+    io:IOError err;
+    string text;
+
+    int readLen;
+    readLen, _ = <int>args[0];
+    text, err = channel.readCharacters(readLen);
+
+    testFunction(text, text);
+}
+
+public function testFunction (@sensitive string sensitiveValue, string anyValue) {
+
+}

--- a/tests/ballerina-test/src/test/resources/test-src/taintchecking/connectors/character-io.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/taintchecking/connectors/character-io.bal
@@ -1,0 +1,24 @@
+import ballerina.io;
+
+function main (string[] args) {
+    string filePath = "/test/path";
+    string permission = "r";
+    string chars = "data";
+
+    io:ByteChannel bchannel = io:openFile(filePath, permission);
+    io:CharacterChannel channel;
+    channel, _ = io:createCharacterChannel(bchannel, "UTF-8");
+
+    int len;
+    len, _ = channel.writeCharacters(chars, 0);
+
+    io:IOError err;
+    string text;
+    text, err = channel.readCharacters(1);
+
+    testFunction(text, text);
+}
+
+public function testFunction (string sensitiveValue, string anyValue) {
+
+}

--- a/tests/ballerina-test/src/test/resources/test-src/taintchecking/connectors/file-read-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/taintchecking/connectors/file-read-negative.bal
@@ -1,0 +1,21 @@
+import ballerina.io;
+import ballerina.file;
+
+function main (string[] args) {
+    file:File target = {path:"/tmp/result.txt"};
+    target.open(args[0]);
+
+    io:ByteChannel bchannel = target.openChannel(args[0]);
+    int intArg;
+    intArg, _ = <int> args[0];
+
+    blob data;
+    int len;
+    data, len, _ = bchannel.read(intArg, intArg);
+
+    testFunction(data, data);
+}
+
+public function testFunction (@sensitive any sensitiveValue, any anyValue) {
+
+}


### PR DESCRIPTION
## Purpose
> Currently file IO operations are not protected against tainted values. File paths, access permissions and read-lengths etc. can be derived from user input without any validation in place. This could lead to security vulnerabilities, including patch traversals and unauthorized file access, if constructs were used incorrectly. 

## Goals
> Add taint checking to file operations and IO functions. It is required to make sure only trusted data can be passed into security sensitive areas of the file and IO functions. Return values need to be correctly flagged with tainted status. 

## Approach
> Added proper taint checking annotations to the function signatures, so that paths, access rights, read lengths, read-offsets are considered sensitive (user data cannot be passed to such parameters without being validated). Users can write any value to a file (tainted or untainted), however, values read from a file is considered tainted.