### PR TITLE
Fix .balx file path parameter passed to compiler plugins

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BinaryFileWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BinaryFileWriter.java
@@ -109,8 +109,8 @@ public class BinaryFileWriter {
             throw new BLangCompilerException("error writing program file '" + fileName + "'", e);
         }
 
-        this.sourceDirectory.saveCompiledProgram(new ByteArrayInputStream(byteArrayOS.toByteArray()), fileName);
-        final Path execFilePath = this.sourceDirectory.getPath().resolve(fileName);
+        final Path execFilePath = this.sourceDirectory.saveCompiledProgram(new ByteArrayInputStream(byteArrayOS
+                .toByteArray()), fileName);
         ServiceLoader<CompilerPlugin> processorServiceLoader = ServiceLoader.load(CompilerPlugin.class);
         processorServiceLoader.forEach(plugin -> {
             plugin.codeGenerated(execFilePath);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProgramDirectory.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProgramDirectory.java
@@ -91,10 +91,11 @@ public class FileSystemProgramDirectory implements SourceDirectory {
     }
 
     @Override
-    public void saveCompiledProgram(InputStream source, String fileName) {
+    public Path saveCompiledProgram(InputStream source, String fileName) {
         Path targetFilePath = programDirPath.resolve(fileName);
         try {
             Files.copy(source, targetFilePath, StandardCopyOption.REPLACE_EXISTING);
+            return targetFilePath;
         } catch (DirectoryNotEmptyException e) {
             throw new BLangCompilerException("A directory exists with the same name as the file name '" +
                     targetFilePath.toString() + "'");

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProjectDirectory.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/FileSystemProjectDirectory.java
@@ -111,10 +111,11 @@ public class FileSystemProjectDirectory extends FileSystemProgramDirectory {
     }
 
     @Override
-    public void saveCompiledProgram(InputStream source, String fileName) {
+    public Path saveCompiledProgram(InputStream source, String fileName) {
         Path targetFilePath = ensureAndGetTargetDirPath().resolve(fileName);
         try {
             Files.copy(source, targetFilePath, StandardCopyOption.REPLACE_EXISTING);
+            return targetFilePath;
         } catch (DirectoryNotEmptyException e) {
             throw new BLangCompilerException("A directory exists with the same name as the file name '" +
                     targetFilePath.toString() + "'");

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/SourceDirectory.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/SourceDirectory.java
@@ -40,7 +40,7 @@ public interface SourceDirectory {
 
     InputStream getLockFileContent();
 
-    void saveCompiledProgram(InputStream source, String fileName);
+    Path saveCompiledProgram(InputStream source, String fileName);
 
     void saveCompiledPackage(InputStream source, String fileName);
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/repository/NullSourceDirectory.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/repository/NullSourceDirectory.java
@@ -58,8 +58,8 @@ public class NullSourceDirectory implements SourceDirectory {
     }
 
     @Override
-    public void saveCompiledProgram(InputStream source, String fileName) {
-
+    public Path saveCompiledProgram(InputStream source, String fileName) {
+        return null;
     }
 
     @Override


### PR DESCRIPTION
## Purpose
> .balx file path passed to compiler plugin is invalid when compiling packages. The binaryPath value received by the compiler plugins `codeGenerated(Path binaryPath)` method doesn't contain the target folder.

## Goals
> Provide accurate balx location to compiler plugins.

## Approach
> Change the saveCompiledProgram method to return the modified path. The returned path is passed to the compiler plugin.
