### PR TITLE
Return errors by WebSocket apis

### DIFF
--- a/docs/ballerina-by-example/examples/http-to-websocket-upgrade/http-to-websocket-upgrade.bal
+++ b/docs/ballerina-by-example/examples/http-to-websocket-upgrade/http-to-websocket-upgrade.bal
@@ -47,16 +47,16 @@ service<http:WebSocketService> wsService {
 
     onOpen (endpoint ep) {
         var conn = ep.getClient();
-        io:println("New WebSocket connection: " + conn.id);
+        io:println("New WebSocket connection: " + ep.id);
     }
 
     onTextMessage (endpoint ep, http:TextFrame frame) {
         io:println(frame.text);
-        ep -> pushText(frame.text);
+        _ = ep -> pushText(frame.text);
     }
 
     onIdleTimeout (endpoint ep) {
         var conn = ep.getClient();
-        io:println("Idle timeout: " + conn.id);
+        io:println("Idle timeout: " + ep.id);
     }
 }

--- a/docs/ballerina-by-example/examples/websocket-basic-sample/websocket-basic-sample.bal
+++ b/docs/ballerina-by-example/examples/websocket-basic-sample/websocket-basic-sample.bal
@@ -46,9 +46,11 @@ service<http:WebSocketService> SimpleSecureServer bind ep {
             io:println("Pinging...");
             conn -> ping(pingData);
         } else if (text == "closeMe") {
-            conn -> closeConnection(1001, "You asked me to close connection");
+            var val = conn -> closeConnection(1001, "You asked me to close connection");
+            handleError(val);
         } else {
-            conn -> pushText("You said: " + frame.text);
+            var val = conn -> pushText("You said: " + frame.text);
+            handleError(val);
         }
     }
 
@@ -57,7 +59,8 @@ service<http:WebSocketService> SimpleSecureServer bind ep {
         io:println("\nNew binary message received");
         blob b = frame.data;
         io:println("UTF-8 decoded binary message: " + b.toString("UTF-8"));
-        conn -> pushBinary(b);
+        var val = conn -> pushBinary(b);
+        handleError(val);
     }
 
     @Description {value:"This resource is triggered when a ping message is received from the client. If this resource is not implemented then pong message will be sent automatically to the connected endpoint when a ping is received."}
@@ -75,7 +78,8 @@ service<http:WebSocketService> SimpleSecureServer bind ep {
         // This resource will be triggered after 180 seconds if there is no activity in a given channel.
         io:println("\nReached idle timeout");
         io:println("Closing connection " + conn.id);
-        conn -> closeConnection(1001, "Connection timeout");
+        var val = conn -> closeConnection(1001, "Connection timeout");
+        handleError(val);
     }
 
     @Description {value:"This resource is triggered when a client connection is closed from the client side."}
@@ -93,5 +97,14 @@ function printHeaders (map<string> headers) {
         var value = headers[key];
         io:println(key + ": " + value);
         i = i + 1;
+    }
+}
+
+function handleError(http:WebSocketConnectorError|null val){
+    match val {
+        http:WebSocketConnectorError err => {io:println("Error: " + err.message);}
+        any|null err => {//ignore x
+            var x = err;
+        }
     }
 }

--- a/docs/ballerina-by-example/examples/websocket-chat-application/websocket-chat-application.bal
+++ b/docs/ballerina-by-example/examples/websocket-chat-application/websocket-chat-application.bal
@@ -3,7 +3,7 @@ import ballerina/http;
 
 const string NAME = "NAME";
 const string AGE = "AGE";
