### PR TITLE
Fix hello-world-service example endpoint URL

### DIFF
--- a/docs/ballerina-by-example/examples/hello-world-service/hello-world-service.client.sh
+++ b/docs/ballerina-by-example/examples/hello-world-service/hello-world-service.client.sh
@@ -1,3 +1,3 @@
 // Invoke the service using "curl".
-$ curl http://localhost:9090/helloWorld/sayHello
+$ curl http://localhost:9090/hello/sayHello
 Hello, World!


### PR DESCRIPTION
## Purpose
> Fix hello-world-service example endpoint URL. The ServiceConfig basePath is `/hello` in the sample service.