### PR TITLE
Add hover support for new documentation syntax

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/ContextConstants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/ContextConstants.java
@@ -31,4 +31,9 @@ public class ContextConstants {
     public static final String RETURN = "Return";
     public static final String FIELD = "Field";
     public static final String COMPLETION_ERROR_STRATEGY = "CompletionCustomErrorStrategy";
+    public static final String DOC_FIELD = "FIELD";
+    public static final String DOC_PARAM = "PARAM";
+    public static final String DOC_RECEIVER = "RECEIVER";
+    public static final String DOC_RETURN = "RETURN";
+    public static final String DOC_VARIABLE = "VARIABLE";
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/util/HoverUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/util/HoverUtil.java
@@ -28,18 +28,22 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.wso2.ballerinalang.compiler.tree.BLangAction;
 import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
 import org.wso2.ballerinalang.compiler.tree.BLangConnector;
+import org.wso2.ballerinalang.compiler.tree.BLangDocumentation;
 import org.wso2.ballerinalang.compiler.tree.BLangEnum;
 import org.wso2.ballerinalang.compiler.tree.BLangFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.tree.BLangStruct;
 import org.wso2.ballerinalang.compiler.tree.BLangTransformer;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangDocumentationAttribute;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Utility class for Hover functionality of language server.
@@ -62,7 +66,11 @@ public class HoverUtil {
                                 .equals(hoverContext.get(NodeContextKeys.NAME_OF_NODE_KEY)))
                         .findAny().orElse(null);
                 if (bLangFunction != null) {
-                    hover = getAnnotationContent(bLangFunction.annAttachments);
+                    if (bLangFunction.docAttachments.size() > 0) {
+                        hover = getDocumentationContent(bLangFunction.docAttachments);
+                    } else {
+                        hover = getAnnotationContent(bLangFunction.annAttachments);
+                    }
                 } else {
                     hover = getDefaultHoverObject();
                 }
@@ -74,7 +82,11 @@ public class HoverUtil {
                                 .equals(hoverContext.get(NodeContextKeys.NAME_OF_NODE_KEY)))
                         .findAny().orElse(null);
                 if (bLangStruct != null) {
-                    hover = getAnnotationContent(bLangStruct.annAttachments);
+                    if (bLangStruct.docAttachments.size() > 0) {
+                        hover = getDocumentationContent(bLangStruct.docAttachments);
+                    } else {
+                        hover = getAnnotationContent(bLangStruct.annAttachments);
+                    }
                 } else {
                     hover = getDefaultHoverObject();
                 }
@@ -86,7 +98,11 @@ public class HoverUtil {
                                 .equals(hoverContext.get(NodeContextKeys.NAME_OF_NODE_KEY)))
                         .findAny().orElse(null);
                 if (bLangEnum != null) {
-                    hover = getAnnotationContent(bLangEnum.annAttachments);
+                    if (bLangEnum.docAttachments.size() > 0) {
+                        hover = getDocumentationContent(bLangEnum.docAttachments);
+                    } else {
+                        hover = getAnnotationContent(bLangEnum.annAttachments);
+                    }
                 } else {
                     hover = getDefaultHoverObject();
                 }
@@ -98,7 +114,11 @@ public class HoverUtil {
                                 .equals(hoverContext.get(NodeContextKeys.NAME_OF_NODE_KEY)))
                         .findAny().orElse(null);
                 if (bLangTransformer != null) {
-                    hover = getAnnotationContent(bLangTransformer.annAttachments);
+                    if (bLangTransformer.docAttachments.size() > 0) {
+                        hover = getDocumentationContent(bLangTransformer.docAttachments);
+                    } else {
+                        hover = getAnnotationContent(bLangTransformer.annAttachments);
+                    }
                 } else {
                     hover = getDefaultHoverObject();
                 }
@@ -111,7 +131,11 @@ public class HoverUtil {
                                 .equals(hoverContext.get(NodeContextKeys.NAME_OF_NODE_KEY)))
                         .findAny().orElse(null);
                 if (bLangConnector != null) {
-                    hover = getAnnotationContent(bLangConnector.annAttachments);
+                    if (bLangConnector.docAttachments.size() > 0) {
+                        hover = getDocumentationContent(bLangConnector.docAttachments);
+                    } else {
+                        hover = getAnnotationContent(bLangConnector.annAttachments);
+                    }
                 } else {
                     hover = getDefaultHoverObject();
                 }
@@ -128,11 +152,14 @@ public class HoverUtil {
                                 .equals(hoverContext.get(NodeContextKeys.NAME_OF_NODE_KEY)))
                         .findAny().orElse(null);
                 if (bLangAction != null) {
-                    hover = getAnnotationContent(bLangAction.annAttachments);
+                    if (bLangAction.docAttachments.size() > 0) {
+                        hover = getDocumentationContent(bLangAction.docAttachments);
+                    } else {
+                        hover = getAnnotationContent(bLangAction.annAttachments);
+                    }
                 } else {
                     hover = getDefaultHoverObject();
                 }
-
                 break;
             default:
                 hover = new Hover();
@@ -230,6 +257,24 @@ public class HoverUtil {
     }
 
     /**
+     * Get the doc annotation attributes.
+     *
+     * @param attributes attributes to be extracted
+     * @return {@link String } extracted content of annotation
+     */
+    private static String getDocAttributes(List<BLangDocumentationAttribute> attributes) {
+        StringBuilder value = new StringBuilder();
+        for (BLangDocumentationAttribute attribute : attributes) {
+            value.append("- ")
+                    .append(attribute.documentationField.getValue().replace("\n", ""))
+                    .append(":")
+                    .append(attribute.documentationText.replaceAll("\n", "")).append("\r\n");
+        }
+
+        return value.toString();
+    }
+
+    /**
      * get the formatted string with markdowns.
      *
      * @param header  header.
@@ -238,6 +283,16 @@ public class HoverUtil {
      */
     private static String getFormattedHoverContent(String header, String content) {
         return "**" + header + "**\r\n```\r\n" + content + "\r\n```\r\n";
+    }
+
+    /**
+     * get the formatted string with markdowns.
+     *
+     * @param header header.
+     * @return {@link String} formatted string using markdown.
+     */
+    private static String getFormattedHoverDocContent(String header, String content) {
+        return "**" + header + "**\r\n" + content + "\r\n";
     }
 
     /**
@@ -274,6 +329,77 @@ public class HoverUtil {
         hover.setContents(contents);
 
         return hover;
+    }
+
+    /**
+     * Get documentation content
+     *
+     * @param docAnnotation list of doc annotation
+     * @return {@link Hover} hover object.
+     */
+    private static Hover getDocumentationContent(List<BLangDocumentation> docAnnotation) {
+        Hover hover = new Hover();
+        StringBuilder content = new StringBuilder();
+        BLangDocumentation bLangDocumentation = docAnnotation.get(0);
+        Map<String, List<BLangDocumentationAttribute>> filterAttributes =
+                filterDocumentationAttributes(docAnnotation.get(0));
+
+        if (!bLangDocumentation.documentationText.isEmpty()) {
+            content.append(getFormattedHoverDocContent(ContextConstants.DESCRIPTION,
+                    bLangDocumentation.documentationText));
+        }
+
+        if (filterAttributes.get(ContextConstants.DOC_RECEIVER) != null) {
+            content.append(getFormattedHoverDocContent(ContextConstants.DOC_RECEIVER,
+                    getDocAttributes(filterAttributes.get(ContextConstants.DOC_RECEIVER))));
+        }
+
+        if (filterAttributes.get(ContextConstants.DOC_PARAM) != null) {
+            content.append(getFormattedHoverDocContent(ContextConstants.DOC_PARAM,
+                    getDocAttributes(filterAttributes.get(ContextConstants.DOC_PARAM))));
+        }
+
+        if (filterAttributes.get(ContextConstants.DOC_FIELD) != null) {
+            content.append(getFormattedHoverDocContent(ContextConstants.DOC_FIELD,
+                    getDocAttributes(filterAttributes.get(ContextConstants.DOC_FIELD))));
+        }
+
+        if (filterAttributes.get(ContextConstants.DOC_RETURN) != null) {
+            content.append(getFormattedHoverDocContent(ContextConstants.DOC_RETURN,
+                    getDocAttributes(filterAttributes.get(ContextConstants.DOC_RETURN))));
+        }
+
+        if (filterAttributes.get(ContextConstants.DOC_VARIABLE) != null) {
+            content.append(getFormattedHoverDocContent(ContextConstants.DOC_VARIABLE,
+                    getDocAttributes(filterAttributes.get(ContextConstants.DOC_VARIABLE))));
+        }
+
+        List<Either<String, MarkedString>> contents = new ArrayList<>();
+        contents.add(Either.forLeft(content.toString()));
+        hover.setContents(contents);
+
+        return hover;
+    }
+
+    /**
+     * Filter documentation attributes to each tags.
+     *
+     * @param bLangDocumentation documentation node
+     * @return {@link Map} filtered content map
+     */
+    private static Map<String, List<BLangDocumentationAttribute>> filterDocumentationAttributes(
+            BLangDocumentation bLangDocumentation) {
+        Map<String, List<BLangDocumentationAttribute>> filteredAttributes = new HashMap<>();
+        for (BLangDocumentationAttribute bLangDocumentationAttribute : bLangDocumentation.attributes) {
+            if (filteredAttributes.get(bLangDocumentationAttribute.docTag.name()) == null) {
+                filteredAttributes.put(bLangDocumentationAttribute.docTag.name(), new ArrayList<>());
+                filteredAttributes.get(bLangDocumentationAttribute.docTag.name()).add(bLangDocumentationAttribute);
+            } else {
+                filteredAttributes.get(bLangDocumentationAttribute.docTag.name()).add(bLangDocumentationAttribute);
+            }
+        }
+
+        return filteredAttributes;
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/util/HoverUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/util/HoverUtil.java
@@ -332,7 +332,7 @@ public class HoverUtil {
     }
 
     /**
-     * Get documentation content
+     * Get documentation content.
      *
      * @param docAnnotation list of doc annotation
      * @return {@link Hover} hover object.


### PR DESCRIPTION
## Purpose
> Fix #5266

## Goals
>  This will add the hover support for new documentation markdown to show styled documentation when hover over a top level construct of object.

## Approach
![ezgif com-video-to-gif 34](https://user-images.githubusercontent.com/9109762/37552519-230682d6-29dd-11e8-88e0-8a63bcfd1492.gif)