-endpoint http:ServiceEndpoint ep {
+endpoint http:WebSocketEndpoint ep {
     port:9090
 };
 
@@ -12,7 +12,7 @@ endpoint http:ServiceEndpoint ep {
 }
 service<http:WebSocketService> ChatApp bind ep {
     string msg;
-    map<http:WebSocketConnector> consMap = {};
+    map<http:WebSocketEndpoint> consMap = {};
     onUpgrade (endpoint conn, http:Request req, string name) {
         var params = req.getQueryParams();
         conn.attributes[NAME] = name;
@@ -27,7 +27,7 @@ service<http:WebSocketService> ChatApp bind ep {
     }
     onOpen (endpoint conn) {
         io:println(msg);
-        consMap[conn.id] = conn.getClient();
+        consMap[conn.id] = conn;
         broadcast(consMap, msg);
     }
 
@@ -44,13 +44,20 @@ service<http:WebSocketService> ChatApp bind ep {
     }
 }
 
-function broadcast (map<http:WebSocketConnector> consMap, string text) {
+function broadcast (map<http:WebSocketEndpoint> consMap, string text) {
+    endpoint http:WebSocketEndpoint con;
     string[] conKeys = consMap.keys();
     int len = lengthof conKeys;
     int i = 0;
     while (i < len) {
-        http:WebSocketConnector con = consMap[conKeys[i]];
-        con.pushText(text);
+        con = consMap[conKeys[i]];
+        var val = con -> pushText(text);
+        match val {
+            http:WebSocketConnectorError err => {io:println("Error: " + err.message);}
+            any|null err => {//ignore x
+                var x = err;
+            }
+        }
         i = i + 1;
     }
 }

--- a/docs/ballerina-by-example/examples/websocket-proxy-server/websocket-proxy-server.bal
+++ b/docs/ballerina-by-example/examples/websocket-proxy-server/websocket-proxy-server.bal
@@ -25,17 +25,20 @@ service<http:WebSocketService> SimpleProxyServer bind serviceEndpoint {
 
     onTextMessage (endpoint ep, http:TextFrame frame) {
         endpoint http:WebSocketClient clientEp = getAssociatedClientEndpoint(ep);
-        clientEp -> pushText(frame.text);
+        var val = clientEp -> pushText(frame.text);
+        handleError(val);
     }
 
     onBinaryMessage (endpoint ep, http:BinaryFrame frame) {
         endpoint http:WebSocketClient clientEp = getAssociatedClientEndpoint(ep);
-        clientEp -> pushBinary(frame.data);
+        var val = clientEp -> pushBinary(frame.data);
+        handleError(val);
     }
 
     onClose (endpoint ep, http:CloseFrame frame) {
         endpoint http:WebSocketClient clientEp = getAssociatedClientEndpoint(ep);
-        clientEp -> closeConnection(frame.statusCode, frame.reason);
+        var val = clientEp -> closeConnection(frame.statusCode, frame.reason);
+        handleError(val);
         _ = ep.attributes.remove(ASSOCIATED_CONNECTION);
     }
 }
@@ -46,17 +49,20 @@ service<http:WebSocketClientService> ClientService {
 
     onTextMessage (endpoint ep, http:TextFrame frame) {
         endpoint http:WebSocketEndpoint parentEp = getAssociatedServerEndpoint(ep);
-        parentEp -> pushText(frame.text);
+        var val = parentEp -> pushText(frame.text);
+        handleError(val);
     }
 
     onBinaryMessage (endpoint ep, http:BinaryFrame frame) {
         endpoint http:WebSocketEndpoint parentEp = getAssociatedServerEndpoint(ep);
-        parentEp -> pushBinary(frame.data);
+        var val = parentEp -> pushBinary(frame.data);
+        handleError(val);
     }
 
     onClose (endpoint ep, http:CloseFrame frame) {
         endpoint http:WebSocketEndpoint parentEp = getAssociatedServerEndpoint(ep);
-        parentEp -> closeConnection(frame.statusCode, frame.reason);
+        var val = parentEp -> closeConnection(frame.statusCode, frame.reason);
+        handleError(val);
         _ = ep.attributes.remove(ASSOCIATED_CONNECTION);
     }
 
@@ -82,6 +88,15 @@ function getAssociatedServerEndpoint (http:WebSocketClient ep) returns (http:Web
         any|null val => {
             error err = {message:"Associated connection is not set"};
             throw err;
+        }
+    }
+}
+
+function handleError(http:WebSocketConnectorError|null val){
+    match val {
+        http:WebSocketConnectorError err => {io:println("Error: " + err.message);}
+        any|null err => {//ignore x
+            var x = err;
         }
     }
 }

--- a/misc/testerina/modules/testerina-core/src/test/resources/service.skeleton/service-skeleton-test.bal
+++ b/misc/testerina/modules/testerina-core/src/test/resources/service.skeleton/service-skeleton-test.bal
@@ -19,7 +19,7 @@ function clean() {
 function testService () {
     endpoint http:ClientEndpoint httpEndpoint {
         targets:[{
-            uri:url
+            url:url
         }]
     };
 

--- a/pom.xml
+++ b/pom.xml
@@ -1469,7 +1469,7 @@
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
         <carbon.kernel.version>5.1.0</carbon.kernel.version>
-        <transport.http.version>6.0.117</transport.http.version>
+        <transport.http.version>6.0.120</transport.http.version>
         <carbon.messaging.version>2.3.7</carbon.messaging.version>
         <carbon.deployment.version>5.0.0</carbon.deployment.version>
         <carbon.config.version>2.1.2</carbon.config.version>

--- a/stdlib/ballerina-http/src/main/ballerina/http/websocket_client.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/websocket_client.bal
@@ -31,17 +31,6 @@ public function <WebSocketClientEndpointConfig config> WebSocketClientEndpointCo
     config.idleTimeoutInSeconds = -1;
 }
 
-//TODO: This throws errors. Fix it.
-//@Description { value:"Gets called when the endpoint is being initialize during package init time"}
-//@Param { value:"epName: The endpoint name" }
-//@Param { value:"config: The ServiceEndpointConfiguration of the endpoint" }
-//@Return { value:"Error occured during initialization" }
-//public function <WebSocketClient ep> init (string epName, WebSocketClientEndpointConfig config){
-//    ep.epName = epName;
-//    ep.config = config;
-//    ep.initEndpoint();
-//}
-
 @Description { value:"Gets called when the endpoint is being initialize during package init time"}
 @Param { value:"epName: The endpoint name" }
 @Param { value:"config: The ServiceEndpointConfiguration of the endpoint" }
@@ -84,5 +73,5 @@ public function <WebSocketClient h> getClient() returns (WebSocketConnector){
 @Description { value:"Stops the registered service"}
 @Return { value:"Error occured during registration" }
 public function <WebSocketClient h> stop (){
-    h.getClient().closeConnection(1001, "The connection has been stopped");
+    _ = h.getClient().closeConnection(1001, "The connection has been stopped");
 }

--- a/stdlib/ballerina-http/src/main/ballerina/http/websocket_connector.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/websocket_connector.bal
@@ -5,72 +5,41 @@ package ballerina.http;
 ///////////////////////////
 
 @Description {value:"Represents a WebSocket connector in ballerina. This include all connector oriented operations."}
-@Field {value: "attributes: Custom user attributes"}
-@Field {value: "id: The ID of the WebSocket connection"}
-@Field {value: "negotiatedSubProtocol: The negotiated sub protocol of the connection"}
-@Field {value: "isSecure: the connection is secure"}
-@Field {value: "isOpen: whether the connection is open"}
-@Field {value: "upgradeHeaders: a map of all the upgrade headers of the connection"}
+@Field {value:"attributes: Custom user attributes"}
+@Field {value:"id: The ID of the WebSocket connection"}
+@Field {value:"negotiatedSubProtocol: The negotiated sub protocol of the connection"}
+@Field {value:"isSecure: the connection is secure"}
+@Field {value:"isOpen: whether the connection is open"}
+@Field {value:"upgradeHeaders: a map of all the upgrade headers of the connection"}
 public struct WebSocketConnector {
 }
 
-//@Description {value:"Gets the ID of the WebSocket connection"}
-//@Return {value:"ID of the connection"}
-//public native function <WebSocketConnector wsConnector> getID() (string);
-
-//@Description {value:"Gets the negotiated sub protocol of the connection"}
-//@Return {value:"Negotiated sub protocol"}
-//public native function <WebSocketConnector wsConnector> getNegotiatedSubProtocol() (string);
-//
-//@Description {value:"Checks whether the connection is secure or not"}
-//@Return {value:"True if the connection is secure"}
-//public native function <WebSocketConnector wsConnector> isSecure() (boolean);
-//
-//@Description {value:"Checks whether the connection is still open or not."}
-//@Return {value:"True if the connection is open"}
-//public native function <WebSocketConnector wsConnector> isOpen() (boolean);
-//
-//@Description {value:"Gets a map of all the upgrade headers of the connection"}
-//@Return {value:"Map of all the headers received in the connection upgrade"}
-//public native function <WebSocketConnector wsConnector> getUpgradeHeaders() (map);
-
-//TODO: To work on later
-//@Description {value:"Gets a value of a header"}
-//@Param {value:"key: Key of the header for which the value should be retrieved"}
-//@Return {value:"Value of the header if it exists, else it is null"}
-//public native function <WebSocketConnector wsConnector> getUpgradeHeader(string key) (string);
-
 @Description {value:"Push text to the connection"}
 @Param {value:"text: Text to be sent"}
-public native function <WebSocketConnector wsConnector> pushText(string text);
+public native function <WebSocketConnector wsConnector> pushText (string text) returns (WebSocketConnectorError|null);
 
 @Description {value:"Push binary data to the connection"}
 @Param {value:"data: Binary data to be sent"}
-public native function <WebSocketConnector wsConnector> pushBinary(blob data);
+public native function <WebSocketConnector wsConnector> pushBinary (blob data) returns (WebSocketConnectorError|null);
 
 @Description {value:"Ping the connection"}
 @Param {value:"data: Binary data to be sent"}
-public native function <WebSocketConnector wsConnector> ping(blob data);
+public native function <WebSocketConnector wsConnector> ping (blob data);
 
 @Description {value:"Send pong message to the connection"}
 @Param {value:"data: Binary data to be sent"}
-public native function <WebSocketConnector wsConnector> pong(blob data);
+public native function <WebSocketConnector wsConnector> pong (blob data);
 
 @Description {value:"Close the connection"}
 @Param {value:"statusCode: Status code for closing the connection"}
 @Param {value:"reason: Reason for closing the connection"}
-public native function <WebSocketConnector wsConnector> closeConnection(int statusCode, string reason);
+public native function <WebSocketConnector wsConnector> closeConnection (int statusCode, string reason) returns (WebSocketConnectorError|null);
 
-@Description { value:"Sends a upgrade request with custom headers" }
+@Description {value:"Sends a upgrade request with custom headers"}
 @Param {value:"headers: a map of custom headers for handshake."}
-public native function <WebSocketConnector conn> upgradeToWebSocket(map headers);
+public native function <WebSocketConnector conn> upgradeToWebSocket (map headers);
 
-@Description { value:"Cancels the handshake" }
+@Description {value:"Cancels the handshake"}
 @Param {value:"statusCode: Status code for closing the connection"}
 @Param {value:"reason: Reason for closing the connection"}
-public native function <WebSocketConnector conn> cancelUpgradeToWebSocket(int status, string reason);
-
-//TODO: Check on this if it should come in the request
-//@Description {value:"Gets the query parameters from the Connection as a map"}
-//@Return {value:"The map of query params" }
-//public native function <WebSocketConnector ep> getQueryParams () returns (map);
+public native function <WebSocketConnector conn> cancelUpgradeToWebSocket (int status, string reason);

--- a/stdlib/ballerina-http/src/main/ballerina/http/websocket_frames.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/websocket_frames.bal
@@ -2,16 +2,16 @@ package ballerina.http;
 
 
 @Description {value:"Represents a WebSocket text frame in Ballerina."}
-@Field {value: "text: Text in the text frame"}
-@Field {value: "isFinalFragment: Check whether this is the final frame. True if the frame is final frame."}
+@Field {value:"text: Text in the text frame"}
+@Field {value:"isFinalFragment: Check whether this is the final frame. True if the frame is final frame."}
 public struct TextFrame {
     string text;
     boolean isFinalFragment;
 }
 
 @Description {value:"Represents a WebSocket binary frame in Ballerina."}
-@Field {value: "data: Binary data of the frame"}
-@Field {value: "isFinalFragment: Check whether this is the final frame. True if the frame is final frame."}
+@Field {value:"data: Binary data of the frame"}
+@Field {value:"isFinalFragment: Check whether this is the final frame. True if the frame is final frame."}
 public struct BinaryFrame {
     blob data;
     boolean isFinalFragment;
@@ -19,29 +19,30 @@ public struct BinaryFrame {
 
 
 @Description {value:"Represents a WebSocket close frame in Ballerina."}
-@Field {value: "statusCode: Status code for the reason of the closure of the connection"}
-@Field {value: "reason: Reason to close the connection"}
+@Field {value:"statusCode: Status code for the reason of the closure of the connection"}
+@Field {value:"reason: Reason to close the connection"}
 public struct CloseFrame {
     int statusCode;
     string reason;
 }
 
 @Description {value:"Represents a WebSocket ping frame in Ballerina."}
-@Field {value: "data: Data of the frame"}
+@Field {value:"data: Data of the frame"}
 public struct PingFrame {
     blob data;
 }
 
 @Description {value:"Represents a WebSocket pong frame in Ballerina."}
-@Field {value: "data: Data of the frame"}
+@Field {value:"data: Data of the frame"}
 public struct PongFrame {
     blob data;
 }
 
-@Description {value: "Error struct for WebSocket connection errors"}
-@Field {value:"message:  An error message explaining the error"}
-@Field {value:"cause: The error that caused HttpConnectorError to be returned"}
+@Description {value:"WebSocketConnectorError struct represents an error occured during WebSocket message transfers"}
+@Field {value:"message:  An error message explaining about the error"}
+@Field {value:"cause: The error(s) that caused HttpConnectorError to get thrown"}
+@Field {value:"code: An error code that differenciates different errors"}
 public struct WebSocketConnectorError {
     string message;
-    error cause;
+    error[] cause;
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketConstants.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketConstants.java
@@ -25,6 +25,9 @@ public class WebSocketConstants {
 
     public static final String WEBSOCKET_ENDPOINT_NAME = "ballerina.http:WebSocketEndpoint";
     public static final String WEBSOCKET_CLIENT_ENDPOINT_NAME = "ballerina.http:WebSocketClient";
+    public static final String WEBSOCKET_CONNECTOR = "WebSocketConnector";
+    public static final String WEBSOCKET_ENDPOINT = "WebSocketEndpoint";
+    public static final String WEBSOCKET_CONNECTOR_ERROR = "WebSocketConnectorError";
 
     public static final String WEBSOCKET_ANNOTATION_CONFIGURATION = "WebSocketServiceConfig";
     public static final String ANNOTATION_ATTR_SUB_PROTOCOLS = "subProtocols";
@@ -54,8 +57,6 @@ public class WebSocketConstants {
 
     public static final String NATIVE_DATA_QUERY_PARAMS = "NATIVE_DATA_QUERY_PARAMS";
 
-    public static final String WEBSOCKET_CONNECTOR = "WebSocketConnector";
-    public static final String WEBSOCKET_ENDPOINT = "WebSocketEndpoint";
     public static final String CLIENT_URL_CONFIG = "url";
     public static final String CLIENT_SERVICE_CONFIG = "callbackService";
     public static final String CLIENT_SUBPROTOCOLS_CONFIG = "subProtocols";

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketDispatcher.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketDispatcher.java
@@ -213,7 +213,7 @@ public class WebSocketDispatcher {
     private static void pingAutomatically(WebSocketControlMessage controlMessage) {
         Session session = controlMessage.getChannelSession();
         try {
-            session.getBasicRemote().sendPong(controlMessage.getPayload());
+            session.getAsyncRemote().sendPong(controlMessage.getPayload());
         } catch (IOException ex) {
             ErrorHandlerUtils.printError(ex);
         }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketUtil.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/WebSocketUtil.java
@@ -18,6 +18,8 @@
 
 package org.ballerinalang.net.http;
 
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.handler.codec.http.HttpHeaders;
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.connector.api.Annotation;
@@ -37,6 +39,7 @@ import org.wso2.transport.http.netty.contract.websocket.HandshakeListener;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketInitMessage;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.websocket.Session;
 
 
@@ -120,5 +123,22 @@ public abstract class WebSocketUtil {
         endpoint.setStringField(1, session.getNegotiatedSubprotocol());
         endpoint.setBooleanField(0, session.isSecure() ? 1 : 0);
         endpoint.setBooleanField(1, session.isOpen() ? 1 : 0);
+    }
+
+    public static BValue[] getWebSocketError(Context context, ChannelFuture webSocketChannelFuture, String message)
+            throws InterruptedException {
+        AtomicReference<BValue[]> error = new AtomicReference<>();
+        webSocketChannelFuture.addListener((ChannelFutureListener) future1 -> {
+            Throwable cause = future1.cause();
+            if (!future1.isSuccess() && cause != null) {
+                error.set(new BValue[]{BLangConnectorSPIUtil.createBStruct(context, HttpConstants.PROTOCOL_PACKAGE_HTTP,
+                                                                           WebSocketConstants.WEBSOCKET_CONNECTOR_ERROR,
+                                                                           message, new BValue[]{})});
+            } else {
+                error.set(new BValue[0]);
+            }
+        });
+        webSocketChannelFuture.sync();
+        return error.get();
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/CloseConnection.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/CloseConnection.java
@@ -18,14 +18,15 @@ package org.ballerinalang.net.http.actions.websocketconnector;
 
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
+import org.ballerinalang.connector.api.BLangConnectorSPIUtil;
 import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.net.http.HttpConstants;
 import org.ballerinalang.net.http.WebSocketConnectionManager;
 import org.ballerinalang.net.http.WebSocketConstants;
-import org.ballerinalang.util.exceptions.BallerinaException;
 
 import java.io.IOException;
 import javax.websocket.CloseReason;
@@ -38,7 +39,7 @@ import javax.websocket.Session;
         orgName = "ballerina", packageName = "http",
         functionName = "closeConnection",
         receiver = @Receiver(type = TypeKind.STRUCT, structType = WebSocketConstants.WEBSOCKET_CONNECTOR,
-                structPackage = "ballerina.http"),
+                             structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "wsConnector", type = TypeKind.STRUCT),
                 @Argument(name = "statusCode", type = TypeKind.INT),
@@ -56,7 +57,10 @@ public class CloseConnection extends BlockingNativeCallableUnit {
         try {
             session.close(new CloseReason(() -> statusCode, reason));
         } catch (IOException e) {
-            throw new BallerinaException("Could not close the connection: " + e.getMessage());
+            context.setReturnValues(BLangConnectorSPIUtil.createBStruct(context, HttpConstants.PROTOCOL_PACKAGE_HTTP,
+                                                                        WebSocketConstants.WEBSOCKET_CONNECTOR_ERROR,
+                                                                        "Could not close the connection: " +
+                                                                                e.getMessage()));
         } finally {
             WebSocketConnectionManager.getInstance().removeConnection(session.getId());
         }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/Ping.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/Ping.java
@@ -50,7 +50,7 @@ public class Ping extends BlockingNativeCallableUnit {
             BStruct wsConnection = (BStruct) context.getRefArgument(0);
             Session session = (Session) wsConnection.getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_SESSION);
             byte[] binaryData = context.getBlobArgument(0);
-            session.getBasicRemote().sendPing(ByteBuffer.wrap(binaryData));
+            session.getAsyncRemote().sendPing(ByteBuffer.wrap(binaryData));
         } catch (Throwable e) {
             throw new BallerinaException("Cannot send the message. Error occurred.");
         }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/Pong.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/Pong.java
@@ -50,10 +50,9 @@ public class Pong extends BlockingNativeCallableUnit {
             BStruct wsConnection = (BStruct) context.getRefArgument(0);
             Session session = (Session) wsConnection.getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_SESSION);
             byte[] binaryData = context.getBlobArgument(0);
-            session.getBasicRemote().sendPong(ByteBuffer.wrap(binaryData));
+            session.getAsyncRemote().sendPong(ByteBuffer.wrap(binaryData));
         } catch (Throwable e) {
             throw new BallerinaException("Cannot send the message. Error occurred.");
         }
-        context.setReturnValues();
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/PushBinary.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/PushBinary.java
@@ -16,6 +16,7 @@
 
 package org.ballerinalang.net.http.actions.websocketconnector;
 
+import io.netty.channel.ChannelFuture;
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
 import org.ballerinalang.model.types.TypeKind;
@@ -24,6 +25,7 @@ import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.net.http.WebSocketConstants;
+import org.ballerinalang.net.http.WebSocketUtil;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
 import java.nio.ByteBuffer;
@@ -36,7 +38,7 @@ import javax.websocket.Session;
         orgName = "ballerina", packageName = "http",
         functionName = "pushBinary",
         receiver = @Receiver(type = TypeKind.STRUCT, structType = WebSocketConstants.WEBSOCKET_CONNECTOR,
-                structPackage = "ballerina.http"),
+                             structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "wsConnector", type = TypeKind.STRUCT),
                 @Argument(name = "data", type = TypeKind.BLOB)
@@ -50,10 +52,12 @@ public class PushBinary extends BlockingNativeCallableUnit {
             BStruct wsConnection = (BStruct) context.getRefArgument(0);
             Session session = (Session) wsConnection.getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_SESSION);
             byte[] binaryData = context.getBlobArgument(0);
-            session.getBasicRemote().sendBinary(ByteBuffer.wrap(binaryData));
+            ChannelFuture webSocketChannelFuture = (ChannelFuture) session.getAsyncRemote().sendBinary(
+                    ByteBuffer.wrap(binaryData));
+            context.setReturnValues(
+                    WebSocketUtil.getWebSocketError(context, webSocketChannelFuture, "Failed to send binary message"));
         } catch (Throwable e) {
             throw new BallerinaException("Cannot send the message. Error occurred.");
         }
-        context.setReturnValues();
     }
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/PushText.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/PushText.java
@@ -16,6 +16,7 @@
 
 package org.ballerinalang.net.http.actions.websocketconnector;
 
+import io.netty.channel.ChannelFuture;
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
 import org.ballerinalang.model.types.TypeKind;
@@ -24,6 +25,7 @@ import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.net.http.WebSocketConstants;
+import org.ballerinalang.net.http.WebSocketUtil;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
 import javax.websocket.Session;
@@ -35,7 +37,7 @@ import javax.websocket.Session;
         orgName = "ballerina", packageName = "http",
         functionName = "pushText",
         receiver = @Receiver(type = TypeKind.STRUCT, structType = WebSocketConstants.WEBSOCKET_CONNECTOR,
-                structPackage = "ballerina.http"),
+                             structPackage = "ballerina.http"),
         args = {
                 @Argument(name = "wsConnector", type = TypeKind.STRUCT),
                 @Argument(name = "text", type = TypeKind.STRING)
@@ -49,10 +51,12 @@ public class PushText extends BlockingNativeCallableUnit {
             BStruct wsConnection = (BStruct) context.getRefArgument(0);
             Session session = (Session) wsConnection.getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_SESSION);
             String text = context.getStringArgument(0);
-            session.getBasicRemote().sendText(text);
+            ChannelFuture future = (ChannelFuture) session.getAsyncRemote().sendText(text);
+            context.setReturnValues(
+                    WebSocketUtil.getWebSocketError(context, future, "Failed to send text message"));
         } catch (Throwable e) {
             throw new BallerinaException("Cannot send the message. Error occurred.");
         }
-        context.setReturnValues();
     }
+
 }

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/websocketclientendpoint/Start.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/websocketclientendpoint/Start.java
@@ -65,7 +65,7 @@ public class Start extends BlockingNativeCallableUnit {
         Struct clientEndpointConfig = clientEndpoint.getStructField(HttpConstants.CLIENT_ENDPOINT_CONFIG);
         Object configs = clientEndpointConfig.getNativeData(WebSocketConstants.CLIENT_CONNECTOR_CONFIGS);
         if (configs == null || !(configs instanceof WsClientConnectorConfig)) {
-            throw new BallerinaConnectorException("Initialize the service before starting it");
+            throw new BallerinaConnectorException("Error in initializing: Missing client endpoint configurations");
         }
         WebSocketClientConnector clientConnector =
                 connectorFactory.createWsClientConnector((WsClientConnectorConfig) configs);
@@ -73,7 +73,7 @@ public class Start extends BlockingNativeCallableUnit {
                 clientConnectorListener = new WebSocketClientConnectorListener();
         Object serviceConfig = clientEndpointConfig.getNativeData(WebSocketConstants.CLIENT_SERVICE_CONFIG);
         if (serviceConfig == null || !(serviceConfig instanceof WebSocketService)) {
-            throw new BallerinaConnectorException("Initialize the service before starting it");
+            throw new BallerinaConnectorException("Error in initializing: A callbackService is required");
         }
         WebSocketService wsService = (WebSocketService) serviceConfig;
         HandshakeFuture handshakeFuture = clientConnector.connect(clientConnectorListener);
@@ -112,7 +112,7 @@ public class Start extends BlockingNativeCallableUnit {
 
         @Override
         public void onError(Throwable t) {
-            throw new BallerinaConnectorException("Initialize the service before starting it");
+            throw new BallerinaConnectorException("Error occured: " + t.getMessage());
         }
     }
 }


### PR DESCRIPTION
## Purpose
> Resolve https://github.com/ballerina-lang/ballerina/issues/6069

## Goals
> Give user more flexibility to handle errors.

## Approach
> Now the connector methods closeConnection, pushBinary and pushText return errors.
Modified the samples to reflect these changes.