### PR TITLE
Include missing path config param in resource definitions of httpMethodTest.bal

### DIFF
--- a/tests/ballerina-test-integration/src/test/resources/httpService/httpMethodTest.bal
+++ b/tests/ballerina-test-integration/src/test/resources/httpService/httpMethodTest.bal
@@ -157,6 +157,7 @@ service<http:Service> quoteService bind serviceEndpoint {
 
     @http:ResourceConfig {
         methods:["POST"],
+        path:"employee",
         body:"person"
     }
     employee (endpoint client, http:Request req, json person) {


### PR DESCRIPTION
## Purpose
$subject.
