### PR TITLE
Add configurations for ssl session creation

### DIFF
--- a/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/client_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/client_endpoint.bal
@@ -112,13 +112,15 @@ public struct Retry {
 @Field {value: "validateCert: Certificate validation against CRL or OCSP related options"}
 @Field {value:"ciphers: List of ciphers to be used. eg: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"}
 @Field {value:"hostNameVerificationEnabled: Enable/disable host name verification"}
+@Field {value:"sessionCreationEnabled: Enable/disable new ssl session creation"}
 public struct SecureSocket {
     TrustStore trustStore;
     KeyStore keyStore;
     Protocols protocols;
     ValidateCert validateCert;
     string ciphers;
-    boolean hostNameVerificationEnabled;
+    boolean hostNameVerification = true;
+    boolean sessionCreation = true;
 }
 
 @Description { value:"FollowRedirects struct represents HTTP redirect related options to be used for HTTP client invocation" }

--- a/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/service_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/ballerina/net/http/service_endpoint.bal
@@ -65,7 +65,7 @@ public struct ServiceSecureSocket {
     ValidateCert validateCert;
     string ciphers;
     string sslVerifyClient;
-    boolean hostNameVerificationEnabled;
+    boolean sessionCreation = true;
 }
 
 public enum KeepAlive {

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -262,7 +262,8 @@ public class HttpConstants {
     public static final String SSL_CONFIG_CIPHERS = "ciphers";
     public static final String SSL_CONFIG_CACHE_SIZE = "cacheSize";
     public static final String SSL_CONFIG_CACHE_VALIDITY_PERIOD = "cacheValidityPeriod";
-    public static final String SSL_CONFIG_HOST_NAME_VERIFICATION_ENABLED = "hostNameVerificationEnabled";
+    public static final String SSL_CONFIG_HOST_NAME_VERIFICATION_ENABLED = "hostNameVerification";
+    public static final String SSL_CONFIG_ENABLE_SESSION_CREATION = "sessionCreation";
 
     //Client Endpoint
     public static final String CLIENT_ENDPOINT_CONFIG = "config";

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateHttpClient.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateHttpClient.java
@@ -193,6 +193,11 @@ public class CreateHttpClient extends BlockingNativeCallableUnit {
                     Parameter clientCiphers = new Parameter(HttpConstants.CIPHERS, ciphers);
                     clientParams.add(clientCiphers);
                 }
+                String enableSessionCreation = String.valueOf(secureSocket
+                        .getBooleanField(HttpConstants.SSL_CONFIG_ENABLE_SESSION_CREATION));
+                Parameter clientEnableSessionCreation = new Parameter(HttpConstants.SSL_CONFIG_ENABLE_SESSION_CREATION,
+                        enableSessionCreation);
+                clientParams.add(clientEnableSessionCreation);
                 if (!clientParams.isEmpty()) {
                     senderConfiguration.setParameters(clientParams);
                 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/serviceendpoint/InitEndpoint.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/serviceendpoint/InitEndpoint.java
@@ -274,7 +274,11 @@ public class InitEndpoint extends BlockingNativeCallableUnit {
             }
         }
         listenerConfiguration.setTLSStoreType(HttpConstants.PKCS_STORE_TYPE);
-
+        String serverEnableSessionCreation = String.valueOf(sslConfig
+                .getBooleanField(HttpConstants.SSL_CONFIG_ENABLE_SESSION_CREATION));
+        Parameter enableSessionCreationParam = new Parameter(HttpConstants.SSL_CONFIG_ENABLE_SESSION_CREATION,
+                serverEnableSessionCreation);
+        serverParams.add(enableSessionCreationParam);
         if (!serverParams.isEmpty()) {
             listenerConfiguration.setParameters(serverParams);
         }

--- a/tests/ballerina-test-integration/src/test/resources/mutualSSL/mutualSSLServer.bal
+++ b/tests/ballerina-test-integration/src/test/resources/mutualSSL/mutualSSLServer.bal
@@ -16,17 +16,18 @@ endpoint http:ServiceEndpoint echo {
             protocolName: "TLSv1.2",
             versions: "TLSv1.2,TLSv1.1"
         },
-        ciphers:"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
+        ciphers:"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+        sslVerifyClient:"require"
     }
 };
 
-@http:serviceConfig {
+@http:ServiceConfig {
     endpoints:[echo],
     basePath:"/echo"
 }
 service<http:Service> helloWorld bind echo {
 
-    @http:resourceConfig {
+    @http:ResourceConfig {
         methods:["GET"],
         path:"/"
     }
@@ -42,13 +43,13 @@ endpoint http:ServiceEndpoint echoDummy {
     port:9090
 };
 
-@http:serviceConfig {
+@http:ServiceConfig {
     endpoints:[echoDummy],
     basePath:"/echoDummy"
 }
 service<http:Service> echoDummyService bind echoDummy {
 
-     @http:resourceConfig {
+     @http:ResourceConfig {
          methods:["POST"],
          path:"/"
      }


### PR DESCRIPTION
Related issue : https://github.com/ballerina-lang/ballerina/issues/5345

## Purpose
Allow user to control ssl session creation. Default value is set to true which means establishing new ssl sessions when there are no existing ssl sessions to resume.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
### Client endpoint

```
endpoint http:ClientEndpoint clientEP {
    targets: [{
        uri: "https://localhost:7070",
        secureSocket: {
            keyStore: {
                filePath: "${ballerina.home}/bre/security/ballerinaKeystore.p12",
                password: "ballerina"
            },
            trustStore: {
                filePath: "${ballerina.home}/bre/security/ballerinaTruststore.p12",
                password: "ballerina"
            },
            protocols: {
                protocolName: "SSL"
            },
            ciphers:"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
	    sessionCreation:true
        }
    }]
};
```


## Related PRs
https://github.com/wso2/transport-http/pull/91

Related issue : https://github.com/ballerina-lang/ballerina/issues/5345
