### PR TITLE
Fix ReturnStmtNegativeTest.java

### DIFF
--- a/tests/ballerina-test/src/test/resources/test-src/statements/returnstmt/missing-return-forkjoin-2.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/returnstmt/missing-return-forkjoin-2.bal
@@ -12,12 +12,12 @@ function testNullInForkJoin () returns (string, string) {
         }
     } join (all) (map allReplies) {
         any[] temp;
-        temp =? (any[])allReplies["foo"];
+        temp =? <any[]> allReplies["foo"];
         string m1;
-        m1 =? (string) temp[0];
-        temp =? (any[])allReplies["bar"];
+        m1 =? <string> temp[0];
+        temp =? <any[]> allReplies["bar"];
         string m2;
-        m2 =? (string) temp[0];
+        m2 =? <string> temp[0];
         return (m1,m2);
     } timeout (30000) (map msgs) {
 

--- a/tests/ballerina-test/src/test/resources/test-src/statements/returnstmt/return-in-resource.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/statements/returnstmt/return-in-resource.bal
@@ -12,6 +12,6 @@ function <DummyEndpoint s> init (struct {} conf)  {
 struct DummyService {}
 
 function <DummyService s> getEndpoint() returns (DummyEndpoint) {
-    DummyEndpoint ep;
+    DummyEndpoint ep = {};
     return ep;
 }


### PR DESCRIPTION
## Purpose
Update missing-return-forkjoin-2.bal and return-in-resource.bal with latest syntax.