### PR TITLE
Use a union return type in json.toXML

### DIFF
--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/builtin/jsonlib.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/builtin/jsonlib.bal
@@ -38,4 +38,4 @@ public native function <json j> getKeys() returns (string[]);
 public native function <json j> toXML (struct {
                                            string attributePrefix = "@";
                                            string arrayEntryTag = "item";
-                                       } options) returns (xml, error);
+                                       } options) returns (xml| error);

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/builtin/jsonlib/ToXML.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/builtin/jsonlib/ToXML.java
@@ -58,9 +58,10 @@ public class ToXML extends BlockingNativeCallableUnit {
             String arrayEntryTag = optionsStruct.getStringField(1);
             //Converting to xml.
             xml = JSONUtils.convertToXML(json, attributePrefix, arrayEntryTag);
+            ctx.setReturnValues(xml);
         } catch (Throwable e) {
             error = Utils.createConversionError(ctx, "failed to convert json to xml: " + e.getMessage());
+            ctx.setReturnValues(error);
         }
-        ctx.setReturnValues(xml, error);
     }
 }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/json/JSONTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/types/json/JSONTest.java
@@ -245,8 +245,6 @@ public class JSONTest {
         Assert.assertTrue(returns[0] instanceof BXML);
         OMNode returnElement = ((BXMLItem) returns[0]).value();
         Assert.assertEquals(((OMText) returnElement).getText(), "value");
-
-        Assert.assertNull(returns[1]);
     }
 
     @Test(description = "Convert a json object with boolean value only")
@@ -256,8 +254,6 @@ public class JSONTest {
         Assert.assertTrue(returns[0] instanceof BXML);
         OMNode returnElement = ((BXMLItem) returns[0]).value();
         Assert.assertEquals(((OMText) returnElement).getText(), "true");
-
-        Assert.assertNull(returns[1]);
     }
 
     @Test(description = "Convert json object with key value")
@@ -384,8 +380,6 @@ public class JSONTest {
         OMNode returnElement = ((BXMLItem) returns[0]).value();
         Assert.assertEquals(returnElement.toString(), "<info><address/><homeAddresses><item>a</item><item>b</item>"
                 + "</homeAddresses><phoneNumbers/></info>");
-
-        Assert.assertNull(returns[1]);
     }
 
     @Test(description = "Convert a simple json object with attributes")
@@ -397,8 +391,6 @@ public class JSONTest {
         OMNode returnElement = ((BXMLItem) returns[0]).value();
         Assert.assertEquals(returnElement.toString(), "<info id=\"100\"><name>John</name><age>30</age><car>honda</car>"
                 + "</info>");
-
-        Assert.assertNull(returns[1]);
     }
 
     @Test(description = "Convert a complex json object with attributes")
@@ -411,8 +403,6 @@ public class JSONTest {
         Assert.assertEquals(returnElement.toString(), "<bookStore storeName=\"foo\"><postalCode>94</postalCode>"
                 + "<isOpen>true</isOpen><address city=\"Colombo\"><street>PalmGrove</street><country>SriLanka</country>"
                 + "</address><codes><item>4</item><item>8</item><item>9</item></codes></bookStore>");
-
-        Assert.assertNull(returns[1]);
     }
 
     @Test(description = "Convert a complex json object with attributes and custom attribute prefix")
@@ -425,8 +415,6 @@ public class JSONTest {
         Assert.assertEquals(returnElement.toString(), "<bookStore storeName=\"foo\"><postalCode>94</postalCode>"
                 + "<isOpen>true</isOpen><address city=\"Colombo\"><street>PalmGrove</street><country>SriLanka</country>"
                 + "</address><codes><wrapper>4</wrapper><wrapper>8</wrapper><wrapper>9</wrapper></codes></bookStore>");
-
-        Assert.assertNull(returns[1]);
     }
 
     private String getJsonAsString(BValue bValue) {
@@ -459,9 +447,9 @@ public class JSONTest {
     public void testJSONToXMLWithUnsupportedChar() {
         BValue[] args = {new BJSON(jsonToXML13)};
         BValue[] returns = BRunUtil.invoke(compileResult, "testToXMLWithOptions", args);
-        Assert.assertNull(returns[0]);
-        Assert.assertNotNull(returns[1]);
-        Assert.assertEquals(((BStruct) returns[1]).getStringField(0),
+
+        Assert.assertTrue(returns[0] instanceof BStruct);
+        Assert.assertEquals(((BStruct) returns[0]).getStringField(0),
                 "failed to convert json to xml: invalid xml qualified name: unsupported characters in '@storeName'");
     }
 

--- a/tests/ballerina-test/src/test/resources/test-src/types/jsontype/json-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/jsontype/json-test.bal
@@ -21,33 +21,37 @@ function testGetKeys () returns (string[], string[], string[], string[]) {
     return (j1.getKeys(), j2.getKeys(), j3.getKeys(), j4.getKeys());
 }
 
-function testToXML (json msg) returns (xml, error) {
+function testToXML (json msg) returns (xml | error) {
     return msg.toXML({});
 }
 
-function testToXMLStringValue () returns (xml, error) {
+function testToXMLStringValue () returns (xml | error) {
     json j = "value";
     return j.toXML({});
 }
 
-function testToXMLBooleanValue () returns (xml, error) {
+function testToXMLBooleanValue () returns (xml | error) {
     json j = true;
     return j.toXML({});
 }
 
 function testToXMLString (json msg) returns (string) {
-    var (xmlData, _) = msg.toXML({});
-    string s = <string> xmlData;
-    return s;
+    var x = msg.toXML({});
+    match(x){
+        error e => return "";
+        xml xmlData => return <string> xmlData;
+    }
 }
 
 function testToXMLWithXMLSequence (json msg) returns (string) {
-    var (xmlSequence, _) = msg.toXML({});
-    string s = <string> xmlSequence;
-    return s;
+    var x = msg.toXML({});
+    match(x){
+        error e => return "";
+        xml xmlData => return <string> xmlData;
+    }
 }
 
-function testToXMLWithOptions (json msg) returns (xml, error) {
+function testToXMLWithOptions (json msg) returns (xml | error) {
     return msg.toXML({attributePrefix:"#", arrayEntryTag:"wrapper"});
 }
 

--- a/tests/ballerina-test/src/test/resources/test-src/types/jsontype/nullable-json-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/types/jsontype/nullable-json-test.bal
@@ -1,8 +1,8 @@
 function testFieldAccessOfNullableJSON() returns (json) {
-    json? j1 = foo().name;
+    json j1 = foo().name;
     return j1;
 }
 
-function foo() returns (json?) {
+function foo() returns (json) {
 	return null;
 }


### PR DESCRIPTION
## Purpose
Update `toXML` method of `json` type to use a union type instead of a tuple type with` xml` and `error` types.

eg:
```ballerina
    json msg = {foo: "bar"};
    var x = msg.toXML({});
    match(x){
        error e => return "";
        xml xmlData => return <string> xmlData;
    }
```