### PR TITLE
Fix ssl related issue : Unable to create a ssl session

### DIFF
--- a/stdlib/ballerina-http/src/main/ballerina/net.http/client_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/net.http/client_endpoint.bal
@@ -183,8 +183,15 @@ public struct SecureSocket {
     Protocols|null protocols;
     ValidateCert|null validateCert;
     string ciphers;
-    boolean hostNameVerification = true;
-    boolean sessionCreation = true;
+    boolean hostNameVerification;
+    boolean sessionCreation;
+}
+
+@Description {value:"Initializes the SecureSocket struct with default values."}
+@Param {value:"config: The SecureSocket struct to be initialized"}
+public function <SecureSocket config> SecureSocket() {
+    config.hostNameVerification = true;
+    config.sessionCreation = true;
 }
 
 @Description { value:"FollowRedirects struct represents HTTP redirect related options to be used for HTTP client invocation" }

--- a/stdlib/ballerina-http/src/main/ballerina/net.http/service_endpoint.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/net.http/service_endpoint.bal
@@ -66,7 +66,13 @@ public struct ServiceSecureSocket {
     ValidateCert|null validateCert;
     string ciphers;
     string sslVerifyClient;
-    boolean sessionCreation = true;
+    boolean sessionCreation;
+}
+
+@Description {value:"Initializes the ServiceSecureSocket struct with default values."}
+@Param {value:"config: The ServiceSecureSocket struct to be initialized"}
+public function <ServiceSecureSocket config> ServiceSecureSocket() {
+    config.sessionCreation = true;
 }
 
 public enum KeepAlive {


### PR DESCRIPTION
## Purpose
Fix ssl related issue of unable to create a ssl session

## Approach
Default value is not getting picked up unless we set a constructor. A constructor is added to initialize secure socket struct.

