### PR TITLE
Fix the issue with error message background color

### DIFF
--- a/composer/modules/web/scss/modules/ballerina-editor.scss
+++ b/composer/modules/web/scss/modules/ballerina-editor.scss
@@ -344,7 +344,7 @@ $white:#fff;
     width: 400px;
     margin: auto;
     top: 20px;
-    background-color: #d8d8d8;
+    background-color: #988686;
     .list-heading {
       text-align: center;
       font-size: 16px;


### PR DESCRIPTION
## Purpose
> Error message which is appear in the diagram area when we have a syntax error in the code background color was not visible. This commit will make it visible.

## Approach
> ![image](https://user-images.githubusercontent.com/9109762/38136258-eeb07042-343a-11e8-89b0-4029c352edaa.png)
