### PR TITLE
Add request filter implementation

### DIFF
--- a/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/filter.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/filter.bal
@@ -1,0 +1,60 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ballerina.net.http;
+
+@Description {value:"Representation of a HTTP Request Filter. This filter will be applied before the request is
+dispatched to the relevant resource. Any Filter implementation should be struct-wise similar to the Filter struct."}
+@Field {value:"filterRequest: Request filter function pointer"}
+@Field {value:"filterResponse: Response filter function pointer"}
+public struct Filter {
+    function (Request request, FilterContext context) returns (FilterResult) filterRequest;
+    function (Response response, FilterContext context) returns (FilterResult) filterResponse;
+}
+
+@Description {value:"Representation of filter Context."}
+@Field {value:"serviceType: Type of the service"}
+@Field {value:"serviceName: Name of the service"}
+@Field {value:"filterResponse: Name of the resource"}
+public struct FilterContext {
+    // TODO should have a map of properties
+    type serviceType;
+    string serviceName;
+    string resourceName;
+}
+
+@Description {value:"Represents a filter result. This should be populated and returned by each request and response
+filter function"}
+@Field {value:"canProceed: Flag to check if the execution of the request should proceed or stopped"}
+@Field {value:"statusCode: Status code which will be returned to the request sender if the canProceed is set to false"}
+@Field {value:"message: Message which will be returned to the request sender if the canProceed is set to false"}
+public struct FilterResult {
+    boolean canProceed;
+    int statusCode;
+    string message;
+}
+
+@Description {value:"Initializes the filter"}
+public function <Filter filter> init () {
+    error e = {message:"Not implemented"};
+    throw e;
+}
+
+@Description {value:"Stops the filter"}
+public function <Filter filter> terminate () {
+    error e = {message:"Not implemented"};
+    throw e;
+}

--- a/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/service_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/service_endpoint.bal
@@ -29,6 +29,7 @@ public struct RequestLimits {
 @Field {value:"ssl: The SSL configurations for the service endpoint"}
 @Field {value:"httpVersion: Highest HTTP version supported"}
 @Field {value:"requestLimits: Request validation limits configuration"}
+@Field {value:"filters: Filters to be applied to the request before dispatched to the actual resource"}
 public struct ServiceEndpointConfiguration {
     string host;
     int port;
@@ -38,6 +39,7 @@ public struct ServiceEndpointConfiguration {
     SslConfiguration ssl;
     string httpVersion;
     RequestLimits requestLimits;
+    Filter[] filters;
 }
 
 @Description {value:"Initializes a ServiceEndpointConfiguration struct"}
@@ -88,6 +90,12 @@ public function <ServiceEndpoint ep> init (ServiceEndpointConfiguration config) 
     var err = ep.initEndpoint();
     if (err != null) {
         throw err;
+    }
+    // if filters are defined, call init on them
+    if (config.filters != null) {
+        foreach filter in config.filters  {
+            filter.init();
+        }
     }
 }
 

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/BallerinaHTTPConnectorListener.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/BallerinaHTTPConnectorListener.java
@@ -18,18 +18,26 @@
 package org.ballerinalang.net.http;
 
 import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.connector.api.BLangConnectorSPIUtil;
 import org.ballerinalang.connector.api.BallerinaConnectorException;
 import org.ballerinalang.connector.api.Executor;
+import org.ballerinalang.model.values.BStruct;
+import org.ballerinalang.model.values.BTypeValue;
 import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.net.http.serviceendpoint.FilterHolder;
 import org.ballerinalang.runtime.Constants;
 import org.ballerinalang.util.exceptions.BallerinaException;
+import org.ballerinalang.util.program.BLangFunctions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.contract.HttpConnectorListener;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+
+import static org.ballerinalang.net.http.HttpConstants.PROTOCOL_PACKAGE_HTTP;
 
 /**
  * HTTP connector listener for Ballerina.
@@ -41,8 +49,12 @@ public class BallerinaHTTPConnectorListener implements HttpConnectorListener {
 
     private final HTTPServicesRegistry httpServicesRegistry;
 
-    public BallerinaHTTPConnectorListener(HTTPServicesRegistry httpServicesRegistry) {
+    private final HashSet<FilterHolder> filterHolders;
+
+    public BallerinaHTTPConnectorListener(HTTPServicesRegistry httpServicesRegistry,
+            HashSet<FilterHolder> filterHolders) {
         this.httpServicesRegistry = httpServicesRegistry;
+        this.filterHolders = filterHolders;
     }
 
     @Override
@@ -76,9 +88,22 @@ public class BallerinaHTTPConnectorListener implements HttpConnectorListener {
         properties.put(HttpConstants.REMOTE_ADDRESS, httpCarbonMessage.getProperty(HttpConstants.REMOTE_ADDRESS));
         properties.put(HttpConstants.ORIGIN_HOST, httpCarbonMessage.getHeader(HttpConstants.ORIGIN_HOST));
         BValue[] signatureParams = HttpDispatcher.getSignatureParameters(httpResource, httpCarbonMessage);
+        // invoke the request path filters
+        invokeRequestFilters(httpCarbonMessage, signatureParams[1], getRequestFilterContext(httpResource));
         CallableUnitCallback callback = new HttpCallableUnitCallback(httpCarbonMessage);
         //TODO handle BallerinaConnectorException
         Executor.submit(httpResource.getBalResource(), callback, properties, signatureParams);
+    }
+
+    private BValue getRequestFilterContext(HttpResource httpResource) {
+        BStruct filterCtxtStruct = BLangConnectorSPIUtil.createBStruct(
+                httpResource.getBalResource().getResourceInfo().getServiceInfo().getPackageInfo().getProgramFile(),
+                PROTOCOL_PACKAGE_HTTP, "FilterContext");
+        filterCtxtStruct.setRefField(0,
+                new BTypeValue(httpResource.getBalResource().getResourceInfo().getServiceInfo().getType()));
+        filterCtxtStruct.setStringField(0, httpResource.getParentService().getName());
+        filterCtxtStruct.setStringField(1, httpResource.getName());
+        return filterCtxtStruct;
     }
 
     private boolean accessed(HTTPCarbonMessage httpCarbonMessage) {
@@ -98,5 +123,39 @@ public class BallerinaHTTPConnectorListener implements HttpConnectorListener {
         properties.put(Constants.GLOBAL_TRANSACTION_ID, httpCarbonMessage.getHeader(HttpConstants.HEADER_X_XID));
         properties.put(Constants.TRANSACTION_URL, httpCarbonMessage.getHeader(HttpConstants.HEADER_X_REGISTER_AT_URL));
         return properties;
+    }
+
+    /**
+     * Invokes the set of filters for the request path. If one filter fails, the execution would stop and the
+     * relevant error message given from the filter will be returned to the user.
+     *
+     * @param httpCarbonMessage {@link HTTPCarbonMessage} instance
+     * @param requestObject     Representation of ballerina.net.Request struct
+     * @param filterCtxt        filtering criteria
+     */
+    private void invokeRequestFilters(HTTPCarbonMessage httpCarbonMessage, BValue requestObject, BValue filterCtxt) {
+
+        if (filterHolders == null || filterHolders.isEmpty()) {
+            // no filters, return
+            return;
+        }
+
+        for (FilterHolder filterHolder : filterHolders) {
+            // get the request filter function and invoke
+            BValue[] returnValue = BLangFunctions
+                    .invokeCallable(filterHolder.getRequestFilterFunction().getFunctionInfo(),
+                            new BValue[] { requestObject, filterCtxt });
+            BStruct filterResultStruct = (BStruct) returnValue[0];
+            if (filterResultStruct.getBooleanField(0) == 0) {
+                // filter returned false, stop further execution
+                // get the status code and the message
+                int filterStatusCode = Math.toIntExact(filterResultStruct.getIntField(0));
+                // if the status code returned by filter result is 4xx, use it, else use the code 400
+                int responseStatusCode = filterStatusCode >= 400 && filterStatusCode < 500 ? filterStatusCode : 400;
+                httpCarbonMessage.setProperty(HttpConstants.HTTP_STATUS_CODE, responseStatusCode);
+                throw new BallerinaException("Request failed: " + filterResultStruct.getStringField(0));
+            }
+            // filter has returned true, can continue
+        }
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -318,4 +318,7 @@ public class HttpConstants {
     public static final String PROXY_PASSWORD = "pasword";
 
     public static final String HTTP_SERVICE_TYPE = "Service";
+    // Filter related
+    public static final String ENDPOINT_CONFIG_FILTERS = "filters";
+    public static final String FILTERS = "FILTERS";
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/serviceendpoint/AbstractHttpNativeFunction.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/serviceendpoint/AbstractHttpNativeFunction.java
@@ -7,6 +7,8 @@ import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.WebSocketServicesRegistry;
 import org.wso2.transport.http.netty.contract.ServerConnector;
 
+import java.util.LinkedHashSet;
+
 /**
  * Includes common functions to all the actions.
  *
@@ -24,6 +26,16 @@ public abstract class AbstractHttpNativeFunction extends BlockingNativeCallableU
 
     protected ServerConnector getServerConnector(Struct serviceEndpoint) {
         return (ServerConnector) serviceEndpoint.getNativeData(HttpConstants.HTTP_SERVER_CONNECTOR);
+    }
+
+    /**
+     * Returns the filters from the service endpoint.
+     *
+     * @param serviceEndpoint service endpoint struct
+     * @return Ordered set of filters
+     */
+    protected LinkedHashSet<FilterHolder> getFilters(Struct serviceEndpoint) {
+        return (LinkedHashSet<FilterHolder>) serviceEndpoint.getNativeData(HttpConstants.FILTERS);
     }
 
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/serviceendpoint/FilterHolder.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/serviceendpoint/FilterHolder.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.net.http.serviceendpoint;
+
+import org.ballerinalang.util.codegen.cpentries.FunctionRefCPEntry;
+
+/**
+ * Wrapper class to hold request and response filter functions.
+ */
+public class FilterHolder {
+    private FunctionRefCPEntry requestFilterFunction;
+    private FunctionRefCPEntry responseFilterFunction;
+
+    public FilterHolder(FunctionRefCPEntry requestFilterFunction, FunctionRefCPEntry responseFilterFunction) {
+        this.requestFilterFunction = requestFilterFunction;
+        this.responseFilterFunction = responseFilterFunction;
+    }
+
+    public FunctionRefCPEntry getRequestFilterFunction() {
+        return requestFilterFunction;
+    }
+
+    public FunctionRefCPEntry getResponseFilterFunction() {
+        return responseFilterFunction;
+    }
+}

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/serviceendpoint/Start.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/serviceendpoint/Start.java
@@ -35,6 +35,7 @@ import org.ballerinalang.net.http.util.ConnectorStartupSynchronizer;
 import org.wso2.transport.http.netty.contract.ServerConnector;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 
+import java.util.HashSet;
 import java.util.logging.LogManager;
 
 /**
@@ -61,8 +62,10 @@ public class Start extends AbstractHttpNativeFunction {
         }
         ServerConnectorFuture serverConnectorFuture = serverConnector.start();
         HTTPServicesRegistry httpServicesRegistry = getHttpServicesRegistry(serviceEndpoint);
+        HashSet<FilterHolder> filterHolder = getFilters(serviceEndpoint);
         WebSocketServicesRegistry webSocketServicesRegistry = getWebSocketServicesRegistry(serviceEndpoint);
-        serverConnectorFuture.setHttpConnectorListener(new BallerinaHTTPConnectorListener(httpServicesRegistry));
+        serverConnectorFuture.setHttpConnectorListener(new BallerinaHTTPConnectorListener(httpServicesRegistry,
+                filterHolder));
         serverConnectorFuture
                 .setWSConnectorListener(new BallerinaWebSocketServerConnectorListener(webSocketServicesRegistry));
         // TODO: set startup server port binder. Do we really need it with new design?

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/filter/MultpleFiltersTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/filter/MultpleFiltersTestCase.java
@@ -1,0 +1,96 @@
+/*
+*  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.ballerinalang.test.filter;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import org.ballerinalang.test.IntegrationTestCase;
+import org.ballerinalang.test.context.ServerInstance;
+import org.ballerinalang.test.util.HttpClientRequest;
+import org.ballerinalang.test.util.HttpResponse;
+import org.ballerinalang.test.util.TestConstant;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MultpleFiltersTestCase extends IntegrationTestCase {
+
+    private ServerInstance ballerinaServer;
+
+    @Test(description = "Single filter execution success case")
+    public void testMultipleFiltersSuccess() throws Exception {
+        try {
+            String relativePath = new File("src" + File.separator + "test" + File.separator + "resources"
+                    + File.separator + "filter" + File.separator +
+                    "multiple-filters-execution-sucess-test.bal").getAbsolutePath();
+            startServer(relativePath);
+            Map<String, String> headers = new HashMap<>();
+            headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_TEXT_PLAIN);
+            HttpResponse response = HttpClientRequest.doGet(ballerinaServer
+                    .getServiceURLHttp("echo/test"), headers);
+            Assert.assertNotNull(response);
+            Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+        } finally {
+            ballerinaServer.stopServer();
+        }
+    }
+
+    @Test(description = "Single filter execution failure case")
+    public void testMultipleFiltersFailureFromLast() throws Exception {
+        try {
+            String relativePath = new File("src" + File.separator + "test" + File.separator + "resources"
+                    + File.separator + "filter" + File.separator +
+                    "multipler-filters-execution-failure-from-last-test.bal").getAbsolutePath();
+            startServer(relativePath);
+            Map<String, String> headers = new HashMap<>();
+            headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_TEXT_PLAIN);
+            HttpResponse response = HttpClientRequest.doGet(ballerinaServer
+                    .getServiceURLHttp("echo/test"), headers);
+            Assert.assertNotNull(response);
+            Assert.assertEquals(response.getResponseCode(), 403, "Response code mismatched");
+        } finally {
+            ballerinaServer.stopServer();
+        }
+    }
+
+    @Test(description = "Single filter execution failure case")
+    public void testMultipleFiltersFailureFromMiddle() throws Exception {
+        try {
+            String relativePath = new File("src" + File.separator + "test" + File.separator + "resources"
+                    + File.separator + "filter" + File.separator +
+                    "multiple-filters-execution-failure-from-middle-test.bal").getAbsolutePath();
+            startServer(relativePath);
+            Map<String, String> headers = new HashMap<>();
+            headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_TEXT_PLAIN);
+            HttpResponse response = HttpClientRequest.doGet(ballerinaServer
+                    .getServiceURLHttp("echo/test"), headers);
+            Assert.assertNotNull(response);
+            Assert.assertEquals(response.getResponseCode(), 405, "Response code mismatched");
+        } finally {
+            ballerinaServer.stopServer();
+        }
+    }
+
+    private void startServer(String balFile) throws Exception {
+        ballerinaServer = ServerInstance.initBallerinaServer();
+        ballerinaServer.startBallerinaServer(balFile);
+    }
+
+}

--- a/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/filter/SingleFilterTestCase.java
+++ b/tests/ballerina-test-integration/src/test/java/org/ballerinalang/test/filter/SingleFilterTestCase.java
@@ -1,0 +1,77 @@
+/*
+*  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+
+package org.ballerinalang.test.filter;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import org.ballerinalang.test.IntegrationTestCase;
+import org.ballerinalang.test.context.ServerInstance;
+import org.ballerinalang.test.util.HttpClientRequest;
+import org.ballerinalang.test.util.HttpResponse;
+import org.ballerinalang.test.util.TestConstant;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SingleFilterTestCase extends IntegrationTestCase {
+    private ServerInstance ballerinaServer;
+
+    @Test(description = "Single filter execution success case")
+    public void testSingleFilterSuccess() throws Exception {
+        try {
+            String relativePath = new File("src" + File.separator + "test" + File.separator + "resources"
+                    + File.separator + "filter" + File.separator +
+                    "single-filter-execution-success-test.bal").getAbsolutePath();
+            startServer(relativePath);
+            Map<String, String> headers = new HashMap<>();
+            headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_TEXT_PLAIN);
+            HttpResponse response = HttpClientRequest.doGet(ballerinaServer
+                    .getServiceURLHttp("echo/test"), headers);
+            Assert.assertNotNull(response);
+            Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+        } finally {
+            ballerinaServer.stopServer();
+        }
+    }
+
+    @Test(description = "Single filter execution failure case")
+    public void testSingleFilterFailure() throws Exception {
+        try {
+            String relativePath = new File("src" + File.separator + "test" + File.separator + "resources"
+                    + File.separator + "filter" + File.separator +
+                    "single-filter-execution-failure-test.bal").getAbsolutePath();
+            startServer(relativePath);
+            Map<String, String> headers = new HashMap<>();
+            headers.put(HttpHeaderNames.CONTENT_TYPE.toString(), TestConstant.CONTENT_TYPE_TEXT_PLAIN);
+            HttpResponse response = HttpClientRequest.doGet(ballerinaServer
+                    .getServiceURLHttp("echo/test"), headers);
+            Assert.assertNotNull(response);
+            Assert.assertEquals(response.getResponseCode(), 401, "Response code mismatched");
+        } finally {
+            ballerinaServer.stopServer();
+        }
+    }
+
+    private void startServer(String balFile) throws Exception {
+        ballerinaServer = ServerInstance.initBallerinaServer();
+        ballerinaServer.startBallerinaServer(balFile);
+    }
+}

--- a/tests/ballerina-test-integration/src/test/resources/filter/multiple-filters-execution-failure-from-middle-test.bal
+++ b/tests/ballerina-test-integration/src/test/resources/filter/multiple-filters-execution-failure-from-middle-test.bal
@@ -1,0 +1,108 @@
+import ballerina.net.http;
+import ballerina.log;
+
+// Filter1
+
+public struct Filter1 {
+    function (http:Request request, http:FilterContext context) returns (http:FilterResult) filterRequest;
+    function (http:Response response, http:FilterContext context) returns (http:FilterResult) filterResponse;
+}
+
+public function <Filter1 filter> init () {
+    log:printInfo("Initializing filter 1");
+}
+
+public function <Filter1 filter> terminate () {
+    log:printInfo("Stopping filter 1");
+}
+
+public function interceptRequest1 (http:Request request, http:FilterContext context) (http:FilterResult) {
+    log:printInfo("Intercepting request for filter 1");
+    http:FilterResult filterResponse = {canProceed:true, statusCode:200, message:"successful"};
+    return filterResponse;
+}
+
+public function interceptResponse1 (http:Response response, http:FilterContext context) (http:FilterResult) {
+    log:printInfo("Intercepting response for filter 1");
+    http:FilterResult filterResponse = {canProceed:true, statusCode:200, message:"successful"};
+    return filterResponse;
+}
+
+Filter1 filter1 = {filterRequest:interceptRequest1, filterResponse:interceptResponse1};
+
+// Filter2
+
+public struct Filter2 {
+    function (http:Request request, http:FilterContext context) returns (http:FilterResult) filterRequest;
+    function (http:Response response, http:FilterContext context) returns (http:FilterResult) filterResponse;
+}
+
+public function <Filter2 filter> init () {
+    log:printInfo("Initializing filter 2");
+}
+
+public function <Filter2 filter> terminate () {
+    log:printInfo("Stopping filter 2");
+}
+
+public function interceptRequest2 (http:Request request, http:FilterContext context) (http:FilterResult) {
+    log:printInfo("Intercepting request for filter 2");
+    http:FilterResult filterResponse = {canProceed:false, statusCode:405, message:"Not Allowed"};
+    return filterResponse;
+}
+
+public function interceptResponse2 (http:Response response, http:FilterContext context) (http:FilterResult) {
+    log:printInfo("Intercepting response for filter 2");
+    http:FilterResult filterResponse = {canProceed:true, statusCode:200, message:"successful"};
+    return filterResponse;
+}
+
+Filter2 filter2 = {filterRequest:interceptRequest2, filterResponse:interceptResponse2};
+
+// Filter3
+
+public struct Filter3 {
+    function (http:Request request, http:FilterContext context) returns (http:FilterResult) filterRequest;
+    function (http:Response response, http:FilterContext context) returns (http:FilterResult) filterResponse;
+}
+
+public function <Filter3 filter> init () {
+    log:printInfo("Initializing filter 3");
+}
+
+public function <Filter3 filter> terminate () {
+    log:printInfo("Stopping filter 3");
+}
+
+public function interceptRequest3 (http:Request request, http:FilterContext context) (http:FilterResult) {
+    log:printInfo("Intercepting request for filter 3");
+    http:FilterResult filterResponse = {canProceed:true, statusCode:200, message:"successful"};
+    return filterResponse;
+}
+
+public function interceptResponse3 (http:Response response, http:FilterContext context) (http:FilterResult) {
+    log:printInfo("Intercepting response for filter 3");
+    http:FilterResult filterResponse = {canProceed:true, statusCode:200, message:"successful"};
+    return filterResponse;
+}
+
+Filter3 filter3 = {filterRequest:interceptRequest3, filterResponse:interceptResponse3};
+
+endpoint http:Endpoint echoEP {
+    port:9090,
+    filters:[filter1,filter2,filter3]
+};
+
+@http:serviceConfig {
+    basePath:"/echo"
+}
+service<http:HttpService> echo bind echoEP {
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"/test"
+    }
+    echo (endpoint client, http:Request req) {
+        http:Response res = {};
+        _ = client -> respond(res);
+    }
+}

--- a/tests/ballerina-test-integration/src/test/resources/filter/multiple-filters-execution-sucess-test.bal
+++ b/tests/ballerina-test-integration/src/test/resources/filter/multiple-filters-execution-sucess-test.bal
@@ -1,0 +1,79 @@
+import ballerina.net.http;
+import ballerina.log;
+
+// Filter1
+
+public struct Filter1 {
+    function (http:Request request, http:FilterContext context) returns (http:FilterResult) filterRequest;
+    function (http:Response response, http:FilterContext context) returns (http:FilterResult) filterResponse;
+}
+
+public function <Filter1 filter> init () {
+    log:printInfo("Initializing filter 1");
+}
+
+public function <Filter1 filter> terminate () {
+    log:printInfo("Stopping filter 1");
+}
+
+public function interceptRequest1 (http:Request request, http:FilterContext context) (http:FilterResult) {
+    log:printInfo("Intercepting request for filter 1");
+    http:FilterResult filterResponse = {canProceed:true, statusCode:200, message:"successful"};
+    return filterResponse;
+}
+
+public function interceptResponse1 (http:Response response, http:FilterContext context) (http:FilterResult) {
+    log:printInfo("Intercepting response for filter 1");
+    http:FilterResult filterResponse = {canProceed:true, statusCode:200, message:"successful"};
+    return filterResponse;
+}
+
+Filter1 filter1 = {filterRequest:interceptRequest1, filterResponse:interceptResponse1};
+
+// Filter2
+
+public struct Filter2 {
+    function (http:Request request, http:FilterContext context) returns (http:FilterResult) filterRequest;
+    function (http:Response response, http:FilterContext context) returns (http:FilterResult) filterResponse;
+}
+
+public function <Filter2 filter> init () {
+    log:printInfo("Initializing filter 2");
+}
+
+public function <Filter2 filter> terminate () {
+    log:printInfo("Stopping filter 2");
+}
+
+public function interceptRequest2 (http:Request request, http:FilterContext context) (http:FilterResult) {
+    log:printInfo("Intercepting request for filter 2");
+    http:FilterResult filterResponse = {canProceed:true, statusCode:200, message:"successful"};
+    return filterResponse;
+}
+
+public function interceptResponse2 (http:Response response, http:FilterContext context) (http:FilterResult) {
+    log:printInfo("Intercepting response for filter 2");
+    http:FilterResult filterResponse = {canProceed:true, statusCode:200, message:"successful"};
+    return filterResponse;
+}
+
+Filter2 filter2 = {filterRequest:interceptRequest2, filterResponse:interceptResponse2};
+
+endpoint http:Endpoint echoEP {
+    port:9090,
+    filters:[filter1,filter2]
+};
+
+@http:serviceConfig {
+    basePath:"/echo"
+}
+service<http:HttpService> echo bind echoEP {
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"/test"
+    }
+    echo (endpoint client, http:Request req) {
+        http:Response res = {};
+        _ = client -> respond(res);
+    }
+}

--- a/tests/ballerina-test-integration/src/test/resources/filter/multipler-filters-execution-failure-from-last-test.bal
+++ b/tests/ballerina-test-integration/src/test/resources/filter/multipler-filters-execution-failure-from-last-test.bal
@@ -1,0 +1,79 @@
+import ballerina.net.http;
+import ballerina.log;
+
+// Filter1
+
+public struct Filter1 {
+    function (http:Request request, http:FilterContext context) returns (http:FilterResult) filterRequest;
+    function (http:Response response, http:FilterContext context) returns (http:FilterResult) filterResponse;
+}
+
+public function <Filter1 filter> init () {
+    log:printInfo("Initializing filter 1");
+}
+
+public function <Filter1 filter> terminate () {
+    log:printInfo("Stopping filter 1");
+}
+
+public function interceptRequest1 (http:Request request, http:FilterContext context) (http:FilterResult) {
+    log:printInfo("Intercepting request for filter 1");
+    http:FilterResult filterResponse = {canProceed:true, statusCode:200, message:"successful"};
+    return filterResponse;
+}
+
+public function interceptResponse1 (http:Response response, http:FilterContext context) (http:FilterResult) {
+    log:printInfo("Intercepting response for filter 1");
+    http:FilterResult filterResponse = {canProceed:true, statusCode:200, message:"successful"};
+    return filterResponse;
+}
+
+Filter1 filter1 = {filterRequest:interceptRequest1, filterResponse:interceptResponse1};
+
+// Filter2
+
+public struct Filter2 {
+    function (http:Request request, http:FilterContext context) returns (http:FilterResult) filterRequest;
+    function (http:Response response, http:FilterContext context) returns (http:FilterResult) filterResponse;
+}
+
+public function <Filter2 filter> init () {
+    log:printInfo("Initializing filter 2");
+}
+
+public function <Filter2 filter> terminate () {
+    log:printInfo("Stopping filter 2");
+}
+
+public function interceptRequest2 (http:Request request, http:FilterContext context) (http:FilterResult) {
+    log:printInfo("Intercepting request for filter 2");
+    http:FilterResult filterResponse = {canProceed:false, statusCode:403, message:"Authorization failure"};
+    return filterResponse;
+}
+
+public function interceptResponse2 (http:Response response, http:FilterContext context) (http:FilterResult) {
+    log:printInfo("Intercepting response for filter 2");
+    http:FilterResult filterResponse = {canProceed:true, statusCode:200, message:"successful"};
+    return filterResponse;
+}
+
+Filter2 filter2 = {filterRequest:interceptRequest2, filterResponse:interceptResponse2};
+
+endpoint http:Endpoint echoEP {
+    port:9090,
+    filters:[filter1,filter2]
+};
+
+@http:serviceConfig {
+    basePath:"/echo"
+}
+service<http:HttpService> echo bind echoEP {
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"/test"
+    }
+    echo (endpoint client, http:Request req) {
+        http:Response res = {};
+        _ = client -> respond(res);
+    }
+}

--- a/tests/ballerina-test-integration/src/test/resources/filter/single-filter-execution-failure-test.bal
+++ b/tests/ballerina-test-integration/src/test/resources/filter/single-filter-execution-failure-test.bal
@@ -1,0 +1,48 @@
+import ballerina.net.http;
+import ballerina.log;
+
+public struct Filter1 {
+    function (http:Request request, http:FilterContext context) returns (http:FilterResult) filterRequest;
+    function (http:Response response, http:FilterContext context) returns (http:FilterResult) filterResponse;
+}
+
+public function <Filter1 filter> init () {
+    log:printInfo("Initializing filter 1");
+}
+
+public function <Filter1 filter> terminate () {
+    log:printInfo("Stopping filter 1");
+}
+
+public function interceptRequest1 (http:Request request, http:FilterContext context) (http:FilterResult) {
+    log:printInfo("Intercepting request for filter 1");
+    http:FilterResult filterResponse = {canProceed:false, statusCode:401, message:"Authentication failure"};
+    return filterResponse;
+}
+
+public function interceptResponse1 (http:Response response, http:FilterContext context) (http:FilterResult) {
+    log:printInfo("Intercepting response for filter 1");
+    http:FilterResult filterResponse = {canProceed:true, statusCode:200, message:"successful"};
+    return filterResponse;
+}
+
+Filter1 filter1 = {filterRequest:interceptRequest1, filterResponse:interceptResponse1};
+
+endpoint http:Endpoint echoEP {
+    port:9090,
+    filters:[filter1]
+};
+
+@http:serviceConfig {
+    basePath:"/echo"
+}
+service<http:HttpService> echo bind echoEP {
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"/test"
+    }
+    echo (endpoint client, http:Request req) {
+    http:Response res = {};
+    _ = client -> respond(res);
+    }
+}

--- a/tests/ballerina-test-integration/src/test/resources/filter/single-filter-execution-success-test.bal
+++ b/tests/ballerina-test-integration/src/test/resources/filter/single-filter-execution-success-test.bal
@@ -1,0 +1,48 @@
+import ballerina.net.http;
+import ballerina.log;
+
+public struct Filter1 {
+    function (http:Request request, http:FilterContext context) returns (http:FilterResult) filterRequest;
+    function (http:Response response, http:FilterContext context) returns (http:FilterResult) filterResponse;
+}
+
+public function <Filter1 filter> init () {
+    log:printInfo("Initializing filter 1");
+}
+
+public function <Filter1 filter> terminate () {
+    log:printInfo("Stopping filter 1");
+}
+
+public function interceptRequest1 (http:Request request, http:FilterContext context) (http:FilterResult) {
+    log:printInfo("Intercepting request for filter 1");
+    http:FilterResult filterResponse = {canProceed:true, statusCode:200, message:"successful"};
+    return filterResponse;
+}
+
+public function interceptResponse1 (http:Response response, http:FilterContext context) (http:FilterResult) {
+    log:printInfo("Intercepting response for filter 1");
+    http:FilterResult filterResponse = {canProceed:true, statusCode:200, message:"successful"};
+    return filterResponse;
+}
+
+Filter1 filter1 = {filterRequest:interceptRequest1, filterResponse:interceptResponse1};
+
+endpoint http:Endpoint echoEP {
+    port:9090,
+    filters:[filter1]
+};
+
+@http:serviceConfig {
+    basePath:"/echo"
+}
+service<http:HttpService> echo bind echoEP {
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"/test"
+    }
+    echo (endpoint client, http:Request req) {
+        http:Response res = {};
+        _ = client -> respond(res);
+    }
+}

--- a/tests/ballerina-test-integration/src/test/resources/testng.xml
+++ b/tests/ballerina-test-integration/src/test/resources/testng.xml
@@ -29,6 +29,7 @@
             <!--<package name="org.ballerinalang.test.service.http.sample"/>-->
             <!--<package name="org.ballerinalang.test.service.http2"/>-->
             <package name="org.ballerinalang.test.transaction"/>
+	    <!--package name="org.ballerinalang.test.filter"/-->
         </packages>
     </test>
 


### PR DESCRIPTION
## Purpose
> Provide the capability to intercept a HTTP request before its dispatched to a resource and do custom handling. 

## Approach
> Used a Filter struct as an API to provide the filtering capability. Any custom Filter should be struct-wise similar to this Filter struct. Two request and response handler function pointers are defined as fields of the struct. The HTTP Dispatcher would invoke the request and response handlers. 