### PR TITLE
Fix issue #4716 

### DIFF
--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/io/natives.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/io/natives.bal
@@ -74,7 +74,7 @@ public struct SocketProperties {
 @Param {value:"path: path to the file location"}
 @Param {value:"accessMode: whether the file should be opened for read,write or append"}
 @Return {value:"Channel which will allow to source/sink"}
-public native function openFile (@sensitive string path, @sensitive string accessMode) (@tainted ByteChannel);
+public native function openFile (string path, string accessMode) (ByteChannel);
 
 @Description {value:"Opens a socket from a specified network location"}
 @Param {value:"host: Remote server domain/IP"}
@@ -82,16 +82,14 @@ public native function openFile (@sensitive string path, @sensitive string acces
 @Param {value:"options: Connection stream that bridge the client and the server"}
 @Return {value:"Socket which will allow to communicate with a remote server"}
 @Return {value:"Returns an IOError if unable to open the socket connection"}
-public native function openSocket (@sensitive string host, @sensitive int port,
-                                   SocketProperties options) (@tainted Socket, IOError);
+public native function openSocket (string host, int port, SocketProperties options) (Socket, IOError);
 
 @Description {value:"Function to create a CharacterChannel from ByteChannel"}
 @Param {value:"channel: The ByteChannel to be converted"}
 @Param {value:"encoding: The charset/encoding of the content (i.e UTF-8, ASCII)"}
 @Return {value:"CharacterChannel converted from ByteChannel"}
 @Return {value:"Returns an IOError if CharacterChannel could not be created"}
-public native function createCharacterChannel (ByteChannel byteChannel,
-                                               string encoding) (@tainted CharacterChannel, IOError);
+public native function createCharacterChannel (ByteChannel byteChannel, string encoding) (CharacterChannel, IOError);
 
 @Description {value:"Function to create a CharacterChannel to DelimitedRecordChannel"}
 @Param {value:"channel: The CharacterChannel to be converted"}
@@ -100,31 +98,33 @@ public native function createCharacterChannel (ByteChannel byteChannel,
 @Return {value:"DelimitedRecordChannel converted from CharacterChannel"}
 @Return {value:"Returns an IOError if DelimitedRecordChannel could not be created"}
 public native function createDelimitedRecordChannel (CharacterChannel channel, string recordSeparator,
-                                                     string fieldSeparator) (@tainted DelimitedRecordChannel, IOError);
+                                                     string fieldSeparator) (DelimitedRecordChannel, IOError);
 
 @Description {value:"Function to read bytes"}
 @Param {value:"channel: The ByteChannel to read bytes from"}
-@Param {value:"numberOfBytes: Number of bytes which should be read"}
+@Param {value:"content: The byte array which will hold the content which is read"}
+@Param {value:"size: Maximum number of bytes which should be read to the array"}
+@Param {value:"offset: Position the bytes should be read from"}
 @Return {value:"The bytes which were read"}
 @Return {value:"Number of bytes read"}
 @Return {value:"Returns if there's any error while performaing I/O operation"}
-public native function <ByteChannel channel> read (@sensitive int numberOfBytes, @sensitive int offset) (blob, int,
-                                                                                                         IOError);
+public native function <ByteChannel channel> read (byte[] content, int size, int offset) (int, IOError);
 
 @Description {value:"Function to write bytes"}
 @Param {value:"channel: The ByteChannel to write bytes to"}
 @Param {value:"content: Bytes which should be written"}
-@Param {value:"startOffset: If the bytes need to be written with an offset, the value of that offset"}
+@Param {value:"size: Number of bytes which should be written to channel"}
+@Param {value:"offset: If the bytes need to be written with an offset, the value of that offset"}
 @Return {value:"Number of bytes written"}
 @Return {value:"Returns if there's any error while performaing I/O operation"}
-public native function <ByteChannel channel> write (blob content, int startOffset, int numberOfBytes)(int, IOError);
+public native function <ByteChannel channel> write (byte[] content, int size, int offset) (int, IOError);
 
 @Description {value:"Function to read characters"}
 @Param {value:"channel: The CharacterChannel to read characters from"}
 @Param {value:"numberOfChars: Number of characters which should be read"}
 @Return {value:"The character sequence which was read"}
 @Return {value:"Returns if there's any error while performaing I/O operation"}
-public native function <CharacterChannel channel> readCharacters (@sensitive int numberOfChars) (string, IOError);
+public native function <CharacterChannel channel> readCharacters (int numberOfChars) (string, IOError);
 
 @Description {value:"Function to write characters"}
 @Param {value:"channel: The CharacterChannel which will allow writing characters"}
@@ -172,8 +172,7 @@ public native function <CharacterChannel channel> closeCharacterChannel () (IOEr
 @Param {value:"options: Connection stream that bridge the client and the server"}
 @Return {value:"Socket which will allow to communicate with a remote server"}
 @Return {value:"Returns an IOError if unable to open the socket connection"}
-public native function openSecureSocket (@sensitive string host, @sensitive int port,
-                                         SocketProperties options) (@tainted Socket, IOError);
+public native function openSecureSocket (string host, int port, SocketProperties options) (Socket, IOError);
 
 @Description {value:"Close the socket connection with the remote server"}
 @Param {value:"socket: The client socket connection to be to be closed"}
@@ -189,5 +188,5 @@ public native function <Socket socket> closeSocket () (IOError);
 @Param {value:"structType: Name of the struct that each record need to populate"}
 @Return {value:"table of delimited values"}
 @Return {value:"Returns if there's any error while performaing I/O operation"}
-public native function loadToTable(@sensitive string filePath, string recordSeparator, string fieldSeparator,
+public native function loadToTable(string filePath, string recordSeparator, string fieldSeparator,
                                    string encoding, boolean headerLineIncluded, type structType) (table, IOError);

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/Read.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/Read.java
@@ -45,6 +45,7 @@ import org.ballerinalang.natives.annotations.ReturnType;
         functionName = "read",
         receiver = @Receiver(type = TypeKind.STRUCT, structType = "ByteChannel", structPackage = "ballerina.io"),
         args = {@Argument(name = "numberOfBytes", type = TypeKind.INT),
+                @Argument(name = "size", type = TypeKind.INT),
                 @Argument(name = "offset", type = TypeKind.INT)},
         returnType = {@ReturnType(type = TypeKind.BLOB),
                 @ReturnType(type = TypeKind.INT),
@@ -61,7 +62,12 @@ public class Read implements NativeCallableUnit {
     /**
      * Specifies the offset of the array to read bytes.
      */
-    private static final int OFFSET_INDEX = 1;
+    private static final int OFFSET_INDEX = 2;
+
+    /**
+     * Specifies the number of bytes which should be read.
+     */
+    private static final int SIZE_INDEX = 1;
 
     /**
      * Specifies the index which contains the byte channel in ballerina.lo#readBytes.
@@ -102,10 +108,11 @@ public class Read implements NativeCallableUnit {
         BStruct channel = (BStruct) context.getRefArgument(BYTE_CHANNEL_INDEX);
         int numberOfBytes = (int) context.getIntArgument(NUMBER_OF_BYTES_INDEX);
         int offset = (int) context.getIntArgument(OFFSET_INDEX);
+        int size = (int) context.getIntArgument(SIZE_INDEX);
         Channel byteChannel = (Channel) channel.getNativeData(IOConstants.BYTE_CHANNEL_NAME);
         byte[] content = new byte[numberOfBytes];
         EventContext eventContext = new EventContext(context, callback);
-        IOUtils.read(byteChannel, content, offset, eventContext, Read::readResponse);
+        IOUtils.read(byteChannel, content, offset, size, eventContext, Read::readResponse);
     }
 
     @Override

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/Write.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/Write.java
@@ -43,8 +43,8 @@ import org.ballerinalang.natives.annotations.ReturnType;
         functionName = "write",
         receiver = @Receiver(type = TypeKind.STRUCT, structType = "ByteChannel", structPackage = "ballerina.io"),
         args = {@Argument(name = "content", type = TypeKind.BLOB),
-                @Argument(name = "startOffset", type = TypeKind.INT),
-                @Argument(name = "numberOfBytes", type = TypeKind.INT)},
+                @Argument(name = "numberOfBytes", type = TypeKind.INT),
+                @Argument(name = "startOffset", type = TypeKind.INT)},
         returnType = {@ReturnType(type = TypeKind.INT),
                 @ReturnType(type = TypeKind.STRUCT, structType = "IOError", structPackage = "ballerina.io")},
         isPublic = true
@@ -64,12 +64,12 @@ public class Write implements NativeCallableUnit {
     /*
      * Index which holds the start offset in ballerina.io#writeBytes.
      */
-    private static final int START_OFFSET_INDEX = 0;
+    private static final int START_OFFSET_INDEX = 1;
 
     /*
      * Index which holds the number of bytes which should be written.
      */
-    private static final int NUMBER_OF_BYTES_INDEX = 1;
+    private static final int NUMBER_OF_BYTES_INDEX = 0;
 
     /*
      * Function which will be notified on the response obtained after the async operation.

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/bytes/ReadBytesEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/bytes/ReadBytesEvent.java
@@ -52,10 +52,11 @@ public class ReadBytesEvent implements Event {
 
     private static final Logger log = LoggerFactory.getLogger(ReadBytesEvent.class);
 
-    public ReadBytesEvent(Channel channel, byte[] content, int offset, EventContext context) {
+    public ReadBytesEvent(Channel channel, byte[] content, int offset, int size, EventContext context) {
         this.content = ByteBuffer.wrap(content);
         this.context = context;
         this.channel = channel;
+        this.content.limit(size);
         this.content.position(offset);
     }
 

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/bytes/AsyncReadWriteTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/bytes/AsyncReadWriteTest.java
@@ -50,28 +50,29 @@ public class AsyncReadWriteTest {
     @Test(description = "Read into fixed byte[] using async io framework")
     public void readBytes() throws IOException, URISyntaxException, ExecutionException,
             InterruptedException {
-        byte[] content = new byte[2];
+        byte[] content = new byte[4];
         //Number of characters in this file would be 6
         ByteChannel byteChannel = TestUtil.openForReading("datafiles/io/text/6charfile.txt");
         Channel channel = new MockByteChannel(byteChannel);
 
-        byte[] expected = {49, 50};
+        byte[] expected = {49, 50, 0, 0};
         int offset = 0;
-        IOUtils.readFull(channel, content, offset, new EventContext());
+        int size = 2;
+        IOUtils.readFull(channel, content, offset, size, new EventContext());
         Assert.assertEquals(expected, content);
 
-        expected = new byte[]{51, 52};
-        IOUtils.readFull(channel, content, offset, new EventContext());
+        expected = new byte[]{51, 52, 0, 0};
+        IOUtils.readFull(channel, content, offset, size, new EventContext());
         Assert.assertEquals(expected, content);
 
-        expected = new byte[]{53, 54};
-        IOUtils.readFull(channel, content, offset, new EventContext());
+        expected = new byte[]{53, 54, 0, 0};
+        IOUtils.readFull(channel, content, offset, size, new EventContext());
         Assert.assertEquals(expected, content);
 
         int expectedNumberOfBytes = 0;
         content = new byte[2];
         expected = new byte[]{0, 0};
-        int numberOfBytesRead = IOUtils.readFull(channel, content, offset, new EventContext());
+        int numberOfBytesRead = IOUtils.readFull(channel, content, offset, size, new EventContext());
         Assert.assertEquals(numberOfBytesRead, expectedNumberOfBytes);
         Assert.assertEquals(expected, content);
     }
@@ -87,16 +88,17 @@ public class AsyncReadWriteTest {
         byte[] expected = "123".getBytes();
 
         int offset = 0;
-        IOUtils.readFull(channel, content, offset, new EventContext());
+        int size = 3;
+        IOUtils.readFull(channel, content, offset, size, new EventContext());
         Assert.assertEquals(expected, content);
 
         expected = "456".getBytes();
-        IOUtils.readFull(channel, content, offset, new EventContext());
+        IOUtils.readFull(channel, content, offset, size, new EventContext());
         Assert.assertEquals(expected, content);
 
         content = new byte[3];
         expected = new byte[3];
-        IOUtils.readFull(channel, content, offset, new EventContext());
+        IOUtils.readFull(channel, content, offset, size, new EventContext());
         Assert.assertEquals(expected, content);
     }
 

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/socket/SecureClientSocketTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/socket/SecureClientSocketTest.java
@@ -22,7 +22,7 @@ import org.ballerinalang.bre.bvm.BLangVMStructs;
 import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.BRunUtil;
 import org.ballerinalang.launcher.util.CompileResult;
-import org.ballerinalang.model.values.BBlob;
+import org.ballerinalang.model.values.BByteArray;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStruct;
@@ -41,6 +41,7 @@ import java.net.Socket;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -154,15 +155,15 @@ public class SecureClientSocketTest {
         final String newline = System.lineSeparator();
         String content = "Hello World" + newline;
         final byte[] contentBytes = content.getBytes();
-        BValue[] args = { new BBlob(contentBytes), new BInteger(contentBytes.length) };
+        BValue[] args = { new BByteArray(contentBytes), new BInteger(contentBytes.length) };
         final BValue[] writeReturns = BRunUtil.invoke(socketClient, "write", args);
         BInteger returnedSize = (BInteger) writeReturns[0];
         Assert.assertEquals(returnedSize.intValue(), content.length(), "Write content size is not match.");
         args = new BValue[] { new BInteger(content.length()) };
         final BValue[] readReturns = BRunUtil.invoke(socketClient, "read", args);
-        final BBlob readContent = (BBlob) readReturns[0];
+        final BByteArray readContent = (BByteArray) readReturns[0];
         returnedSize = (BInteger) readReturns[1];
-        Assert.assertEquals(readContent.stringValue(), content, "Return content are not match with written content.");
+        Assert.assertTrue(Arrays.equals(contentBytes, readContent.getValues()));
         Assert.assertEquals(returnedSize.intValue(), content.length(), "Read size not match with the request size");
     }
 

--- a/tests/ballerina-test/src/test/resources/test-src/io/bytesio.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/bytesio.bal
@@ -9,13 +9,13 @@ function initFileChannel (string filePath, string permission) {
 function readBytes (int numberOfBytes) (blob) {
     blob bytes;
     int numberOfBytesRead;
-    bytes, numberOfBytesRead, _ = channel.read(numberOfBytes, 0);
+    bytes, numberOfBytesRead, _ = channel.read(numberOfBytes, numberOfBytes, 0);
     return bytes;
 }
 
 function writeBytes (blob content, int startOffset, int size) (int) {
     int numberOfBytesWritten;
-    numberOfBytesWritten, _ = channel.write(content, startOffset, size);
+    numberOfBytesWritten, _ = channel.write(content, size, startOffset);
     return numberOfBytesWritten;
 }
 

--- a/tests/ballerina-test/src/test/resources/test-src/io/bytesio.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/bytesio.bal
@@ -7,7 +7,7 @@ function initFileChannel (string filePath, string permission) {
 }
 
 function readBytes (int numberOfBytes) (byte[]) {
-    byte[] content;
+    byte[] content = [];
     int offset = 0;
     int numberOfBytesRead = 0;
     boolean hasRemaining = true;

--- a/tests/ballerina-test/src/test/resources/test-src/io/bytesio.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/bytesio.bal
@@ -6,14 +6,22 @@ function initFileChannel (string filePath, string permission) {
     channel = io:openFile(filePath, permission);
 }
 
-function readBytes (int numberOfBytes) (blob) {
-    blob bytes;
-    int numberOfBytesRead;
-    bytes, numberOfBytesRead, _ = channel.read(numberOfBytes, numberOfBytes, 0);
-    return bytes;
+function readBytes (int numberOfBytes) (byte[]) {
+    byte[] content;
+    int offset = 0;
+    int numberOfBytesRead = 0;
+    boolean hasRemaining = true;
+    while(hasRemaining){
+      numberOfBytesRead, _ = channel.read(content, numberOfBytes, offset);
+      offset = offset + numberOfBytesRead;
+      if(numberOfBytesRead == 0 || offset == numberOfBytes) {
+        hasRemaining = false;
+      }
+    }
+    return content;
 }
 
-function writeBytes (blob content, int startOffset, int size) (int) {
+function writeBytes (byte[] content,int size, int startOffset) (int) {
     int numberOfBytesWritten;
     numberOfBytesWritten, _ = channel.write(content, size, startOffset);
     return numberOfBytesWritten;

--- a/tests/ballerina-test/src/test/resources/test-src/io/clientsocketio.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/clientsocketio.bal
@@ -15,18 +15,18 @@ function closeSocket () {
     _ = socket.closeSocket();
 }
 
-function write (blob content, int size) (int) {
+function write (byte[] content, int size) (int) {
     int numberOfBytesWritten;
     io:ByteChannel channel = socket.channel;
     numberOfBytesWritten, _ = channel.write(content, size, 0);
     return numberOfBytesWritten;
 }
 
-function read (int size) (blob, int) {
+function read (int size) (byte[], int) {
     io:ByteChannel channel = socket.channel;
-    blob readContent;
+    byte[] readContent = [];
     int readSize;
-    readContent, readSize, _ = channel.read(size, size, 0);
+    readSize, _ = channel.read(readContent, size, 0);
     return readContent, readSize;
 }
 

--- a/tests/ballerina-test/src/test/resources/test-src/io/clientsocketio.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/clientsocketio.bal
@@ -18,7 +18,7 @@ function closeSocket () {
 function write (blob content, int size) (int) {
     int numberOfBytesWritten;
     io:ByteChannel channel = socket.channel;
-    numberOfBytesWritten, _ = channel.write(content, 0, size);
+    numberOfBytesWritten, _ = channel.write(content, size, 0);
     return numberOfBytesWritten;
 }
 
@@ -26,7 +26,7 @@ function read (int size) (blob, int) {
     io:ByteChannel channel = socket.channel;
     blob readContent;
     int readSize;
-    readContent, readSize, _ = channel.read(size, 0);
+    readContent, readSize, _ = channel.read(size, size, 0);
     return readContent, readSize;
 }
 

--- a/tests/ballerina-test/src/test/resources/test-src/io/secureclientsocketio.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/secureclientsocketio.bal
@@ -10,17 +10,17 @@ function closeSocket () {
     _ = socket.closeSocket();
 }
 
-function write (blob content, int size) (int) {
+function write (byte[] content, int size) (int) {
     int numberOfBytesWritten;
     io:ByteChannel channel = socket.channel;
     numberOfBytesWritten, _ = channel.write(content, size, 0);
     return numberOfBytesWritten;
 }
 
-function read (int size) (blob, int) {
+function read (int size) (byte[], int) {
     io:ByteChannel channel = socket.channel;
-    blob readContent;
+    byte[] readContent = [];
     int readSize;
-    readContent, readSize, _ = channel.read(size, size, 0);
+    readSize, _ = channel.read(readContent, size, 0);
     return readContent, readSize;
 }

--- a/tests/ballerina-test/src/test/resources/test-src/io/secureclientsocketio.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/secureclientsocketio.bal
@@ -13,7 +13,7 @@ function closeSocket () {
 function write (blob content, int size) (int) {
     int numberOfBytesWritten;
     io:ByteChannel channel = socket.channel;
-    numberOfBytesWritten, _ = channel.write(content, 0, size);
+    numberOfBytesWritten, _ = channel.write(content, size, 0);
     return numberOfBytesWritten;
 }
 
@@ -21,6 +21,6 @@ function read (int size) (blob, int) {
     io:ByteChannel channel = socket.channel;
     blob readContent;
     int readSize;
-    readContent, readSize, _ = channel.read(size, 0);
+    readContent, readSize, _ = channel.read(size, size, 0);
     return readContent, readSize;
 }

--- a/tests/ballerina-test/src/test/resources/test-src/mime/mime-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/mime/mime-test.bal
@@ -164,9 +164,9 @@ function testGetJsonDataSource (io:ByteChannel byteChannel) (json, mime:EntityEr
 
 function consumeChannel (io:ByteChannel channel) {
     int numberOfBytesRead = 1;
-    blob readContent;
+    byte[] readContent = [];
     while (numberOfBytesRead != 0) {
-        readContent, numberOfBytesRead, _ = channel.read(10000,10000, 0);
+        numberOfBytesRead, _ = channel.read(readContent,10000, 0);
     }
 }
 

--- a/tests/ballerina-test/src/test/resources/test-src/mime/mime-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/mime/mime-test.bal
@@ -166,7 +166,7 @@ function consumeChannel (io:ByteChannel channel) {
     int numberOfBytesRead = 1;
     blob readContent;
     while (numberOfBytesRead != 0) {
-        readContent, numberOfBytesRead, _ = channel.read(10000, 0);
+        readContent, numberOfBytesRead, _ = channel.read(10000,10000, 0);
     }
 }
 


### PR DESCRIPTION
## Purpose
Introduce the capability for I/O APIs to fill explicit byte [], this will fix issue #4716 

## Goals
- Change existing I/O APIs to accept a input byte [] and fill it
- Reflect the changes in the relevant samples
- Modify the test cases

## Related PRs

This PR depends on https://github.com/ballerina-lang/ballerina/pull/5240.  
