### PR TITLE
Fix single-filter-execution-success-test to match new syntax [Do not Merge] 

### DIFF
--- a/tests/ballerina-test-integration/src/test/resources/filter/single-filter-execution-success-test.bal
+++ b/tests/ballerina-test-integration/src/test/resources/filter/single-filter-execution-success-test.bal
@@ -14,13 +14,13 @@ public function <Filter1 filter> terminate () {
     log:printInfo("Stopping filter 1");
 }
 
-public function interceptRequest1 (http:Request request, http:FilterContext context) (http:FilterResult) {
+public function interceptRequest1 (http:Request request, http:FilterContext context) returns (http:FilterResult) {
     log:printInfo("Intercepting request for filter 1");
     http:FilterResult filterResponse = {canProceed:true, statusCode:200, message:"successful"};
     return filterResponse;
 }
 
-public function interceptResponse1 (http:Response response, http:FilterContext context) (http:FilterResult) {
+public function interceptResponse1 (http:Response response, http:FilterContext context) returns (http:FilterResult) {
     log:printInfo("Intercepting response for filter 1");
     http:FilterResult filterResponse = {canProceed:true, statusCode:200, message:"successful"};
     return filterResponse;


### PR DESCRIPTION
## Purpose
> Fix single-filter-execution-success-test to match new syntax

## Goals
> Fix single-filter-execution-success-test to match new syntax


## Approach
> N/A

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A 

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
