### PR TITLE
Add taint checking support for connectors

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BConnectorSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BConnectorSymbol.java
@@ -21,6 +21,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.Name;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * {@link BConnectorSymbol} represents a connector symbol in a scope.
@@ -31,6 +32,7 @@ public class BConnectorSymbol extends BTypeSymbol {
 
     public List<BVarSymbol> params;
     public BInvokableSymbol initFunctionSymbol;
+    public Map<Integer, TaintRecord> taintTable;
 
     public BConnectorSymbol(int flags, Name name, PackageID pkgID, BType type, BSymbol owner) {
         super(SymTag.CONNECTOR, flags, name, pkgID, type, owner);


### PR DESCRIPTION
## Purpose
> Ballerina taint analyzer does not currently support validating connector parameters.

## Goals
>  If connector configuration contained any tainted data, it is required to validate connector parameters and see if a tainted value is being passed to a sensitive parameter. 

## Approach
> Attached taint table to a connector and when endpoint is defined, check if the endpoint configurations values being passed adhere with sensitivity requirements of the "attachedConnector".