### PR TITLE
Stop calling abortResource managers twice on initiator abort

### DIFF
--- a/stdlib/ballerina-builtin/src/main/ballerina/transactions.coordinator/2pc_transaction.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/transactions.coordinator/2pc_transaction.bal
@@ -110,26 +110,23 @@ documentation {
 function<TwoPhaseCommitTransaction txn> markForAbortion () returns string|error {
     string transactionId = txn.transactionId;
     int transactionBlockId = txn.transactionBlockId;
-
-    boolean successful = abortResourceManagers(transactionId, transactionBlockId);
-    if (successful) {
-        string msg = "Marked initiated transaction for abortion";
-        if(!txn.isInitiated) {
-            string participatedTxnId = getParticipatedTransactionId(transactionId, transactionBlockId);
-            msg = "Marked participated transaction for abort. Transaction:" + participatedTxnId;
-        }
-        log:printInfo(msg);
+    if(txn.isInitiated) {
         txn.state = TransactionState.ABORTED;
-        return ""; //TODO: check what will happen if nothing is returned
-    } else {
-        string msg = "Aborting local resource managers failed for initiated transaction:" + transactionId;
-        if(!txn.isInitiated) {
-            string participatedTxnId = getParticipatedTransactionId(transactionId, transactionBlockId);
-            msg = "Aborting local resource managers failed for participated transaction:" + participatedTxnId;
-        }
-        error err = {message:msg};
-        return err;
+        log:printInfo("Marked initiated transaction for abortion");
+    } else { // participant
+       boolean successful = abortResourceManagers(transactionId, transactionBlockId);
+       string participatedTxnId = getParticipatedTransactionId(transactionId, transactionBlockId);
+       if(successful) {
+           txn.state = TransactionState.ABORTED;
+           log:printInfo("Marked participated transaction for abort. Transaction:" + participatedTxnId);
+       } else {
+           string msg = "Aborting local resource managers failed for participated transaction:" + participatedTxnId;
+           log:printError(msg);
+           error err = {message:msg};
+           return err;
+       }
     }
+    return ""; //TODO: check what will happen if nothing is returned
 }
 
 function<TwoPhaseCommitTransaction txn> prepareParticipants (string protocol) returns boolean {


### PR DESCRIPTION
Now on the initiator side, we only mark the transaction for abortion
and don't abort the resource managers, and wait until end transaction
is called, in order to run the abort flow of the protocol.
