### PR TITLE
Handle exception which occurs when compiling

### DIFF
--- a/composer/modules/server/services/ballerina-parser/src/main/java/org/ballerinalang/composer/service/ballerina/parser/service/util/ParserUtils.java
+++ b/composer/modules/server/services/ballerina-parser/src/main/java/org/ballerinalang/composer/service/ballerina/parser/service/util/ParserUtils.java
@@ -844,15 +844,19 @@ public class ParserUtils {
         CollectDiagnosticListener diagnosticListener = new CollectDiagnosticListener(balDiagnostics);
         context.put(DiagnosticListener.class, diagnosticListener);
 
-        Compiler compiler = Compiler.getInstance(context);
         BLangPackage bLangPackage = null;
-        if ("".equals(pkgName)) {
-            Path filePath = path.getFileName();
-            if (filePath != null) {
-                bLangPackage = compiler.compile(filePath.toString());
+        try {
+            Compiler compiler = Compiler.getInstance(context);
+            if ("".equals(pkgName)) {
+                Path filePath = path.getFileName();
+                if (filePath != null) {
+                    bLangPackage = compiler.compile(filePath.toString());
+                }
+            } else {
+                bLangPackage = compiler.compile(pkgName);
             }
-        } else {
-            bLangPackage = compiler.compile(pkgName);
+        } catch (Exception e) {
+            // Ignore.
         }
         BallerinaFile bfile = new BallerinaFile();
         bfile.setBLangPackage(bLangPackage);


### PR DESCRIPTION
## Purpose

This is to ignore the exceptions coming from the compiler when compiling .bal files with syntax error from the composer side since syntax error recognition is done by Language server.

Related issue #6137.