### PR TITLE
Add version to PackageInfo

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/PackageInfo.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/PackageInfo.java
@@ -39,6 +39,8 @@ public class PackageInfo implements ConstantPool, AttributeInfoPool {
 
     private int pkgNameCPIndex;
     private String pkgPath;
+    private int pkgVersionCPIndex;
+    private String pkgVersion;
     private FunctionInfo initFunctionInfo, startFunctionInfo, stopFunctionInfo;
 
     private ConstantPoolEntry[] constPool;
@@ -72,9 +74,11 @@ public class PackageInfo implements ConstantPool, AttributeInfoPool {
     // cache values.
     ProgramFile programFile;
 
-    public PackageInfo(int packageNameCPIndex, String packageName) {
+    public PackageInfo(int packageNameCPIndex, String packageName, int packageVersionCPIndex, String packageVersion) {
         this.pkgNameCPIndex = packageNameCPIndex;
         this.pkgPath = packageName;
+        this.pkgVersionCPIndex = packageVersionCPIndex;
+        this.pkgVersion = packageVersion;
     }
 
     public int getPkgNameCPIndex() {
@@ -85,7 +89,13 @@ public class PackageInfo implements ConstantPool, AttributeInfoPool {
         return pkgPath;
     }
 
-    // CP
+    public int getPackageVersionCPIndex() {
+        return pkgVersionCPIndex;
+    }
+
+    public String getPackageVersion() {
+        return pkgVersion;
+    }
 
     public int addCPEntry(ConstantPoolEntry cpEntry) {
         if (constantPoolEntries.contains(cpEntry)) {

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/ProgramFileReader.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/ProgramFileReader.java
@@ -204,7 +204,10 @@ public class ProgramFileReader {
             case CP_ENTRY_PACKAGE:
                 cpIndex = dataInStream.readInt();
                 utf8CPEntry = (UTF8CPEntry) constantPool.getCPEntry(cpIndex);
-                return new PackageRefCPEntry(cpIndex, utf8CPEntry.getValue());
+                int versionCPIndex = dataInStream.readInt();
+                UTF8CPEntry utf8VersionCPEntry = (UTF8CPEntry) constantPool.getCPEntry(versionCPIndex);
+                return new PackageRefCPEntry(cpIndex, utf8CPEntry.getValue(), versionCPIndex,
+                        utf8VersionCPEntry.getValue());
 
             case CP_ENTRY_STREAMLET_REF:
                 pkgCPIndex = dataInStream.readInt();
@@ -348,7 +351,10 @@ public class ProgramFileReader {
     private void readPackageInfo(DataInputStream dataInStream) throws IOException {
         int pkgNameCPIndex = dataInStream.readInt();
         UTF8CPEntry pkgNameCPEntry = (UTF8CPEntry) programFile.getCPEntry(pkgNameCPIndex);
-        PackageInfo packageInfo = new PackageInfo(pkgNameCPIndex, pkgNameCPEntry.getValue());
+        int pkgVersionCPIndex = dataInStream.readInt();
+        UTF8CPEntry pkgVersionCPEntry = (UTF8CPEntry) programFile.getCPEntry(pkgVersionCPIndex);
+        PackageInfo packageInfo = new PackageInfo(pkgNameCPIndex, pkgNameCPEntry.getValue(), pkgVersionCPIndex,
+                pkgVersionCPEntry.getValue());
         packageInfo.setProgramFile(programFile);
         programFile.addPackageInfo(packageInfo.getPkgPath(), packageInfo);
 

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/cpentries/PackageRefCPEntry.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/cpentries/PackageRefCPEntry.java
@@ -29,15 +29,18 @@ public class PackageRefCPEntry implements ConstantPoolEntry {
     // Index of UTF8 CP entry contains the package path
     private int nameCPIndex;
     private String packageName;
+    private String packageVersion;
 
     // Index of CP entry which contains package version
     private int versionCPIndex;
 
     private PackageInfo packageInfo;
 
-    public PackageRefCPEntry(int nameCPIndex, String packageName) {
+    public PackageRefCPEntry(int nameCPIndex, String packageName, int versionCPIndex, String packageVersion) {
         this.nameCPIndex = nameCPIndex;
         this.packageName = packageName;
+        this.versionCPIndex = versionCPIndex;
+        this.packageVersion = packageVersion;
     }
 
     public int getNameCPIndex() {

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/elements/PackageID.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/elements/PackageID.java
@@ -46,6 +46,7 @@ public class PackageID {
                 nameComps.stream()
                         .map(Name::getValue)
                         .collect(Collectors.joining(".")));
+        this.version = version;
     }
 
     public PackageID(Name orgName, Name name, Name version) {
@@ -57,6 +58,7 @@ public class PackageID {
             this.nameComps = Arrays.stream(name.value.split("\\."))
                     .map(Name::new).collect(Collectors.toList());
         }
+        this.version = version;
     }
 
     public Name getName() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/ProgramFileWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/ProgramFileWriter.java
@@ -143,6 +143,8 @@ public class ProgramFileWriter {
                 case CP_ENTRY_PACKAGE:
                     nameCPIndex = ((PackageRefCPEntry) cpEntry).nameCPIndex;
                     dataOutStream.writeInt(nameCPIndex);
+                    int versionCPIndex = ((PackageRefCPEntry) cpEntry).versionCPIndex;
+                    dataOutStream.writeInt(versionCPIndex);
                     break;
                 case CP_ENTRY_FUNCTION_REF:
                     FunctionRefCPEntry funcRefEntry = (FunctionRefCPEntry) cpEntry;
@@ -197,6 +199,7 @@ public class ProgramFileWriter {
     private static void writePackageInfo(DataOutputStream dataOutStream,
                                          PackageInfo packageInfo) throws IOException {
         dataOutStream.writeInt(packageInfo.nameCPIndex);
+        dataOutStream.writeInt(packageInfo.versionCPIndex);
         writeCP(dataOutStream, packageInfo.getConstPoolEntries());
 
         // Emit struct info entries


### PR DESCRIPTION
## Purpose
> Expose version of the package to the runtime.

## Goals
> Consider package version as service version

## Approach
> Write version to dataOutstream after codegen.
> Read value and set to packageInfo.