### PR TITLE
Add revised byte io apis

### DIFF
--- a/docs/ballerina-by-example/examples/byte-i-o/byte-i-o.bal
+++ b/docs/ballerina-by-example/examples/byte-i-o/byte-i-o.bal
@@ -8,12 +8,12 @@ function getFileChannel (string filePath, string permission) (io:ByteChannel) {
 }
 
 @Description {value:"This function reads the specified number of bytes from the given channel."}
-function readBytes (io:ByteChannel channel, int numberOfBytes, int offset) (blob, int) {
+function readBytes (io:ByteChannel channel, int numberOfBytes) (blob, int) {
     blob bytes;
     int numberOfBytesRead;
     io:IOError readError;
     // Here is how the bytes are read from the channel.
-    bytes, numberOfBytesRead, readError = channel.read(numberOfBytes, offset);
+    bytes, numberOfBytesRead, readError = channel.read(numberOfBytes);
     if (readError != null) {
         throw readError.cause;
     }
@@ -21,11 +21,11 @@ function readBytes (io:ByteChannel channel, int numberOfBytes, int offset) (blob
 }
 
 @Description {value:"This function writes a byte content with the given offset to a channel."}
-function writeBytes (io:ByteChannel channel, blob content, int startOffset, int size) (int) {
+function writeBytes (io:ByteChannel channel, blob content, int startOffset = 0) (int) {
     int numberOfBytesWritten;
     io:IOError writeError;
     // Here is how the bytes are written to the channel.
-    numberOfBytesWritten, writeError = channel.write(content, startOffset, size);
+    numberOfBytesWritten, writeError = channel.write(content,startOffset);
     if (writeError != null) {
         throw writeError.cause;
     }
@@ -45,12 +45,12 @@ function copy (io:ByteChannel src, io:ByteChannel dst) {
         // Here is how to specify to read all the content from
         // the source and copy it to the destination.
         while (!done) {
-            readContent, readCount = readBytes(src, bytesChunk, offset);
+            readContent, readCount = readBytes(src,1000);
             if (readCount <= 0) {
                 //If no content is read we end the loop
                 done = true;
             }
-            numberOfBytesWritten = writeBytes(dst, readContent, offset, readCount);
+            numberOfBytesWritten = writeBytes(dst, readContent);
         }
     } catch (error err) {
         throw err;

--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/io/natives.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/io/natives.bal
@@ -104,20 +104,19 @@ public native function createDelimitedRecordChannel (CharacterChannel channel, s
 
 @Description {value:"Function to read bytes"}
 @Param {value:"channel: The ByteChannel to read bytes from"}
-@Param {value:"numberOfBytes: Number of bytes which should be read"}
+@Param {value:"nBytes: Number of bytes which should be read"}
 @Return {value:"The bytes which were read"}
 @Return {value:"Number of bytes read"}
 @Return {value:"Returns if there's any error while performaing I/O operation"}
-public native function <ByteChannel channel> read (@sensitive int numberOfBytes, @sensitive int offset) (blob, int,
-                                                                                                         IOError);
+public native function <ByteChannel channel> read (@sensitive int nBytes) (blob, int, IOError);
 
 @Description {value:"Function to write bytes"}
 @Param {value:"channel: The ByteChannel to write bytes to"}
 @Param {value:"content: Bytes which should be written"}
-@Param {value:"startOffset: If the bytes need to be written with an offset, the value of that offset"}
+@Param {value:"offset: If the bytes need to be written with an offset, the value of that offset"}
 @Return {value:"Number of bytes written"}
 @Return {value:"Returns if there's any error while performaing I/O operation"}
-public native function <ByteChannel channel> write (blob content, int startOffset, int numberOfBytes)(int, IOError);
+public native function <ByteChannel channel> write (blob content, int offset)(int, IOError);
 
 @Description {value:"Function to read characters"}
 @Param {value:"channel: The CharacterChannel to read characters from"}

--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/io/natives.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/io/natives.bal
@@ -171,8 +171,8 @@ public native function <CharacterChannel channel> closeCharacterChannel () (IOEr
 @Param {value:"options: Connection stream that bridge the client and the server"}
 @Return {value:"Socket which will allow to communicate with a remote server"}
 @Return {value:"Returns an IOError if unable to open the socket connection"}
-public native function openSecureSocket (@sensitive string host, @sensitive int port,
-                                         SocketProperties options) (@tainted Socket, IOError);
+public native function openSecureSocket (@sensitive string host, @sensitive int port, SocketProperties options)
+(@tainted Socket, IOError);
 
 @Description {value:"Close the socket connection with the remote server"}
 @Param {value:"socket: The client socket connection to be to be closed"}

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/Read.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/Read.java
@@ -44,25 +44,17 @@ import org.ballerinalang.natives.annotations.ReturnType;
         packageName = "ballerina.io",
         functionName = "read",
         receiver = @Receiver(type = TypeKind.STRUCT, structType = "ByteChannel", structPackage = "ballerina.io"),
-        args = {@Argument(name = "numberOfBytes", type = TypeKind.INT),
-                @Argument(name = "offset", type = TypeKind.INT)},
+        args = {@Argument(name = "nBytes", type = TypeKind.INT)},
         returnType = {@ReturnType(type = TypeKind.BLOB),
                 @ReturnType(type = TypeKind.INT),
                 @ReturnType(type = TypeKind.STRUCT, structType = "IOError", structPackage = "ballerina.io")},
         isPublic = true
 )
 public class Read implements NativeCallableUnit {
-
     /**
      * Specifies the index which holds the number of bytes in ballerina.lo#readBytes.
      */
     private static final int NUMBER_OF_BYTES_INDEX = 0;
-
-    /**
-     * Specifies the offset of the array to read bytes.
-     */
-    private static final int OFFSET_INDEX = 1;
-
     /**
      * Specifies the index which contains the byte channel in ballerina.lo#readBytes.
      */
@@ -100,12 +92,12 @@ public class Read implements NativeCallableUnit {
     @Override
     public void execute(Context context, CallableUnitCallback callback) {
         BStruct channel = (BStruct) context.getRefArgument(BYTE_CHANNEL_INDEX);
-        int numberOfBytes = (int) context.getIntArgument(NUMBER_OF_BYTES_INDEX);
-        int offset = (int) context.getIntArgument(OFFSET_INDEX);
+        int nBytes = (int) context.getIntArgument(NUMBER_OF_BYTES_INDEX);
+        int arraySize = nBytes <= 0 ? IOConstants.CHANNEL_BUFFER_SIZE : nBytes;
         Channel byteChannel = (Channel) channel.getNativeData(IOConstants.BYTE_CHANNEL_NAME);
-        byte[] content = new byte[numberOfBytes];
+        byte[] content = new byte[arraySize];
         EventContext eventContext = new EventContext(context, callback);
-        IOUtils.read(byteChannel, content, offset, eventContext, Read::readResponse);
+        IOUtils.read(byteChannel, content, eventContext, Read::readResponse);
     }
 
     @Override

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/Write.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/Write.java
@@ -43,8 +43,7 @@ import org.ballerinalang.natives.annotations.ReturnType;
         functionName = "write",
         receiver = @Receiver(type = TypeKind.STRUCT, structType = "ByteChannel", structPackage = "ballerina.io"),
         args = {@Argument(name = "content", type = TypeKind.BLOB),
-                @Argument(name = "startOffset", type = TypeKind.INT),
-                @Argument(name = "numberOfBytes", type = TypeKind.INT)},
+                @Argument(name = "offset", type = TypeKind.INT)},
         returnType = {@ReturnType(type = TypeKind.INT),
                 @ReturnType(type = TypeKind.STRUCT, structType = "IOError", structPackage = "ballerina.io")},
         isPublic = true
@@ -65,11 +64,6 @@ public class Write implements NativeCallableUnit {
      * Index which holds the start offset in ballerina.io#writeBytes.
      */
     private static final int START_OFFSET_INDEX = 0;
-
-    /*
-     * Index which holds the number of bytes which should be written.
-     */
-    private static final int NUMBER_OF_BYTES_INDEX = 1;
 
     /*
      * Function which will be notified on the response obtained after the async operation.
@@ -102,11 +96,10 @@ public class Write implements NativeCallableUnit {
     public void execute(Context context, CallableUnitCallback callback) {
         BStruct channel = (BStruct) context.getRefArgument(BYTE_CHANNEL_INDEX);
         byte[] content = context.getBlobArgument(CONTENT_INDEX);
-        int numberOfBytes = (int) context.getIntArgument(NUMBER_OF_BYTES_INDEX);
         int offset = (int) context.getIntArgument(START_OFFSET_INDEX);
         Channel byteChannel = (Channel) channel.getNativeData(IOConstants.BYTE_CHANNEL_NAME);
         EventContext eventContext = new EventContext(context, callback);
-        IOUtils.write(byteChannel, content, offset, numberOfBytes, eventContext, Write::writeResponse);
+        IOUtils.write(byteChannel, content, offset, eventContext, Write::writeResponse);
     }
 
     @Override

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/bytes/WriteBytesEvent.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/events/bytes/WriteBytesEvent.java
@@ -51,20 +51,18 @@ public class WriteBytesEvent implements Event {
     /**
      * Context of the event which will be called upon completion.
      */
-    public WriteBytesEvent(Channel byteChannel, byte[] content, int startOffset, int size) {
+    public WriteBytesEvent(Channel byteChannel, byte[] content, int startOffset) {
         this.byteChannel = byteChannel;
         writeBuffer = ByteBuffer.wrap(content);
         //If a larger position is set, the position would be disregarded
         writeBuffer.position(startOffset);
-        writeBuffer.limit(size);
     }
 
-    public WriteBytesEvent(Channel byteChannel, byte[] content, int startOffset, int size, EventContext context) {
+    public WriteBytesEvent(Channel byteChannel, byte[] content, int startOffset, EventContext context) {
         this.byteChannel = byteChannel;
         writeBuffer = ByteBuffer.wrap(content);
         //If a larger position is set, the position would be disregarded
         writeBuffer.position(startOffset);
-        writeBuffer.limit(size);
         this.context = context;
     }
 

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/IOTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/IOTest.java
@@ -94,7 +94,7 @@ public class IOTest {
         Assert.assertEquals(expectedBytes, readBytes.blobValue());
 
         //Request for a get, the bytes will be empty
-        expectedBytes = new byte[3];
+        expectedBytes = new byte[0];
         args = new BValue[]{new BInteger(numberOfBytesToRead)};
         returns = BRunUtil.invoke(bytesInputOutputProgramFile, "readBytes", args);
         readBytes = (BBlob) returns[0];
@@ -188,7 +188,7 @@ public class IOTest {
         BValue[] args = {new BString(sourceToWrite), new BString("w")};
         BRunUtil.invoke(bytesInputOutputProgramFile, "initFileChannel", args);
 
-        args = new BValue[]{new BBlob(content), new BInteger(0), new BInteger(content.length)};
+        args = new BValue[]{new BBlob(content), new BInteger(0)};
         BRunUtil.invoke(bytesInputOutputProgramFile, "writeBytes", args);
 
         BRunUtil.invoke(bytesInputOutputProgramFile, "close");

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/bytes/AsyncReadWriteTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/bytes/AsyncReadWriteTest.java
@@ -56,22 +56,21 @@ public class AsyncReadWriteTest {
         Channel channel = new MockByteChannel(byteChannel);
 
         byte[] expected = {49, 50};
-        int offset = 0;
-        IOUtils.readFull(channel, content, offset, new EventContext());
+        IOUtils.readFull(channel, content, new EventContext());
         Assert.assertEquals(expected, content);
 
         expected = new byte[]{51, 52};
-        IOUtils.readFull(channel, content, offset, new EventContext());
+        IOUtils.readFull(channel, content, new EventContext());
         Assert.assertEquals(expected, content);
 
         expected = new byte[]{53, 54};
-        IOUtils.readFull(channel, content, offset, new EventContext());
+        IOUtils.readFull(channel, content, new EventContext());
         Assert.assertEquals(expected, content);
 
         int expectedNumberOfBytes = 0;
         content = new byte[2];
         expected = new byte[]{0, 0};
-        int numberOfBytesRead = IOUtils.readFull(channel, content, offset, new EventContext());
+        int numberOfBytesRead = IOUtils.readFull(channel, content, new EventContext());
         Assert.assertEquals(numberOfBytesRead, expectedNumberOfBytes);
         Assert.assertEquals(expected, content);
     }
@@ -86,17 +85,16 @@ public class AsyncReadWriteTest {
 
         byte[] expected = "123".getBytes();
 
-        int offset = 0;
-        IOUtils.readFull(channel, content, offset, new EventContext());
+        IOUtils.readFull(channel, content, new EventContext());
         Assert.assertEquals(expected, content);
 
         expected = "456".getBytes();
-        IOUtils.readFull(channel, content, offset, new EventContext());
+        IOUtils.readFull(channel, content, new EventContext());
         Assert.assertEquals(expected, content);
 
         content = new byte[3];
         expected = new byte[3];
-        IOUtils.readFull(channel, content, offset, new EventContext());
+        IOUtils.readFull(channel, content, new EventContext());
         Assert.assertEquals(expected, content);
     }
 
@@ -107,7 +105,7 @@ public class AsyncReadWriteTest {
         Channel channel = new MockByteChannel(byteChannel);
         byte[] bytes = "hello".getBytes();
 
-        int numberOfBytesWritten = IOUtils.writeFull(channel, bytes, 0, bytes.length, new EventContext());
+        int numberOfBytesWritten = IOUtils.writeFull(channel, bytes, 0, new EventContext());
         Assert.assertEquals(numberOfBytesWritten, bytes.length);
     }
 

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/socket/ClientSocketTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/socket/ClientSocketTest.java
@@ -139,7 +139,7 @@ public class ClientSocketTest {
     public void testWriteReadContent() {
         String content = "Hello World\n";
         byte[] contentBytes = content.getBytes();
-        BValue[] args = { new BBlob(contentBytes), new BInteger(contentBytes.length) };
+        BValue[] args = { new BBlob(contentBytes)};
         final BValue[] writeReturns = BRunUtil.invoke(socketClient, "write", args);
         BInteger returnedSize = (BInteger) writeReturns[0];
         Assert.assertEquals(returnedSize.intValue(), content.length(), "Write content size is not match.");

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/socket/SecureClientSocketTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/socket/SecureClientSocketTest.java
@@ -154,7 +154,7 @@ public class SecureClientSocketTest {
         final String newline = System.lineSeparator();
         String content = "Hello World" + newline;
         final byte[] contentBytes = content.getBytes();
-        BValue[] args = { new BBlob(contentBytes), new BInteger(contentBytes.length) };
+        BValue[] args = { new BBlob(contentBytes)};
         final BValue[] writeReturns = BRunUtil.invoke(socketClient, "write", args);
         BInteger returnedSize = (BInteger) writeReturns[0];
         Assert.assertEquals(returnedSize.intValue(), content.length(), "Write content size is not match.");

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/taintchecking/connectors/IOTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/taintchecking/connectors/IOTest.java
@@ -46,16 +46,15 @@ public class IOTest {
         BAssertUtil.validateError(result, 2, "tainted value passed to sensitive parameter 'numberOfChars'", 20, 40);
         BAssertUtil.validateError(result, 3, "tainted value passed to sensitive parameter 'sensitiveValue'", 22, 18);
     }
-    
+
     @Test
     public void testFileIONegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/connectors/file-read-negative.bal");
-        Assert.assertTrue(result.getDiagnostics().length == 5);
+        Assert.assertTrue(result.getDiagnostics().length == 4);
         BAssertUtil.validateError(result, 0, "tainted value passed to sensitive parameter 'accessMode'", 6, 17);
         BAssertUtil.validateError(result, 1, "tainted value passed to sensitive parameter 'accessMode'", 8, 50);
-        BAssertUtil.validateError(result, 2, "tainted value passed to sensitive parameter 'numberOfBytes'", 14, 34);
-        BAssertUtil.validateError(result, 3, "tainted value passed to sensitive parameter 'offset'", 14, 42);
-        BAssertUtil.validateError(result, 4, "tainted value passed to sensitive parameter 'sensitiveValue'", 16, 18);
+        BAssertUtil.validateError(result, 2, "tainted value passed to sensitive parameter 'nBytes'", 14, 34);
+        BAssertUtil.validateError(result, 3, "tainted value passed to sensitive parameter 'sensitiveValue'", 16, 18);
     }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/io/bytesio.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/bytesio.bal
@@ -9,13 +9,13 @@ function initFileChannel (string filePath, string permission) {
 function readBytes (int numberOfBytes) (blob) {
     blob bytes;
     int numberOfBytesRead;
-    bytes, numberOfBytesRead, _ = channel.read(numberOfBytes, 0);
+    bytes, numberOfBytesRead, _ = channel.read(numberOfBytes);
     return bytes;
 }
 
-function writeBytes (blob content, int startOffset, int size) (int) {
+function writeBytes (blob content, int startOffset) (int) {
     int numberOfBytesWritten;
-    numberOfBytesWritten, _ = channel.write(content, startOffset, size);
+    numberOfBytesWritten, _ = channel.write(content, startOffset);
     return numberOfBytesWritten;
 }
 

--- a/tests/ballerina-test/src/test/resources/test-src/io/clientsocketio.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/clientsocketio.bal
@@ -15,10 +15,10 @@ function closeSocket () {
     _ = socket.closeSocket();
 }
 
-function write (blob content, int size) (int) {
+function write (blob content) (int) {
     int numberOfBytesWritten;
     io:ByteChannel channel = socket.channel;
-    numberOfBytesWritten, _ = channel.write(content, 0, size);
+    numberOfBytesWritten, _ = channel.write(content, 0);
     return numberOfBytesWritten;
 }
 
@@ -26,7 +26,7 @@ function read (int size) (blob, int) {
     io:ByteChannel channel = socket.channel;
     blob readContent;
     int readSize;
-    readContent, readSize, _ = channel.read(size, 0);
+    readContent, readSize, _ = channel.read(size);
     return readContent, readSize;
 }
 

--- a/tests/ballerina-test/src/test/resources/test-src/io/secureclientsocketio.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/secureclientsocketio.bal
@@ -10,10 +10,10 @@ function closeSocket () {
     _ = socket.closeSocket();
 }
 
-function write (blob content, int size) (int) {
+function write (blob content) (int) {
     int numberOfBytesWritten;
     io:ByteChannel channel = socket.channel;
-    numberOfBytesWritten, _ = channel.write(content, 0, size);
+    numberOfBytesWritten, _ = channel.write(content, 0);
     return numberOfBytesWritten;
 }
 
@@ -21,6 +21,6 @@ function read (int size) (blob, int) {
     io:ByteChannel channel = socket.channel;
     blob readContent;
     int readSize;
-    readContent, readSize, _ = channel.read(size, 0);
+    readContent, readSize, _ = channel.read(size);
     return readContent, readSize;
 }

--- a/tests/ballerina-test/src/test/resources/test-src/mime/mime-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/mime/mime-test.bal
@@ -166,7 +166,7 @@ function consumeChannel (io:ByteChannel channel) {
     int numberOfBytesRead = 1;
     blob readContent;
     while (numberOfBytesRead != 0) {
-        readContent, numberOfBytesRead, _ = channel.read(10000, 0);
+        readContent, numberOfBytesRead, _ = channel.read(10000);
     }
 }
 

--- a/tests/ballerina-test/src/test/resources/test-src/taintchecking/connectors/file-read-negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/taintchecking/connectors/file-read-negative.bal
@@ -11,7 +11,7 @@ function main (string[] args) {
 
     blob data;
     int len;
-    data, len, _ = bchannel.read(intArg, intArg);
+    data, len, _ = bchannel.read(intArg);
 
     testFunction(data, data);
 }


### PR DESCRIPTION
## Purpose
Based on the new revision, byte I/O APIs would conform to support blob. While supporting the async nature of functions.

## Goals
Convert existing byte I/O APIs with the new design.

## Approach
The new byte I/O APIs would look like the following,

```
function<ByteChannel c> read(int numberOfBytes) returns (blob content,int nBytes,error e);
```
```
function<ByteChannel c> write (blob content, int startOffset) returns (int numOfBytesWritten, error e);
```

## Test environment
JDK 1.8