### PR TITLE
Remove unused instruction codes from code base

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/CPU.java
@@ -288,12 +288,6 @@ public class CPU {
                     execLoadOpcodes(ctx, sf, opcode, operands);
                     break;
 
-                case InstructionCodes.ISTORE:
-                case InstructionCodes.FSTORE:
-                case InstructionCodes.SSTORE:
-                case InstructionCodes.BSTORE:
-                case InstructionCodes.LSTORE:
-                case InstructionCodes.RSTORE:
                 case InstructionCodes.IASTORE:
                 case InstructionCodes.FASTORE:
                 case InstructionCodes.SASTORE:
@@ -1191,36 +1185,6 @@ public class CPU {
         BMap<String, BRefType> bMap;
         BJSON jsonVal;
         switch (opcode) {
-            case InstructionCodes.ISTORE:
-                i = operands[0];
-                lvIndex = operands[1];
-                sf.longRegs[lvIndex] = sf.longRegs[i];
-                break;
-            case InstructionCodes.FSTORE:
-                i = operands[0];
-                lvIndex = operands[1];
-                sf.doubleRegs[lvIndex] = sf.doubleRegs[i];
-                break;
-            case InstructionCodes.SSTORE:
-                i = operands[0];
-                lvIndex = operands[1];
-                sf.stringRegs[lvIndex] = sf.stringRegs[i];
-                break;
-            case InstructionCodes.BSTORE:
-                i = operands[0];
-                lvIndex = operands[1];
-                sf.intRegs[lvIndex] = sf.intRegs[i];
-                break;
-            case InstructionCodes.LSTORE:
-                i = operands[0];
-                lvIndex = operands[1];
-                sf.byteRegs[lvIndex] = sf.byteRegs[i];
-                break;
-            case InstructionCodes.RSTORE:
-                i = operands[0];
-                lvIndex = operands[1];
-                sf.refRegs[lvIndex] = sf.refRegs[i];
-                break;
             case InstructionCodes.IASTORE:
                 i = operands[0];
                 j = operands[1];

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/InstructionCodes.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/InstructionCodes.java
@@ -75,12 +75,6 @@ public interface InstructionCodes {
     int JSONLOAD = 47;
     int ENUMERATORLOAD = 48;
 
-    int ISTORE = 49;
-    int FSTORE = 50;
-    int SSTORE = 51;
-    int BSTORE = 52;
-    int LSTORE = 53;
-    int RSTORE = 54;
     int IASTORE = 55;
     int FASTORE = 56;
     int SASTORE = 57;

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/Mnemonics.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/Mnemonics.java
@@ -63,12 +63,6 @@ public class Mnemonics {
         mnemonics[InstructionCodes.LGLOAD] = "lgload";
         mnemonics[InstructionCodes.RGLOAD] = "rgload";
 
-        mnemonics[InstructionCodes.ISTORE] = "istore";
-        mnemonics[InstructionCodes.FSTORE] = "fstore";
-        mnemonics[InstructionCodes.SSTORE] = "sstore";
-        mnemonics[InstructionCodes.BSTORE] = "bstore";
-        mnemonics[InstructionCodes.LSTORE] = "lstore";
-        mnemonics[InstructionCodes.RSTORE] = "rstore";
         mnemonics[InstructionCodes.IASTORE] = "iastore";
         mnemonics[InstructionCodes.FASTORE] = "fastore";
         mnemonics[InstructionCodes.SASTORE] = "sastore";

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/ProgramFileReader.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/ProgramFileReader.java
@@ -1391,12 +1391,6 @@ public class ProgramFileReader {
                 case InstructionCodes.BGLOAD:
                 case InstructionCodes.LGLOAD:
                 case InstructionCodes.RGLOAD:
-                case InstructionCodes.ISTORE:
-                case InstructionCodes.FSTORE:
-                case InstructionCodes.SSTORE:
-                case InstructionCodes.BSTORE:
-                case InstructionCodes.LSTORE:
-                case InstructionCodes.RSTORE:
                 case InstructionCodes.IGSTORE:
                 case InstructionCodes.FGSTORE:
                 case InstructionCodes.SGSTORE:

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/InstructionCodes.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/InstructionCodes.java
@@ -75,12 +75,6 @@ public interface InstructionCodes {
     int JSONLOAD = 47;
     int ENUMERATORLOAD = 48;
 
-    int ISTORE = 49;
-    int FSTORE = 50;
-    int SSTORE = 51;
-    int BSTORE = 52;
-    int LSTORE = 53;
-    int RSTORE = 54;
     int IASTORE = 55;
     int FASTORE = 56;
     int SASTORE = 57;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/Mnemonics.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/Mnemonics.java
@@ -63,12 +63,6 @@ public class Mnemonics {
         mnemonics[InstructionCodes.LGLOAD] = "lgload";
         mnemonics[InstructionCodes.RGLOAD] = "rgload";
 
-        mnemonics[InstructionCodes.ISTORE] = "istore";
-        mnemonics[InstructionCodes.FSTORE] = "fstore";
-        mnemonics[InstructionCodes.SSTORE] = "sstore";
-        mnemonics[InstructionCodes.BSTORE] = "bstore";
-        mnemonics[InstructionCodes.LSTORE] = "lstore";
-        mnemonics[InstructionCodes.RSTORE] = "rstore";
         mnemonics[InstructionCodes.IASTORE] = "iastore";
         mnemonics[InstructionCodes.FASTORE] = "fastore";
         mnemonics[InstructionCodes.SASTORE] = "sastore";


### PR DESCRIPTION
## Purpose
Remove some unused instruction codes from code base

Resolves #5279

## Goals
This commit removes the following unused instruction codes from
code base.

ISTORE, FSTORE, SSTORE, BSTORE, LSTORE, RSTORE.

These codes are no longer used and was replaces by the use of respective MOVE operations.