### PR TITLE
Syntax highlighting for match statements

### DIFF
--- a/tool-plugins/vscode/debugger/index.js
+++ b/tool-plugins/vscode/debugger/index.js
@@ -32,6 +32,7 @@ class BallerinaDebugSession extends LoggingDebugSession {
         this.packagePaths = {};
         this.dirPaths = {};
         this.debugManager = new DebugManager();
+        this.started = false;
 
         this.debugManager.on('debug-hit', debugArgs => {
             this.debugArgs = debugArgs;
@@ -99,6 +100,8 @@ class BallerinaDebugSession extends LoggingDebugSession {
                 { cwd }
             );
     
+            this.startTimeout(args['debugServerTimeout']||5000);
+
             debugServer.on('error', (err) => {
                 this.terminate("Could not start the debug server.");
             });
@@ -107,7 +110,13 @@ class BallerinaDebugSession extends LoggingDebugSession {
                 if (`${data}`.indexOf('Ballerina remote debugger is activated on port') > -1) {
                     this.debugManager.connect(`ws://127.0.0.1:${port}/debug`, () => {
                         this.sendResponse(response);
-                        this.sendEvent(new InitializedEvent());
+                        this.started = true;
+
+                        if (this.timedOut) {
+                            this.debugManager.kill();
+                        } else {
+                            this.sendEvent(new InitializedEvent());
+                        }
                     });
                 }
 
@@ -256,6 +265,16 @@ class BallerinaDebugSession extends LoggingDebugSession {
             this.debugServer.kill();
         }
         this.sendResponse(response);
+    }
+
+    // timeout waiting for the debug server
+    startTimeout(timeout=5000) {
+        setTimeout(() => {
+            if(!this.started) {
+                this.timedOut = true;
+                this.terminate('Timeout. Debug server did not start');
+            }
+        }, timeout);
     }
 
     terminate(msg) {

--- a/tool-plugins/vscode/package.json
+++ b/tool-plugins/vscode/package.json
@@ -99,6 +99,11 @@
                             "script": {
                                 "type": "string",
                                 "default": "${file}"
+                            },
+                            "debugServerTimeout": {
+                                "type": "integer",
+                                "default": 5000,
+                                "description": "How long to wait for the debug server to start up in miliseconds"
                             }
                         }
                     }

--- a/tool-plugins/vscode/syntaxes/ballerina.YAML-tmLanguage
+++ b/tool-plugins/vscode/syntaxes/ballerina.YAML-tmLanguage
@@ -85,8 +85,14 @@ repository:
 
   functionReturns:
     patterns:
-    - match: 'returns'
-      name: keyword.ballerina
+    - begin: '\breturns\b'
+      beginCaptures:
+        '0': { name: keyword.ballerina }
+      end: (?=\{)
+      patterns:
+        - match: '{{identifier}}'
+          name: storage.type.ballerina
+        - include: '#comment'
 
   serviceEndpointAttachments:
     patterns:
@@ -121,6 +127,7 @@ repository:
         '0': { name: punctuation.definition.block.ballerina }
       patterns:
       - include: '#comment'
+      - include: '#matchStatement'
       - include: '#code'
 
   serviceBody:
@@ -159,6 +166,59 @@ repository:
       - include: '#comment'
       - include: '#code'
 
+  matchStatement:
+    patterns:
+    - begin: '\b(match)\b'
+      beginCaptures:
+        '1': { name:  keyword.ballerina }
+      end: '(?<=\})'
+      patterns:
+      - match: '{{identifier}}'
+        name: variable.parameter.ballerina
+      - include: '#matchStatementBody'
+
+  matchStatementBody:
+    patterns:
+    - begin: \{
+      beginCaptures:
+        '0': { name: punctuation.definition.block.ballerina.documentation }
+      end: \}
+      endCaptures:
+        '0': { name: punctuation.definition.block.ballerina.documentation }
+      patterns:
+      - include: '#varDefStatement'
+      - include: '#matchedStatement'
+
+  varDefStatement:
+    patterns:
+    - begin: \b({{identifier}})\b
+      beginCaptures:
+        '1': { name: storage.type.ballerina }
+      end: \b({{identifier}})\b
+      endCaptures:
+        '1': { name: variable.parameter.ballerina }
+      patterns:
+      - include: '#continuedType'
+      - include: '#comment'
+
+  matchedStatement:
+    patterns:
+    - begin: '=>'
+      beginCaptures:
+        '0': { name:  keyword.ballerina }
+      end: '(?<=\})'
+      patterns:
+      - include: '#functionBody'
+
+  continuedType:
+    patterns:
+    - begin: '[|,:]'
+      end: \b({{identifier}})\b
+      endCaptures:
+        '1': { name: storage.type.ballerina }
+      patterns:
+      - include: '#comment'
+
   documentationDef:
     patterns:
     - begin: \b(documentation|deprecated)\b
@@ -177,27 +237,27 @@ repository:
       endCaptures:
         '0': { name: punctuation.definition.block.ballerina.documentation }
       patterns:
-        - match: (P|R|T|F|V)({{)(.+)(}})
-          captures:
-            '1': {name: keyword.other.ballerina.documentation}
-            '2': {name: keyword.other.ballerina.documentation}
-            '3': {name: variable.parameter.ballerina.documentation}
-            '4': {name: keyword.other.ballerina.documentation}
+      - match: (P|R|T|F|V)({{)(.+)(}})
+        captures:
+          '1': {name: keyword.other.ballerina.documentation}
+          '2': {name: keyword.other.ballerina.documentation}
+          '3': {name: variable.parameter.ballerina.documentation}
+          '4': {name: keyword.other.ballerina.documentation}
 
-        - name: comment.block.code.ballerina.documentation
-          begin: \```
-          end: \```
+      - name: comment.block.code.ballerina.documentation
+        begin: \```
+        end: \```
 
-        - name: comment.block.code.ballerina.documentation
-          begin: \``
-          end: \``
+      - name: comment.block.code.ballerina.documentation
+        begin: \``
+        end: \``
 
-        - name: comment.block.code.ballerina.documentation
-          begin: \`
-          end: \`
+      - name: comment.block.code.ballerina.documentation
+        begin: \`
+        end: \`
 
-        - name: comment.block.ballerina.documentation
-          match: .
+      - name: comment.block.ballerina.documentation
+        match: .
 
   publicKeyword:
     patterns:
@@ -243,7 +303,7 @@ repository:
       match: \b(if|else|iterator|try|catch|finally|fork|join|all|some|while|foreach|in|throw|return|returns|break|timeout|transaction|aborted|abort|committed|failed|retries|next|bind|with|lengthof|typeof|enum)\b
 
     - name: keyword.other.ballerina
-      match: \b(import|version|public|attach|as|native|documentation|lock)\b
+      match: \b(import|version|public|private|attach|as|native|documentation|lock)\b
 
     - name: keyword.other.siddhi.ballerina
       match: \b(from|on|select|group|by|having|order|where|followed|insert|into|update|delete|set|for|window|query)\b
@@ -258,7 +318,7 @@ repository:
       match: \b(stream|streamlet|aggregation)\b
 
     - name: keyword.other.ballerina
-      match: \b(annotation|package|type|connector|function|resource|service|action|worker|struct|transformer|endpoint)\b
+      match: \b(annotation|package|type|typedesc|connector|function|resource|service|action|worker|struct|transformer|endpoint)\b
 
     - name: keyword.other.ballerina
       match: \b(const|true|false|reply|create|parameter)\b

--- a/tool-plugins/vscode/syntaxes/ballerina.tmLanguage
+++ b/tool-plugins/vscode/syntaxes/ballerina.tmLanguage
@@ -240,10 +240,31 @@
         <key>patterns</key>
         <array>
           <dict>
-            <key>match</key>
-            <string>returns</string>
-            <key>name</key>
-            <string>keyword.ballerina</string>
+            <key>begin</key>
+            <string>\breturns\b</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>0</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.ballerina</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>(?=\{)</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>match</key>
+                <string>([a-zA-Z_]([a-zA-Z0-9_])*)|(\^"([^|"\\\f\n\r\t]|\\\\[btnfr]|\\[|"\\/])+")</string>
+                <key>name</key>
+                <string>storage.type.ballerina</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#comment</string>
+              </dict>
+            </array>
           </dict>
         </array>
       </dict>
@@ -349,6 +370,10 @@
               <dict>
                 <key>include</key>
                 <string>#comment</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#matchStatement</string>
               </dict>
               <dict>
                 <key>include</key>
@@ -470,6 +495,171 @@
               <dict>
                 <key>include</key>
                 <string>#code</string>
+              </dict>
+            </array>
+          </dict>
+        </array>
+      </dict>
+      <key>matchStatement</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>begin</key>
+            <string>\b(match)\b</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.ballerina</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>(?&lt;=\})</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>match</key>
+                <string>([a-zA-Z_]([a-zA-Z0-9_])*)|(\^"([^|"\\\f\n\r\t]|\\\\[btnfr]|\\[|"\\/])+")</string>
+                <key>name</key>
+                <string>variable.parameter.ballerina</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#matchStatementBody</string>
+              </dict>
+            </array>
+          </dict>
+        </array>
+      </dict>
+      <key>matchStatementBody</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>begin</key>
+            <string>\{</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>0</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.definition.block.ballerina.documentation</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>\}</string>
+            <key>endCaptures</key>
+            <dict>
+              <key>0</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.definition.block.ballerina.documentation</string>
+              </dict>
+            </dict>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#varDefStatement</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#matchedStatement</string>
+              </dict>
+            </array>
+          </dict>
+        </array>
+      </dict>
+      <key>varDefStatement</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>begin</key>
+            <string>\b(([a-zA-Z_]([a-zA-Z0-9_])*)|(\^"([^|"\\\f\n\r\t]|\\\\[btnfr]|\\[|"\\/])+"))\b</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>storage.type.ballerina</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>\b(([a-zA-Z_]([a-zA-Z0-9_])*)|(\^"([^|"\\\f\n\r\t]|\\\\[btnfr]|\\[|"\\/])+"))\b</string>
+            <key>endCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>variable.parameter.ballerina</string>
+              </dict>
+            </dict>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#continuedType</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#comment</string>
+              </dict>
+            </array>
+          </dict>
+        </array>
+      </dict>
+      <key>matchedStatement</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>begin</key>
+            <string>=&gt;</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>0</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.ballerina</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>(?&lt;=\})</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#functionBody</string>
+              </dict>
+            </array>
+          </dict>
+        </array>
+      </dict>
+      <key>continuedType</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>begin</key>
+            <string>[|,:]</string>
+            <key>end</key>
+            <string>\b(([a-zA-Z_]([a-zA-Z0-9_])*)|(\^"([^|"\\\f\n\r\t]|\\\\[btnfr]|\\[|"\\/])+"))\b</string>
+            <key>endCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>storage.type.ballerina</string>
+              </dict>
+            </dict>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#comment</string>
               </dict>
             </array>
           </dict>
@@ -703,7 +893,7 @@
             <key>name</key>
             <string>keyword.other.ballerina</string>
             <key>match</key>
-            <string>\b(import|version|public|attach|as|native|documentation|lock)\b</string>
+            <string>\b(import|version|public|private|attach|as|native|documentation|lock)\b</string>
           </dict>
           <dict>
             <key>name</key>
@@ -733,7 +923,7 @@
             <key>name</key>
             <string>keyword.other.ballerina</string>
             <key>match</key>
-            <string>\b(annotation|package|type|connector|function|resource|service|action|worker|struct|transformer|endpoint)\b</string>
+            <string>\b(annotation|package|type|typedesc|connector|function|resource|service|action|worker|struct|transformer|endpoint)\b</string>
           </dict>
           <dict>
             <key>name</key>


### PR DESCRIPTION
## Purpose
Add syntax highlighting for `match` statement in vscode.

![image](https://user-images.githubusercontent.com/3872221/37746420-2ceeb68a-2da0-11e8-8f40-40179d8b60fa.png)


