### PR TITLE
Cleanup transactions 

### DIFF
--- a/stdlib/ballerina-builtin/src/main/ballerina/transactions.coordinator/2pc_transaction.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/transactions.coordinator/2pc_transaction.bal
@@ -26,6 +26,7 @@ struct TwoPhaseCommitTransaction {
     boolean isInitiated; // Indicates whether this is a transaction that was initiated or is participated in
     map<Participant> participants;
     Protocol[] coordinatorProtocols;
+    int createdTime;
     TransactionState state;
     boolean possibleMixedOutcome;
 }

--- a/stdlib/ballerina-builtin/src/main/ballerina/transactions.coordinator/2pc_transaction.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/transactions.coordinator/2pc_transaction.bal
@@ -234,11 +234,8 @@ function<TwoPhaseCommitTransaction txn> prepareRemoteParticipant (Participant pa
     match result {
         error err => {
             log:printErrorCause("Remote participant: " + participantId + " failed", err);
-            boolean participantRemoved = txn.participants.remove(participantId);
-            if (!participantRemoved) {
-                log:printError("Could not remove failed participant: " +
-                               participantId + " from transaction: " + transactionId);
-            }
+            txn.removeParticipant(participantId, "Could not remove failed participant: " +
+                                                    participantId + " from transaction: " + transactionId);
             successful = false;
         }
         string status => {
@@ -246,11 +243,8 @@ function<TwoPhaseCommitTransaction txn> prepareRemoteParticipant (Participant pa
                 log:printInfo("Remote participant: " + participantId + " aborted.");
                 // Remove the participant who sent the abort since we don't want to do a notify(Abort) to that
                 // participant
-                boolean participantRemoved = txn.participants.remove(participantId);
-                if (!participantRemoved) {
-                    log:printError("Could not remove aborted participant: " +
-                                   participantId + " from transaction: " + transactionId);
-                }
+                txn.removeParticipant(participantId, "Could not remove aborted participant: " +
+                                                      participantId + " from transaction: " + transactionId);
                 successful = false;
             } else if (status == OUTCOME_COMMITTED) {
                 log:printInfo("Remote participant: " + participantId + " committed");
@@ -258,19 +252,13 @@ function<TwoPhaseCommitTransaction txn> prepareRemoteParticipant (Participant pa
                 // report a mixed-outcome to the initiator
                 txn.possibleMixedOutcome = true;
                 // Don't send notify to this participant because it is has already committed. We can forget about this participant.
-                boolean participantRemoved = txn.participants.remove(participantId);
-                if (!participantRemoved) {
-                    log:printError("Could not remove committed participant: " +
-                                   participantId + " from transaction: " + transactionId);
-                }
+                txn.removeParticipant(participantId, "Could not remove committed participant: " +
+                                                      participantId + " from transaction: " + transactionId);
             } else if (status == OUTCOME_READ_ONLY) {
                 log:printInfo("Remote participant: " + participantId + " read-only");
                 // Don't send notify to this participant because it is read-only. We can forget about this participant.
-                boolean participantRemoved = txn.participants.remove(participantId);
-                if (!participantRemoved) {
-                    log:printError("Could not remove read-only participant: " +
-                                   participantId + " from transaction: " + transactionId);
-                }
+                txn.removeParticipant(participantId, "Could not remove read-only participant: " +
+                                                      participantId + " from transaction: " + transactionId);
             } else if (status == OUTCOME_PREPARED) {
                 log:printInfo("Remote participant: " + participantId + " prepared");
             } else {
@@ -374,4 +362,11 @@ function<TwoPhaseCommitTransaction txn> abortLocalParticipantTransaction () retu
         ret = {message:msg};
     }
     return ret;
+}
+
+function<TwoPhaseCommitTransaction txn> removeParticipant(string participantId, string failedMessage) {
+    boolean participantRemoved = txn.participants.remove(participantId);
+    if (!participantRemoved) {
+        log:printError(failedMessage);
+    }
 }

--- a/stdlib/ballerina-builtin/src/main/ballerina/transactions.coordinator/commons.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/transactions.coordinator/commons.bal
@@ -19,6 +19,8 @@ package ballerina.transactions.coordinator;
 import ballerina/caching;
 import ballerina/log;
 import ballerina/net.http;
+import ballerina/time;
+import ballerina/task;
 import ballerina/util;
 
 documentation {
@@ -40,6 +42,60 @@ documentation {
     This cache is used for caching HTTP connectors against the URL, since creating connectors is expensive.
 }
 caching:Cache httpClientCache = caching:createCache("ballerina.http.client.cache", 900000, 100, 0.1);
+
+const boolean scheduleInit = scheduleTimer(1000, 60000);
+
+function scheduleTimer (int delay, int interval) returns boolean {
+    function () returns (error|null) onTriggerFunction = cleanupTransactions;
+    _ = task:scheduleTimer(onTriggerFunction, null, {delay:delay, interval:interval});
+    return true;
+}
+
+function cleanupTransactions () returns error|null {
+    worker w1 {
+        foreach _, txn in participatedTransactions {
+            string participatedTxnId = getParticipatedTransactionId(txn.transactionId, txn.transactionBlockId);
+            if(time:currentTime().time - txn.createdTime >= 120000){
+                TwoPhaseCommitTransaction twopcTxn =? <TwoPhaseCommitTransaction> txn;
+                if(twopcTxn.state != TransactionState.ABORTED) {
+                    // Commit the transaction since prepare hasn't been received
+                    boolean successful = commitResourceManagers(txn.transactionId, txn.transactionBlockId);
+                    if(!successful) {
+                        log:printError("Auto-commit of participated transaction: " + participatedTxnId + " failed");
+                    } else {
+                        twopcTxn.state = TransactionState.COMMITTED;
+                    }
+                }
+            }
+            if(time:currentTime().time - txn.createdTime >= 600000){
+                // We don't want dead transactions hanging around
+                removeParticipatedTransaction(participatedTxnId);
+            }
+        }
+    }
+    worker w2 {
+        foreach _, txn in initiatedTransactions {
+            if(time:currentTime().time - txn.createdTime >= 120000){
+                TwoPhaseCommitTransaction twopcTxn =? <TwoPhaseCommitTransaction> txn;
+                if(twopcTxn.state != TransactionState.ABORTED) {
+                    // Commit the transaction since prepare hasn't been received
+                    var result = twopcTxn.twoPhaseCommit();
+                    match result {
+                        string str => log:printInfo("Auto-committed initiated transaction: " +
+                                                        txn.transactionId + ". Result: " + str);
+                        error err => log:printErrorCause("Auto-commit of participated transaction: " +
+                                                            txn.transactionId + " failed", err);
+                    }
+                }
+            }
+            if(time:currentTime().time - txn.createdTime >= 600000){
+                // We don't want dead transactions hanging around
+                removeInitiatedTransaction(txn.transactionId);
+            }
+        }
+        return null;
+    }
+}
 
 
 function isRegisteredParticipant (string participantId, map<Participant> participants) returns boolean {
@@ -95,7 +151,8 @@ function createNewTransaction (string coordinationType, int transactionBlockId) 
     if (coordinationType == TWO_PHASE_COMMIT) {
         TwoPhaseCommitTransaction twopcTxn = {transactionId:util:uuid(),
                                                  transactionBlockId:transactionBlockId,
-                                                 coordinationType:TWO_PHASE_COMMIT};
+                                                 createdTime: time:currentTime().time,
+                                                 coordinationType:coordinationType};
         Transaction txn = <Transaction>twopcTxn;
         return txn;
     } else {
@@ -164,6 +221,7 @@ function registerParticipantWithLocalInitiator (string transactionId,
             //Set initiator protocols
             TwoPhaseCommitTransaction twopcTxn = {transactionId:transactionId,
                                                      transactionBlockId:transactionBlockId,
+                                                     createdTime: time:currentTime().time,
                                                      coordinationType:TWO_PHASE_COMMIT};
             Protocol initiatorProto = {name:"durable", transactionBlockId:transactionBlockId};
             twopcTxn.coordinatorProtocols = [initiatorProto];
@@ -298,6 +356,7 @@ public function registerParticipantWithRemoteInitiator (string transactionId,
             Protocol[] coordinatorProtocols = regRes.coordinatorProtocols;
             TwoPhaseCommitTransaction twopcTxn = {transactionId:transactionId,
                                                      transactionBlockId:transactionBlockId,
+                                                     createdTime: time:currentTime().time,
                                                      coordinationType:TWO_PHASE_COMMIT};
             twopcTxn.coordinatorProtocols = coordinatorProtocols;
             participatedTransactions[participatedTxnId] = twopcTxn;

--- a/stdlib/ballerina-builtin/src/main/ballerina/transactions.coordinator/commons.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/transactions.coordinator/commons.bal
@@ -190,6 +190,10 @@ function localParticipantProtocolFn (string transactionId,
         if (txn.state == TransactionState.ABORTED) {
             removeParticipatedTransaction(participatedTxnId);
             return false;
+        } else if(txn.state == TransactionState.COMMITTED) {
+            removeParticipatedTransaction(participatedTxnId);
+            txn.possibleMixedOutcome = true;
+            return true;
         } else {
             boolean successful = prepareResourceManagers(transactionId, transactionBlockId);
             if (successful) {

--- a/stdlib/ballerina-builtin/src/main/ballerina/transactions.coordinator/data.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/transactions.coordinator/data.bal
@@ -50,6 +50,7 @@ struct Transaction {
     boolean isInitiated; // Indicates whether this is a transaction that was initiated or is participated in
     map<Participant> participants;
     Protocol[] coordinatorProtocols;
+    int createdTime;
 }
 
 public struct TransactionContext {


### PR DESCRIPTION
## Purpose
A timer task has been introduced to commit transactions that are lingering because the protocol messages have been lost or not received.