### PR TITLE
 Make 'json|null' type to work same as 'json'

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -314,12 +314,12 @@ public class SymbolResolver extends BLangNodeVisitor {
         this.diagCode = preDiagCode;
 
         // If the typeNode.nullable is true then convert the resultType to a union type
-        // if it is not already a union type
+        // if it is not already a union type or a JSON type
         if (typeNode.nullable && this.resultType.tag == TypeTags.UNION) {
             BUnionType unionType = (BUnionType) this.resultType;
             unionType.memberTypes.add(symTable.nullType);
             unionType.setNullable(true);
-        } else if (typeNode.nullable) {
+        } else if (typeNode.nullable && typeNode.type.tag != TypeTags.JSON) {
             Set<BType> memberTypes = new HashSet<BType>(2) {{
                 add(resultType);
                 add(symTable.nullType);

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/json/JSONTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/json/JSONTest.java
@@ -30,6 +30,7 @@ import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.model.values.BXML;
 import org.ballerinalang.model.values.BXMLItem;
+import org.ballerinalang.util.exceptions.BLangRuntimeException;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -477,5 +478,12 @@ public class JSONTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testJSONArrayToJsonAssignment");
         Assert.assertNotNull(returns[0]);
         Assert.assertEquals(returns[0].stringValue(), "[{\"a\":\"b\"},{\"c\":\"d\"}]");
+    }
+
+    @Test(expectedExceptions = { BLangRuntimeException.class },
+            expectedExceptionsMessageRegExp = "error: ballerina.runtime:NullReferenceException.*")
+    public void testFieldAccessOfNullableJSON() {
+        CompileResult compileResult = BCompileUtil.compile("test-src/types/jsontype/nullable-json-test.bal");
+        BRunUtil.invoke(compileResult, "testFieldAccessOfNullableJSON");
     }
 }

--- a/tests/ballerina-test/src/test/resources/test-src/types/jsontype/nullable-json-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/jsontype/nullable-json-test.bal
@@ -1,0 +1,8 @@
+function testFieldAccessOfNullableJSON() returns (json) {
+    json? j1 = foo().name;
+    return j1;
+}
+
+function foo() returns (json?) {
+	return null;
+}


### PR DESCRIPTION
Make nullable json (ie: json|null) to work as same as json.
This allows to access fileds (j.foo.bar) of a nullable json.