### PR TITLE
Disable connector related test cases

### DIFF
--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/CompositeConnectorTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/CompositeConnectorTest.java
@@ -28,6 +28,7 @@ import org.testng.annotations.Test;
 /**
  * Class to test the functionality of composite connectors.
  */
+@Test(enabled = false)
 public class CompositeConnectorTest {
 
     private CompileResult result;

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/ConnectorActionTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/ConnectorActionTest.java
@@ -32,6 +32,7 @@ import org.testng.annotations.Test;
 /**
  * Test class for Connector actions.
  */
+@Test(enabled = false)
 public class ConnectorActionTest {
     CompileResult result;
     CompileResult resultNegative;

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/ConnectorActionWithOptionalParamsTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/ConnectorActionWithOptionalParamsTest.java
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
 /**
  * Test class for Connector actions with optional and named params.
  */
+@Test(enabled = false)
 public class ConnectorActionWithOptionalParamsTest {
     CompileResult result;
 

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/ConnectorInitTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/ConnectorInitTest.java
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
  *
  * @since 0.8.0
  */
+@Test(enabled = false)
 public class ConnectorInitTest {
 
     CompileResult result;

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/ConnectorServiceTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/ConnectorServiceTest.java
@@ -33,6 +33,7 @@ import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 /**
  * Test class for Connector service.
  */
+@Test(enabled = false)
 public class ConnectorServiceTest {
 
 

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/EndpointConnectorPkgTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/EndpointConnectorPkgTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.Test;
 /**
  * Test class for endpoint and connector combination in packages.
  */
+@Test(enabled = false)
 public class EndpointConnectorPkgTest {
     CompileResult result;
     CompileResult resultNegative;

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/EndpointConnectorTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/EndpointConnectorTest.java
@@ -31,6 +31,7 @@ import org.testng.annotations.Test;
 /**
  * Test class for endpoint connector combination.
  */
+@Test (enabled = false)
 public class EndpointConnectorTest {
     CompileResult result;
     CompileResult resultNegative;

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/FilterConnectorTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/connectors/FilterConnectorTest.java
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
 /**
  * Class to test the functionality of filter connectors.
  */
+@Test (enabled = false)
 public class FilterConnectorTest {
 
     private CompileResult result;

--- a/tests/ballerina-test/src/test/resources/test-src/connectors/incorrect-action-definition2.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/connectors/incorrect-action-definition2.bal
@@ -1,6 +1,0 @@
-connector TestConnector(){
-
-    action testAction(string a, int b)(string s){
-        return "testing";
-    }
-}

--- a/tests/ballerina-test/src/test/resources/test-src/connectors/incorrect-action-invocation.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/connectors/incorrect-action-invocation.bal
@@ -1,4 +1,0 @@
-function testAction(string[] args){
-    string cal = "saman";
-    int m = cal.add1(cal, 1,2);
-}


### PR DESCRIPTION
## Purpose
Connector syntax changed lately and now there is no separate connector keyword. Connector and actions are now implementing using struct and functions. So we need to revisit these test cases and verify with struct related test cases
