### PR TITLE
Skip generated-sources from the check-style check

### DIFF
--- a/tests/ballerina-test-integration/pom.xml
+++ b/tests/ballerina-test-integration/pom.xml
@@ -137,5 +137,9 @@
     <properties>
         <!-- Path to the generated natives ballerina files temp directory -->
         <mavan.findbugsplugin.exclude.file>findbugs-exclude.xml</mavan.findbugsplugin.exclude.file>
+        <maven.checkstyleplugin.excludes>
+            **/generated/**,
+            **/generated-sources/**
+        </maven.checkstyleplugin.excludes>
     </properties>
 </project>


### PR DESCRIPTION
## Purpose
Fix the check style issue in the release build.
````
[INFO] [INFO] --- maven-checkstyle-plugin:2.17:check (validate) @ test-integration --- [INFO] [INFO] Starting audit... [INFO] [ERROR] /home/jenkins/workspace/ballerina-build-pipeline/ballerina/tests/ballerina-test-integration/target/generated-sources/protobuf/java/org/ballerinalang/test/util/grpc/HelloWorld.java:6: Missing a Javadoc comment. [JavadocType] [INFO] [ERROR] /home/jenkins/workspace/ballerina-build-pipeline/ballerina/tests/ballerina-test-integration/target/generated-sources/protobuf/java/org/ballerinalang/test/util/grpc/HelloWorld.java:33:60: '.' is followed by whitespace. [NoWhitespaceAfter] [INFO] [ERROR] /home/jenkins/workspace/ballerina-build-pipeline/ballerina/tests/ballerina-test-integration/target/generated-sources/protobuf/grpc-java/org/ballerinalang/test/util/grpc/helloWorldGrpc.java:4: Wrong order for 'io.grpc.stub.ClientCalls.asyncServerStreamingCall' import. [ImportOrder] [INFO] [ERROR] /home/jenkins/workspace/ballerina-build-pipeline/ballerina/tests/ballerina-test-integration/target/generated-sources/protobuf/grpc-java/org/ballerinalang/test/util/grpc/helloWorldGrpc.java:4:15: Unused import - io.grpc.stub.ClientCalls.asyncServerStreamingCall. [UnusedImports]
````
