### PR TITLE
Make displaying errors from lang server configurable

### DIFF
--- a/tool-plugins/vscode/extension.js
+++ b/tool-plugins/vscode/extension.js
@@ -53,6 +53,11 @@ exports.activate = function(context) {
 	let serverModule = context.asAbsolutePath(path.join('server-build', 'langserver.jar'));
 	const main = 'org.ballerinalang.langserver.launchers.stdio.Main';
 
+	// Options to control the language client
+	const clientOptions = {
+		documentSelector: [{ scheme: 'file', language: 'ballerina' }],
+	}
+
 	const config = workspace.getConfiguration('ballerina');
 	oldConfig = config;
 	// in windows class path seperated by ';'
@@ -63,10 +68,15 @@ exports.activate = function(context) {
 		serverModule = context.asAbsolutePath(path.join('server-build', 'langserver-no-bal-deps.jar'));
 		serverModule += (sep + path.join(config.sdk, 'bre', 'lib', '*'));
 	}
+
+	if (!config.showLSErrors) {
+		clientOptions.outputChannel = dropOutputChannel;
+	}
+
 	const args = ['-cp', serverModule, main];
 	// If the extension is launched in debug mode then the debug server options are used
 	// Otherwise the run options are used
-	let serverOptions = {
+	const serverOptions = {
 		run: { command: 'java', args },
 		debug: {
 			command: 'java', 
@@ -76,14 +86,10 @@ exports.activate = function(context) {
 			],
 		},
 	}
-	// Options to control the language client
-	let clientOptions = {
-		documentSelector: [{ scheme: 'file', language: 'ballerina' }],
-	}
 
 	const forceDebug = (process.env.LSDEBUG === "true");
 
-	let disposable = new LanguageClient('ballerina-vscode', 'Ballerina vscode lanugage client',
+	const disposable = new LanguageClient('ballerina-vscode', 'Ballerina vscode lanugage client',
 		serverOptions, clientOptions, forceDebug).start();
 
 	// Push the disposable to the context's subscriptions so that the 
@@ -105,5 +111,30 @@ workspace.onDidChangeConfiguration(params => {
 		});
 	}
 
+	if (newConfig.showLSErrors != oldConfig.showLSErrors) {
+		const msg = 'Configuration for displaying output from language server changed. Please restart vscode for changes to take effect.';
+		const action = 'Restart Now';
+		window.showWarningMessage(msg, action).then((selection) => {
+			if (action === selection) {
+				commands.executeCommand('workbench.action.reloadWindow');
+			}
+		});
+	}
+
 	oldConfig = newConfig;
 });
+
+
+
+// This channel ignores(drops) all requests it receives.
+// So the user won't see any output sent through this channel
+const dropOutputChannel = {
+	name: 'dropOutputChannel',
+	append: () => {},
+	appendLine: () => {},
+	clear: () => {},
+	show: () => {},
+	show: () => {},
+	hide: () => {},
+	dispose: () => {},
+}

--- a/tool-plugins/vscode/package.json
+++ b/tool-plugins/vscode/package.json
@@ -50,6 +50,13 @@
                     ],
                     "default": null,
                     "description": "Specifies the path to the ballerina sdk"
+                },
+                "ballerina.showLSErrors": {
+                    "type": [
+                        "boolean"
+                    ],
+                    "default": false,
+                    "description": "If set to true the language server's error log will be printed in the plugins console"
                 }
             }
         },


### PR DESCRIPTION
## Purpose
When language server encounters an error its printed in the plugins console. Since for most users this might be distracting its made configurable and off by default.

## Approach
In the workspace settings section the user can now set a config named `ballerina.showLSErrors` to `true` to view the lang server errors. Its `false` by default