### PR TITLE
Cleanup the Language server Context API

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,10 +45,17 @@ public class BallerinaLanguageServer implements LanguageServer, LanguageClientAw
     private int shutdown = 1;
 
     public BallerinaLanguageServer() {
-        WorkspaceDocumentManagerImpl documentManager = WorkspaceDocumentManagerImpl.getInstance();
-        LSPackageCache lSPackageCache = new LSPackageCache();
-        textService = new BallerinaTextDocumentService(this, documentManager, lSPackageCache);
-        workspaceService = new BallerinaWorkspaceService(this, documentManager, lSPackageCache);
+        LSGlobalContext lsGlobalContext = new LSGlobalContext();
+        LSPackageCache packageCache = new LSPackageCache();
+        LSAnnotationCache annotationCache = new LSAnnotationCache(packageCache);
+        
+        lsGlobalContext.put(LSGlobalContextKeys.LANGUAGE_SERVER_KEY, this);
+        lsGlobalContext.put(LSGlobalContextKeys.PKG_CACHE_KEY, packageCache);
+        lsGlobalContext.put(LSGlobalContextKeys.ANNOTATION_CACHE_KEY, annotationCache);
+        lsGlobalContext.put(LSGlobalContextKeys.DOCUMENT_MANAGER_KEY, WorkspaceDocumentManagerImpl.getInstance());
+        
+        textService = new BallerinaTextDocumentService(lsGlobalContext);
+        workspaceService = new BallerinaWorkspaceService(lsGlobalContext);
     }
 
     public LanguageClient getClient() {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaWorkspaceService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaWorkspaceService.java
@@ -32,17 +32,15 @@ import java.util.concurrent.CompletableFuture;
 /**
  * Workspace service implementation for Ballerina.
  */
-public class BallerinaWorkspaceService implements WorkspaceService {
+class BallerinaWorkspaceService implements WorkspaceService {
     private BallerinaLanguageServer ballerinaLanguageServer;
     private WorkspaceDocumentManagerImpl workspaceDocumentManager;
     private LSPackageCache lSPackageCache;
     
-    public BallerinaWorkspaceService(BallerinaLanguageServer ballerinaLanguageServer,
-                                     WorkspaceDocumentManagerImpl workspaceDocumentManager,
-                                     LSPackageCache packageContext) {
-        this.ballerinaLanguageServer = ballerinaLanguageServer;
-        this.workspaceDocumentManager = workspaceDocumentManager;
-        this.lSPackageCache = packageContext;
+    BallerinaWorkspaceService(LSGlobalContext lsGlobalContext) {
+        this.ballerinaLanguageServer = lsGlobalContext.get(LSGlobalContextKeys.LANGUAGE_SERVER_KEY);
+        this.workspaceDocumentManager = lsGlobalContext.get(LSGlobalContextKeys.DOCUMENT_MANAGER_KEY);
+        this.lSPackageCache = lsGlobalContext.get(LSGlobalContextKeys.PKG_CACHE_KEY);
     }
 
     @Override
@@ -61,7 +59,7 @@ public class BallerinaWorkspaceService implements WorkspaceService {
 
     @Override
     public CompletableFuture<Object> executeCommand(ExecuteCommandParams params) {
-        WorkspaceServiceContext executeCommandContext = new WorkspaceServiceContext();
+        LSServiceOperationContext executeCommandContext = new LSServiceOperationContext();
         executeCommandContext.put(ExecuteCommandKeys.COMMAND_ARGUMENTS_KEY, params.getArguments());
         executeCommandContext.put(ExecuteCommandKeys.DOCUMENT_MANAGER_KEY, this.workspaceDocumentManager);
         executeCommandContext.put(ExecuteCommandKeys.LS_PACKAGE_CACHE_KEY, this.lSPackageCache);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/DocumentServiceKeys.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/DocumentServiceKeys.java
@@ -33,32 +33,32 @@ import java.util.List;
  * @since 0.95.5
  */
 public class DocumentServiceKeys {
-    public static final LanguageServerContext.Key<String> FILE_URI_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<TextDocumentPositionParams> POSITION_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<String> FILE_NAME_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<CompilerContext> COMPILER_CONTEXT_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<ParserRuleContext> PARSER_RULE_CONTEXT_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<TokenStream> TOKEN_STREAM_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<Vocabulary> VOCABULARY_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<Integer> TOKEN_INDEX_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<SymbolTable> SYMBOL_TABLE_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<List<SymbolInformation>> SYMBOL_LIST_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<LSPackageCache> LS_PACKAGE_CACHE_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<String> CURRENT_PACKAGE_NAME_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<TextDocumentServiceContext> OPERATION_META_CONTEXT_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<BLangPackage> CURRENT_BLANG_PACKAGE_CONTEXT_KEY
-            = new LanguageServerContext.Key<>();
+    public static final LSContext.Key<String> FILE_URI_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<TextDocumentPositionParams> POSITION_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<String> FILE_NAME_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<CompilerContext> COMPILER_CONTEXT_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<ParserRuleContext> PARSER_RULE_CONTEXT_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<TokenStream> TOKEN_STREAM_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<Vocabulary> VOCABULARY_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<Integer> TOKEN_INDEX_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<SymbolTable> SYMBOL_TABLE_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<List<SymbolInformation>> SYMBOL_LIST_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<LSPackageCache> LS_PACKAGE_CACHE_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<String> CURRENT_PACKAGE_NAME_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<LSServiceOperationContext> OPERATION_META_CONTEXT_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<BLangPackage> CURRENT_BLANG_PACKAGE_CONTEXT_KEY
+            = new LSContext.Key<>();
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSAnnotationCache.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSAnnotationCache.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver;
+
+import org.ballerinalang.model.elements.PackageID;
+import org.wso2.ballerinalang.compiler.tree.BLangAnnotation;
+import org.wso2.ballerinalang.compiler.tree.BLangPackage;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Annotation cache for Language server.
+ * 
+ * Note: Annotation cache should be synced with the LS Package Cache
+ * 
+ * @since 0.970.0
+ */
+class LSAnnotationCache {
+    
+    private final HashMap<PackageID, List<BLangAnnotation>> serviceAnnotations = new HashMap<>();
+    private HashMap<PackageID, List<BLangAnnotation>> resourceAnnotations = new HashMap<>();
+    private HashMap<PackageID, List<BLangAnnotation>> functionAnnotations = new HashMap<>();
+    private HashMap<PackageID, List<BLangAnnotation>> constantAnnotations = new HashMap<>();
+
+    LSAnnotationCache(LSPackageCache lsPackageCache) {
+        loadAnnotations(lsPackageCache.getPackageMap().values().stream().collect(Collectors.toList()));
+    }
+    
+    private void loadAnnotations(List<BLangPackage> packageList) {
+        packageList.forEach(bLangPackage -> {
+            bLangPackage.getAnnotations().forEach(bLangAnnotation -> {
+                bLangAnnotation.getAttachmentPoints().forEach(attachmentPoint -> {
+                    switch (attachmentPoint.attachmentPoint) {
+                        case SERVICE:
+                            this.addAttachment(bLangAnnotation, serviceAnnotations, bLangPackage.packageID);
+                            break;
+                        case RESOURCE:
+                            this.addAttachment(bLangAnnotation, resourceAnnotations, bLangPackage.packageID);
+                            break;
+                        case FUNCTION:
+                            this.addAttachment(bLangAnnotation, functionAnnotations, bLangPackage.packageID);
+                            break;
+                        case CONST:
+                            this.addAttachment(bLangAnnotation, constantAnnotations, bLangPackage.packageID);
+                            break;
+                        default:
+                            break;
+                    }
+                });
+            });
+        });
+    }
+    
+    private void addAttachment(BLangAnnotation bLangAnnotation, HashMap<PackageID, List<BLangAnnotation>> map,
+                               PackageID packageID) {
+        if (map.containsKey(packageID)) {
+            map.get(packageID).add(bLangAnnotation);
+            return;
+        }
+        map.put(packageID, new ArrayList<>(Collections.singletonList(bLangAnnotation)));
+    }
+
+    public HashMap<PackageID, List<BLangAnnotation>> getServiceAnnotations() {
+        return serviceAnnotations;
+    }
+
+    public HashMap<PackageID, List<BLangAnnotation>> getResourceAnnotations() {
+        return resourceAnnotations;
+    }
+
+    public HashMap<PackageID, List<BLangAnnotation>> getFunctionAnnotations() {
+        return functionAnnotations;
+    }
+
+    public HashMap<PackageID, List<BLangAnnotation>> getConstantAnnotations() {
+        return constantAnnotations;
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSContext.java
@@ -1,5 +1,5 @@
 /*
-*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 *  WSO2 Inc. licenses this file to you under the Apache License,
 *  Version 2.0 (the "License"); you may not use this file except
@@ -19,9 +19,9 @@ package org.ballerinalang.langserver;
 
 /**
  * Ballerina Language server context.
- * @since 0.95.5
+ * @since 0.970.0
  */
-public interface LanguageServerContext {
+public interface LSContext {
 
     /**
      * Add new Context property.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSGlobalContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSGlobalContext.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Global context for Language server.
+ * 
+ * @since 0.970.0
+ */
+class LSGlobalContext implements LSContext {
+
+    private Map<Key<?>, Object> props = new HashMap<>();
+    
+    @Override
+    public <V> void put(Key<V> key, V value) {
+        props.put(key, value);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <V> V get(Key<V> key) {
+        return (V) props.get(key);
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSGlobalContextKeys.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSGlobalContextKeys.java
@@ -15,24 +15,20 @@
  */
 package org.ballerinalang.langserver;
 
-import java.util.HashMap;
-import java.util.Map;
+import org.ballerinalang.langserver.workspace.WorkspaceDocumentManagerImpl;
 
 /**
- * Language server context for the Workspace service.
- * @since v0.964.0
+ * Language Server Global Context Keys.
+ * 
+ * @since 0.970.0
  */
-public class WorkspaceServiceContext implements LanguageServerContext {
-    private Map<LanguageServerContext.Key<?>, Object> props = new HashMap<>();
-
-    @Override
-    public <V> void put(LanguageServerContext.Key<V> key, V value) {
-        props.put(key, value);
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public <V> V get(LanguageServerContext.Key<V> key) {
-        return (V) props.get(key);
-    }
+public class LSGlobalContextKeys {
+    public static final LSContext.Key<LSPackageCache> PKG_CACHE_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<LSAnnotationCache> ANNOTATION_CACHE_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<WorkspaceDocumentManagerImpl> DOCUMENT_MANAGER_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<BallerinaLanguageServer> LANGUAGE_SERVER_KEY
+            = new LSContext.Key<>();
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSServiceOperationContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSServiceOperationContext.java
@@ -24,7 +24,7 @@ import java.util.Map;
  * Language server context for text document server.
  * @since 0.95.5
  */
-public class TextDocumentServiceContext implements LanguageServerContext {
+public class LSServiceOperationContext implements LSContext {
 
     private Map<Key<?>, Object> props = new HashMap<>();
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/TextDocumentServiceUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/TextDocumentServiceUtil.java
@@ -227,7 +227,7 @@ public class TextDocumentServiceUtil {
      * @param compileFullProject  compile full project from the source root
      * @return {@link BLangPackage} BLang Package
      */
-    public static List<BLangPackage> getBLangPackage(LanguageServerContext context, WorkspaceDocumentManager docManager,
+    public static List<BLangPackage> getBLangPackage(LSContext context, WorkspaceDocumentManager docManager,
                                                      boolean preserveWhitespace, Class customErrorStrategy,
                                                      boolean compileFullProject) {
         String uri = context.get(DocumentServiceKeys.FILE_URI_KEY);
@@ -286,7 +286,7 @@ public class TextDocumentServiceUtil {
      * @param customErrorStrategy custom error strategy class
      * @return {@link Compiler} ballerina compiler
      */
-    private static Compiler getCompiler(LanguageServerContext context, String fileName,
+    private static Compiler getCompiler(LSContext context, String fileName,
                                         PackageRepository packageRepository, LSDocument sourceRoot,
                                         boolean preserveWhitespace, Class customErrorStrategy,
                                         WorkspaceDocumentManager documentManager) {
@@ -295,7 +295,7 @@ public class TextDocumentServiceUtil {
                         preserveWhitespace, documentManager);
         context.put(DocumentServiceKeys.FILE_NAME_KEY, fileName);
         context.put(DocumentServiceKeys.COMPILER_CONTEXT_KEY, compilerContext);
-        context.put(DocumentServiceKeys.OPERATION_META_CONTEXT_KEY, new TextDocumentServiceContext());
+        context.put(DocumentServiceKeys.OPERATION_META_CONTEXT_KEY, new LSServiceOperationContext());
         List<org.ballerinalang.util.diagnostic.Diagnostic> balDiagnostics = new ArrayList<>();
         CollectDiagnosticListener diagnosticListener = new CollectDiagnosticListener(balDiagnostics);
         compilerContext.put(DiagnosticListener.class, diagnosticListener);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/CommandExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/CommandExecutor.java
@@ -17,8 +17,8 @@ package org.ballerinalang.langserver.command;
 
 import com.google.gson.internal.LinkedTreeMap;
 import org.ballerinalang.langserver.DocumentServiceKeys;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.TextDocumentServiceUtil;
-import org.ballerinalang.langserver.WorkspaceServiceContext;
 import org.ballerinalang.langserver.common.LSCustomErrorStrategy;
 import org.ballerinalang.langserver.common.UtilSymbolKeys;
 import org.ballerinalang.langserver.common.constants.CommandConstants;
@@ -67,7 +67,7 @@ public class CommandExecutor {
      * @param params    Parameters for the command
      * @param context   Workspace service context
      */
-    public static void executeCommand(ExecuteCommandParams params, WorkspaceServiceContext context) {
+    public static void executeCommand(ExecuteCommandParams params, LSServiceOperationContext context) {
         switch (params.getCommand()) {
             case CommandConstants.CMD_IMPORT_PACKAGE:
                 executeImportPackage(context);
@@ -88,7 +88,7 @@ public class CommandExecutor {
      * Execute the command, import package.
      * @param context   Workspace service context
      */
-    private static void executeImportPackage(WorkspaceServiceContext context) {
+    private static void executeImportPackage(LSServiceOperationContext context) {
         String documentUri = null;
         VersionedTextDocumentIdentifier textDocumentIdentifier = new VersionedTextDocumentIdentifier();
         
@@ -158,7 +158,7 @@ public class CommandExecutor {
      * Execute the add documentation command.
      * @param context   Workspace service context
      */
-    private static void executeAddDocumentation(WorkspaceServiceContext context) {
+    private static void executeAddDocumentation(LSServiceOperationContext context) {
         String topLevelNodeType = "";
         String documentUri = "";
         int line = 0;
@@ -201,7 +201,7 @@ public class CommandExecutor {
      * Generate workspace edit for generating doc comments for all top level nodes and resources.
      * @param context   Workspace Service Context
      */
-    private static void executeAddAllDocumentation(WorkspaceServiceContext context) {
+    private static void executeAddAllDocumentation(LSServiceOperationContext context) {
         String documentUri = "";
         VersionedTextDocumentIdentifier textDocumentIdentifier = new VersionedTextDocumentIdentifier();
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/ExecuteCommandKeys.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/ExecuteCommandKeys.java
@@ -16,8 +16,8 @@
 package org.ballerinalang.langserver.command;
 
 import org.ballerinalang.langserver.BallerinaLanguageServer;
+import org.ballerinalang.langserver.LSContext;
 import org.ballerinalang.langserver.LSPackageCache;
-import org.ballerinalang.langserver.LanguageServerContext;
 import org.ballerinalang.langserver.workspace.WorkspaceDocumentManagerImpl;
 
 import java.util.List;
@@ -27,14 +27,14 @@ import java.util.List;
  * @since v0.964.0
  */
 public class ExecuteCommandKeys {
-    public static final LanguageServerContext.Key<WorkspaceDocumentManagerImpl> DOCUMENT_MANAGER_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<LSPackageCache> LS_PACKAGE_CACHE_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<List<Object>> COMMAND_ARGUMENTS_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<BallerinaLanguageServer> LANGUAGE_SERVER_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<String> PKG_NAME_KEY
-            = new LanguageServerContext.Key<>();
+    public static final LSContext.Key<WorkspaceDocumentManagerImpl> DOCUMENT_MANAGER_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<LSPackageCache> LS_PACKAGE_CACHE_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<List<Object>> COMMAND_ARGUMENTS_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<BallerinaLanguageServer> LANGUAGE_SERVER_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<String> PKG_NAME_KEY
+            = new LSContext.Key<>();
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/CustomErrorStrategyFactory.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/CustomErrorStrategyFactory.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.common;
 
-import org.ballerinalang.langserver.LanguageServerContext;
+import org.ballerinalang.langserver.LSContext;
 import org.ballerinalang.langserver.common.constants.ContextConstants;
 import org.ballerinalang.langserver.completions.CompletionCustomErrorStrategy;
 
@@ -33,7 +33,7 @@ public class CustomErrorStrategyFactory {
      * @return {@link LSCustomErrorStrategy} custom strategy
      */
     public static LSCustomErrorStrategy getCustomErrorStrategy(Class customErrorStrategyClass,
-                                                               LanguageServerContext context) {
+                                                               LSContext context) {
         LSCustomErrorStrategy lsCustomErrorStrategy;
         switch (customErrorStrategyClass.getSimpleName()) {
             case ContextConstants.COMPLETION_ERROR_STRATEGY:

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/LSCustomErrorStrategy.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/LSCustomErrorStrategy.java
@@ -22,7 +22,7 @@ import org.antlr.v4.runtime.NoViableAltException;
 import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.LanguageServerContext;
+import org.ballerinalang.langserver.LSContext;
 import org.wso2.ballerinalang.compiler.parser.antlr4.BallerinaParser;
 import org.wso2.ballerinalang.compiler.parser.antlr4.BallerinaParserErrorStrategy;
 
@@ -30,7 +30,7 @@ import org.wso2.ballerinalang.compiler.parser.antlr4.BallerinaParserErrorStrateg
  * Custom error strategy for language server.
  */
 public class LSCustomErrorStrategy extends BallerinaParserErrorStrategy {
-    public LSCustomErrorStrategy(LanguageServerContext context) {
+    public LSCustomErrorStrategy(LSContext context) {
         super(context.get(DocumentServiceKeys.COMPILER_CONTEXT_KEY), null);
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/NodeContextKeys.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/NodeContextKeys.java
@@ -15,7 +15,7 @@
  */
 package org.ballerinalang.langserver.common.constants;
 
-import org.ballerinalang.langserver.LanguageServerContext;
+import org.ballerinalang.langserver.LSContext;
 import org.ballerinalang.model.elements.PackageID;
 import org.eclipse.lsp4j.Location;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
@@ -27,26 +27,26 @@ import java.util.Stack;
  * Keys for the hover context.
  */
 public class NodeContextKeys {
-    public static final LanguageServerContext.Key<BLangNode> NODE_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<PackageID> PACKAGE_OF_NODE_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<String> NAME_OF_NODE_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<String> SYMBOL_KIND_OF_NODE_PARENT_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<Object> PREVIOUSLY_VISITED_NODE_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<String> NODE_OWNER_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<PackageID> NODE_OWNER_PACKAGE_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<Stack<BLangNode>> NODE_STACK_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<String> SYMBOL_KIND_OF_NODE_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<String> VAR_NAME_OF_NODE_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<List<Location>> REFERENCE_NODES_KEY
-            = new LanguageServerContext.Key<>();
+    public static final LSContext.Key<BLangNode> NODE_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<PackageID> PACKAGE_OF_NODE_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<String> NAME_OF_NODE_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<String> SYMBOL_KIND_OF_NODE_PARENT_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<Object> PREVIOUSLY_VISITED_NODE_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<String> NODE_OWNER_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<PackageID> NODE_OWNER_PACKAGE_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<Stack<BLangNode>> NODE_STACK_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<String> SYMBOL_KIND_OF_NODE_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<String> VAR_NAME_OF_NODE_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<List<Location>> REFERENCE_NODES_KEY
+            = new LSContext.Key<>();
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/position/PositionTreeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/position/PositionTreeVisitor.java
@@ -17,7 +17,7 @@
 package org.ballerinalang.langserver.common.position;
 
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.LSNodeVisitor;
 import org.ballerinalang.langserver.common.constants.ContextConstants;
 import org.ballerinalang.langserver.common.constants.NodeContextKeys;
@@ -95,11 +95,11 @@ public class PositionTreeVisitor extends LSNodeVisitor {
     private Position position;
     private boolean terminateVisitor = false;
     private SymbolTable symTable;
-    private TextDocumentServiceContext context;
+    private LSServiceOperationContext context;
     private Object previousNode;
     private Stack<BLangNode> nodeStack;
 
-    public PositionTreeVisitor(TextDocumentServiceContext context) {
+    public PositionTreeVisitor(LSServiceOperationContext context) {
         this.context = context;
         this.position = context.get(DocumentServiceKeys.POSITION_KEY).getPosition();
         this.fileName = context.get(DocumentServiceKeys.FILE_NAME_KEY);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -27,7 +27,7 @@ import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.ballerinalang.compiler.CompilerPhase;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.LSDocument;
 import org.ballerinalang.langserver.format.TextDocumentFormatUtil;
 import org.ballerinalang.langserver.workspace.WorkspaceDocumentManager;
@@ -440,7 +440,7 @@ public class CommonUtil {
      * @param terminalTokens List of terminal tokens
      * @return {@link Boolean}  Whether the cursor is within the brackets or not
      */
-    public static boolean isWithinBrackets(TextDocumentServiceContext context, List<String> terminalTokens) {
+    public static boolean isWithinBrackets(LSServiceOperationContext context, List<String> terminalTokens) {
         int currentTokenIndex = context.get(DocumentServiceKeys.TOKEN_INDEX_KEY);
         TokenStream tokenStream = context.get(DocumentServiceKeys.TOKEN_STREAM_KEY);
         Token previousToken = tokenStream.get(currentTokenIndex);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/CompletionCustomErrorStrategy.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/CompletionCustomErrorStrategy.java
@@ -24,7 +24,7 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.TokenStream;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.LanguageServerContext;
+import org.ballerinalang.langserver.LSContext;
 import org.ballerinalang.langserver.common.LSCustomErrorStrategy;
 import org.ballerinalang.langserver.common.UtilSymbolKeys;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
@@ -36,9 +36,9 @@ import java.util.List;
  * Capture possible errors from source.
  */
 public class CompletionCustomErrorStrategy extends LSCustomErrorStrategy {
-    private LanguageServerContext context;
+    private LSContext context;
 
-    public CompletionCustomErrorStrategy(LanguageServerContext context) {
+    public CompletionCustomErrorStrategy(LSContext context) {
         super(context);
         this.context = context;
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/CompletionKeys.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/CompletionKeys.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions;
 
-import org.ballerinalang.langserver.LanguageServerContext;
+import org.ballerinalang.langserver.LSContext;
 import org.ballerinalang.model.tree.Node;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
 
@@ -28,26 +28,26 @@ import java.util.List;
  * @since 0.95.5
  */
 public class CompletionKeys {
-    public static final LanguageServerContext.Key<BLangNode> SYMBOL_ENV_NODE_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<List<SymbolInfo>> VISIBLE_SYMBOLS_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<Node> BLOCK_OWNER_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<BLangNode> PREVIOUS_NODE_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<Integer> LOOP_COUNT_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<Boolean> CURRENT_NODE_TRANSACTION_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<Integer> TRANSACTION_COUNT_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<Boolean> INVOCATION_STATEMENT_KEY
-            = new LanguageServerContext.Key<>();
+    public static final LSContext.Key<BLangNode> SYMBOL_ENV_NODE_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<List<SymbolInfo>> VISIBLE_SYMBOLS_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<Node> BLOCK_OWNER_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<BLangNode> PREVIOUS_NODE_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<Integer> LOOP_COUNT_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<Boolean> CURRENT_NODE_TRANSACTION_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<Integer> TRANSACTION_COUNT_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<Boolean> INVOCATION_STATEMENT_KEY
+            = new LSContext.Key<>();
     
     // Meta context Keys
-    public static final LanguageServerContext.Key<Boolean> META_CONTEXT_IS_ENDPOINT_KEY
-            = new LanguageServerContext.Key<>();
-    public static final LanguageServerContext.Key<String> META_CONTEXT_ENDPOINT_NAME_KEY
-            = new LanguageServerContext.Key<>();
+    public static final LSContext.Key<Boolean> META_CONTEXT_IS_ENDPOINT_KEY
+            = new LSContext.Key<>();
+    public static final LSContext.Key<String> META_CONTEXT_ENDPOINT_NAME_KEY
+            = new LSContext.Key<>();
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/TreeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/TreeVisitor.java
@@ -22,7 +22,7 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.TokenStream;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.LSNodeVisitor;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.completions.util.ScopeResolverConstants;
@@ -122,10 +122,10 @@ public class TreeVisitor extends LSNodeVisitor {
     private Stack<BLangBlockStmt> blockStmtStack;
     private Stack<Boolean> isCurrentNodeTransactionStack;
     private Class cursorPositionResolver;
-    private TextDocumentServiceContext documentServiceContext;
+    private LSServiceOperationContext documentServiceContext;
     private BLangNode previousNode = null;
 
-    public TreeVisitor(TextDocumentServiceContext documentServiceContext) {
+    public TreeVisitor(LSServiceOperationContext documentServiceContext) {
         this.documentServiceContext = documentServiceContext;
         init(this.documentServiceContext.get(DocumentServiceKeys.COMPILER_CONTEXT_KEY));
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/AbstractItemResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/AbstractItemResolver.java
@@ -20,7 +20,7 @@ package org.ballerinalang.langserver.completions.resolvers;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.TokenStream;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.UtilSymbolKeys;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.completions.CompletionKeys;
@@ -46,7 +46,7 @@ import java.util.List;
  */
 public abstract class AbstractItemResolver {
     
-    public abstract ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext);
+    public abstract ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext);
 
     /**
      * Populate the completion item list by considering the.
@@ -219,7 +219,7 @@ public abstract class AbstractItemResolver {
      * @param documentServiceContext - Completion operation context
      * @return {@link Boolean}
      */
-    protected boolean isInvocationOrFieldAccess(TextDocumentServiceContext documentServiceContext) {
+    protected boolean isInvocationOrFieldAccess(LSServiceOperationContext documentServiceContext) {
         ArrayList<String> terminalTokens = new ArrayList<>(Arrays.asList(new String[]{";", "}", "{", "(", ")"}));
         TokenStream tokenStream = documentServiceContext.get(DocumentServiceKeys.TOKEN_STREAM_KEY);
         if (tokenStream == null) {
@@ -261,7 +261,7 @@ public abstract class AbstractItemResolver {
      * @param documentServiceContext - Completion operation context
      * @return {@link Boolean}
      */
-    boolean isAnnotationContext(TextDocumentServiceContext documentServiceContext) {
+    boolean isAnnotationContext(LSServiceOperationContext documentServiceContext) {
         return findPreviousToken(documentServiceContext, "@", 3) >= 0;
     }
 
@@ -295,7 +295,7 @@ public abstract class AbstractItemResolver {
         }
     }
 
-    int findPreviousToken(TextDocumentServiceContext documentServiceContext, String needle, int maxSteps) {
+    int findPreviousToken(LSServiceOperationContext documentServiceContext, String needle, int maxSteps) {
         TokenStream tokenStream = documentServiceContext.get(DocumentServiceKeys.TOKEN_STREAM_KEY);
         if (tokenStream == null) {
             return -1;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/AnnotationAttachmentContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/AnnotationAttachmentContextResolver.java
@@ -18,7 +18,7 @@
 
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.eclipse.lsp4j.CompletionItem;
 
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ import java.util.ArrayList;
  */
 public class AnnotationAttachmentContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         return new ArrayList<>();
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/AnnotationAttachmentResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/AnnotationAttachmentResolver.java
@@ -18,7 +18,7 @@
 
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.eclipse.lsp4j.CompletionItem;
 
 import java.util.ArrayList;
@@ -29,7 +29,7 @@ import java.util.List;
  */
 public class AnnotationAttachmentResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         return filterAnnotations(completionContext);
     }
 
@@ -38,40 +38,9 @@ public class AnnotationAttachmentResolver extends AbstractItemResolver {
      * @param completionContext - Completion operation context
      * @return {@link List}
      */
-    ArrayList<CompletionItem> filterAnnotations(TextDocumentServiceContext completionContext) {
-
-//        Set<Map.Entry<String, ModelPackage>> packages = dataModel.getPackages();
-//        if (packages == null) {
-//            packages = Utils.getAllPackages().entrySet();
-//        }
-//        Stream<AnnotationDef> annotationDefStream = packages.stream().map(i -> i.getValue().getAnnotations())
-//                .flatMap(Collection::stream);
-//        List<CompletionItem> collect = annotationDefStream.map(i -> {
-//            CompletionItem importItem = new CompletionItem();
-//
-//            String insertText = lastPart(i.getPackagePath()) + ":" + i.getName();
-//            importItem.setLabel("@" + insertText + " (" + i.getPackagePath() + ")");
-//            if (dataModel.getParserRuleContext() == null) {
-//                insertText = "@" + insertText;
-//            } else {
-//                if (findPreviousToken(dataModel, "@", 3) < 0) {
-//                    insertText = "@" + insertText;
-//                }
-//            }
-//            if (i.getAnnotationAttributeDefs().size() == 0) {
-//                importItem.setInsertText(insertText + "{}");
-//            } else {
-//                importItem.setInsertText(insertText + "{${1}}");
-//            }
-//            importItem.setDetail(ItemResolverConstants.ANNOTATION_TYPE);
-//            importItem.setSortText(ItemResolverConstants.PRIORITY_6);
-//            return importItem;
-//        }).collect(Collectors.toList());
-
-        ArrayList<CompletionItem> list = new ArrayList<>();
-//        collect.sort(Comparator.comparing(CompletionItem::getLabel));
-//        list.addAll(collect);
-        return list;
+    ArrayList<CompletionItem> filterAnnotations(LSServiceOperationContext completionContext) {
+        // TODO: Implementation needed with the new annotation cache.
+        return new ArrayList<>();
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/BLangEndpointContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/BLangEndpointContextResolver.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
 import org.eclipse.lsp4j.CompletionItem;
@@ -41,7 +41,7 @@ public class BLangEndpointContextResolver extends AbstractItemResolver {
     
     @Override
     @SuppressWarnings("unchecked")
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         BLangNode bLangEndpoint = completionContext.get(CompletionKeys.SYMBOL_ENV_NODE_KEY);
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         ArrayList<SymbolInfo> configurationFields = new ArrayList<>();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/BLangMatchContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/BLangMatchContextResolver.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.UtilSymbolKeys;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
 public class BLangMatchContextResolver extends AbstractItemResolver {
 
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         BLangNode symbolEnvNode = completionContext.get(CompletionKeys.SYMBOL_ENV_NODE_KEY);
         List<SymbolInfo> visibleSymbols = completionContext.get(CompletionKeys.VISIBLE_SYMBOLS_KEY);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/BLangStructContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/BLangStructContextResolver.java
@@ -18,7 +18,7 @@
 
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.eclipse.lsp4j.CompletionItem;
 
@@ -29,7 +29,7 @@ import java.util.ArrayList;
  */
 public class BLangStructContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         this.populateBasicTypes(completionItems, completionContext.get(CompletionKeys.VISIBLE_SYMBOLS_KEY));
         return completionItems;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/BlockStatementContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/BlockStatementContextResolver.java
@@ -19,7 +19,7 @@ package org.ballerinalang.langserver.completions.resolvers;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.util.CompletionItemResolver;
 import org.eclipse.lsp4j.CompletionItem;
 
@@ -30,7 +30,7 @@ import java.util.ArrayList;
  */
 public class BlockStatementContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         AbstractItemResolver itemResolver;
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/ConnectorActionContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/ConnectorActionContextResolver.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.util.CompletionItemResolver;
 import org.eclipse.lsp4j.CompletionItem;
 import org.wso2.ballerinalang.compiler.tree.BLangResource;
@@ -29,7 +29,7 @@ import java.util.ArrayList;
  */
 public class ConnectorActionContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         // Same item resolving logic is used for both the BLangResource and the BLangAction
         return CompletionItemResolver.getResolverByClass(BLangResource.class).resolveItems(completionContext);
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/ConnectorDefinitionContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/ConnectorDefinitionContextResolver.java
@@ -19,7 +19,7 @@ package org.ballerinalang.langserver.completions.resolvers;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.util.CompletionItemResolver;
 import org.ballerinalang.langserver.completions.util.sorters.CompletionItemSorter;
@@ -33,7 +33,7 @@ import java.util.ArrayList;
  */
 public class ConnectorDefinitionContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
 
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/DefaultResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/DefaultResolver.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
 import org.ballerinalang.langserver.completions.util.Snippet;
@@ -33,7 +33,7 @@ import java.util.ArrayList;
 public class DefaultResolver extends AbstractItemResolver {
     @Override
     @SuppressWarnings("unchecked")
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
 
         CompletionItem workerItem = new CompletionItem();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/FunctionContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/FunctionContextResolver.java
@@ -19,7 +19,7 @@ package org.ballerinalang.langserver.completions.resolvers;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.util.CompletionItemResolver;
 import org.eclipse.lsp4j.CompletionItem;
 
@@ -30,7 +30,7 @@ import java.util.ArrayList;
  */
 public class FunctionContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         ParserRuleContext parserRuleContext = completionContext.get(DocumentServiceKeys.PARSER_RULE_CONTEXT_KEY);
         AbstractItemResolver contextResolver = CompletionItemResolver.getResolverByClass(parserRuleContext.getClass());
         if (contextResolver != null) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/GlobalScopeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/GlobalScopeResolver.java
@@ -20,7 +20,7 @@ package org.ballerinalang.langserver.completions.resolvers;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
 import org.ballerinalang.langserver.completions.util.CompletionItemResolver;
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 public class GlobalScopeResolver extends AbstractItemResolver {
 
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
 
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/ObjectTypeContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/ObjectTypeContextResolver.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
 import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
  */
 public class ObjectTypeContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         List<SymbolInfo> filteredTypes = completionContext.get(CompletionKeys.VISIBLE_SYMBOLS_KEY).stream()
                 .filter(symbolInfo -> symbolInfo.getScopeEntry().symbol instanceof BTypeSymbol)

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/PackageNameContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/PackageNameContextResolver.java
@@ -20,7 +20,7 @@ package org.ballerinalang.langserver.completions.resolvers;
 
 import org.ballerinalang.langserver.DocumentServiceKeys;
 import org.ballerinalang.langserver.LSPackageCache;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
 import org.ballerinalang.model.elements.PackageID;
 import org.eclipse.lsp4j.CompletionItem;
@@ -36,7 +36,7 @@ import java.util.List;
 public class PackageNameContextResolver extends AbstractItemResolver {
     
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         LSPackageCache lsPackageCache = completionContext.get(DocumentServiceKeys.LS_PACKAGE_CACHE_KEY);
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/ParameterContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/ParameterContextResolver.java
@@ -18,7 +18,7 @@
 
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.eclipse.lsp4j.CompletionItem;
 
@@ -29,7 +29,7 @@ import java.util.ArrayList;
  */
 public class ParameterContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         this.populateBasicTypes(completionItems, completionContext.get(CompletionKeys.VISIBLE_SYMBOLS_KEY));
         return completionItems;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/ResourceContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/ResourceContextResolver.java
@@ -19,7 +19,7 @@ package org.ballerinalang.langserver.completions.resolvers;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.util.CompletionItemResolver;
 import org.ballerinalang.model.AnnotationAttachment;
 import org.eclipse.lsp4j.CompletionItem;
@@ -32,7 +32,7 @@ import java.util.ArrayList;
 public class ResourceContextResolver extends AbstractItemResolver {
 
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         ParserRuleContext parserRuleContext = completionContext.get(DocumentServiceKeys.PARSER_RULE_CONTEXT_KEY);
         AbstractItemResolver itemResolver = CompletionItemResolver.getResolverByClass(parserRuleContext.getClass());

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/ServiceContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/ServiceContextResolver.java
@@ -19,7 +19,7 @@ package org.ballerinalang.langserver.completions.resolvers;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.util.CompletionItemResolver;
 import org.ballerinalang.langserver.completions.util.sorters.CompletionItemSorter;
@@ -34,7 +34,7 @@ import java.util.ArrayList;
 public class ServiceContextResolver extends AbstractItemResolver {
 
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         // TODO: Add annotations
         ParserRuleContext parserRuleContext = completionContext.get(DocumentServiceKeys.PARSER_RULE_CONTEXT_KEY);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/StatementContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/StatementContextResolver.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
 import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
@@ -40,7 +40,7 @@ import java.util.Arrays;
 public class StatementContextResolver extends AbstractItemResolver {
     @Override
     @SuppressWarnings("unchecked")
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
 
         // Here we specifically need to check whether the statement is function invocation,

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/TopLevelResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/TopLevelResolver.java
@@ -18,7 +18,7 @@ package org.ballerinalang.langserver.completions.resolvers;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.resolvers.parsercontext.ParserRuleConstantDefinitionContextResolver;
 import org.ballerinalang.langserver.completions.resolvers.parsercontext.ParserRuleGlobalVariableDefinitionContextResolver;
 import org.ballerinalang.langserver.completions.resolvers.parsercontext.ParserRuleTypeNameContextResolver;
@@ -40,7 +40,7 @@ import java.util.List;
 public class TopLevelResolver extends AbstractItemResolver {
 
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
 
         ParserRuleContext parserRuleContext = completionContext.get(DocumentServiceKeys.PARSER_RULE_CONTEXT_KEY);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleAnnotationBodyContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleAnnotationBodyContextResolver.java
@@ -19,7 +19,7 @@ package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
 import org.antlr.v4.runtime.TokenStream;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
 import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
 import org.eclipse.lsp4j.CompletionItem;
@@ -37,7 +37,7 @@ public class ParserRuleAnnotationBodyContextResolver extends AbstractItemResolve
      * @return {@link ArrayList}
      */
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
 
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         TokenStream tokenStream = completionContext.get(DocumentServiceKeys.TOKEN_STREAM_KEY);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleAssignmentStatementContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleAssignmentStatementContextResolver.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
 import org.ballerinalang.langserver.completions.util.CompletionItemResolver;
 import org.eclipse.lsp4j.CompletionItem;
@@ -30,7 +30,7 @@ import java.util.ArrayList;
  */
 public class ParserRuleAssignmentStatementContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
 
         // TODO: left hand side of the assignment statement should analyze when suggesting the completions
         // TODO: at the moment we are using the same completion resolving criteria as the variable definition

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleAttachmentPointContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleAttachmentPointContextResolver.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
 import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
 import org.eclipse.lsp4j.CompletionItem;
@@ -29,7 +29,7 @@ import java.util.ArrayList;
  */
 public class ParserRuleAttachmentPointContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         completionItems.add(populateCompletionItem(ItemResolverConstants.ACTION, ItemResolverConstants.KEYWORD_TYPE,
                 ItemResolverConstants.ACTION));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleCallableUnitBodyContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleCallableUnitBodyContextResolver.java
@@ -20,8 +20,8 @@ package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.TokenStream;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.LanguageServerContext;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
@@ -43,7 +43,7 @@ public class ParserRuleCallableUnitBodyContextResolver extends AbstractItemResol
     
     private static final String ENDPOINT_KEYWORD = "endpoint";
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         int tokenIndex = completionContext.get(DocumentServiceKeys.TOKEN_INDEX_KEY);
         int endpointTokenIndex = -1;
         String tokenString;
@@ -88,7 +88,7 @@ public class ParserRuleCallableUnitBodyContextResolver extends AbstractItemResol
         return cursorLine < tokenLine || (cursorLine == tokenLine && cursorCol <= tokenCol);
     }
     
-    private static List<SymbolInfo> getPackagesAndConnectors(LanguageServerContext context) {
+    private static List<SymbolInfo> getPackagesAndConnectors(LSContext context) {
         List<SymbolInfo> symbolInfoList = context.get(CompletionKeys.VISIBLE_SYMBOLS_KEY);
         return symbolInfoList.stream()
                 .filter(symbolInfo -> {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleConditionalClauseContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleConditionalClauseContextResolver.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
@@ -49,7 +49,7 @@ public class ParserRuleConditionalClauseContextResolver extends AbstractItemReso
     private static final String WHILE_KEY_WORD = "while";
     
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         List<SymbolInfo> symbolInfos =
                 this.filterConditionalSymbols(completionContext.get(CompletionKeys.VISIBLE_SYMBOLS_KEY));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleConstantDefinitionContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleConstantDefinitionContextResolver.java
@@ -18,7 +18,7 @@
 
 package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
 import org.eclipse.lsp4j.CompletionItem;
 
@@ -29,7 +29,7 @@ import java.util.ArrayList;
  */
 public class ParserRuleConstantDefinitionContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         // TODO: Implementation required after revamp
         return new ArrayList<>();
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleExpressionContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleExpressionContextResolver.java
@@ -19,7 +19,7 @@ package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
 import org.ballerinalang.langserver.completions.util.CompletionItemResolver;
 import org.eclipse.lsp4j.CompletionItem;
@@ -33,7 +33,7 @@ import java.util.ArrayList;
  */
 public class ParserRuleExpressionContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         ParserRuleContext contextParent = completionContext
                 .get(DocumentServiceKeys.PARSER_RULE_CONTEXT_KEY).getParent();
         // TODO: Specially add the check in case of binary expressions

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleExpressionVariableDefStatementContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleExpressionVariableDefStatementContextResolver.java
@@ -18,7 +18,7 @@
 
 package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
 import org.ballerinalang.langserver.completions.util.CompletionItemResolver;
 import org.eclipse.lsp4j.CompletionItem;
@@ -32,7 +32,7 @@ import java.util.ArrayList;
  */
 public class ParserRuleExpressionVariableDefStatementContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
 
         // Here we are using the existing variable statement itm resolver
         Class parserRuleContextResolver = BallerinaParser.VariableDefinitionStatementContext.class;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleGlobalVariableDefinitionContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleGlobalVariableDefinitionContextResolver.java
@@ -18,7 +18,7 @@
 
 package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
 import org.eclipse.lsp4j.CompletionItem;
 
@@ -29,7 +29,7 @@ import java.util.ArrayList;
  */
 public class ParserRuleGlobalVariableDefinitionContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         // currently we are returning a empty List
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         return completionItems;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleMatchStatementContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleMatchStatementContextResolver.java
@@ -20,7 +20,7 @@ package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.TokenStream;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.UtilSymbolKeys;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.completions.CompletionKeys;
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
  */
 public class ParserRuleMatchStatementContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         int currentTokenIndex = completionContext.get(DocumentServiceKeys.TOKEN_INDEX_KEY);
         List<SymbolInfo> visibleSymbols = completionContext.get(CompletionKeys.VISIBLE_SYMBOLS_KEY);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleStatementContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleStatementContextResolver.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
 import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
@@ -39,7 +39,7 @@ import java.util.ArrayList;
 public class ParserRuleStatementContextResolver extends AbstractItemResolver {
     @Override
     @SuppressWarnings("unchecked")
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         ArrayList<SymbolInfo> filteredSymbols = new ArrayList<>();
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleTriggerWorkerContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleTriggerWorkerContext.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
 import org.eclipse.lsp4j.CompletionItem;
 
@@ -28,7 +28,7 @@ import java.util.ArrayList;
  */
 public class ParserRuleTriggerWorkerContext extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
 
         return new ArrayList<>();
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleTypeNameContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleTypeNameContextResolver.java
@@ -22,7 +22,7 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.TokenStream;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
@@ -55,7 +55,7 @@ public class ParserRuleTypeNameContextResolver extends AbstractItemResolver {
     
     @Override
     @SuppressWarnings("unchecked")
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
 
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         TokenStream tokenStream = completionContext.get(DocumentServiceKeys.TOKEN_STREAM_KEY);
@@ -84,7 +84,7 @@ public class ParserRuleTypeNameContextResolver extends AbstractItemResolver {
         return completionItems;
     }
 
-    private static List<SymbolInfo> filterEndpointContextSymbolInfo(TextDocumentServiceContext context) {
+    private static List<SymbolInfo> filterEndpointContextSymbolInfo(LSServiceOperationContext context) {
         List<SymbolInfo> symbolInfos = context.get(CompletionKeys.VISIBLE_SYMBOLS_KEY);
         int currentTokenIndex = context.get(DocumentServiceKeys.TOKEN_INDEX_KEY) - 1;
         TokenStream tokenStream = context.get(DocumentServiceKeys.TOKEN_STREAM_KEY);
@@ -114,7 +114,7 @@ public class ParserRuleTypeNameContextResolver extends AbstractItemResolver {
         return returnList;
     }
 
-    private static List<SymbolInfo> filterCatchConditionSymbolInfo(TextDocumentServiceContext context) {
+    private static List<SymbolInfo> filterCatchConditionSymbolInfo(LSServiceOperationContext context) {
         List<SymbolInfo> symbolInfos = context.get(CompletionKeys.VISIBLE_SYMBOLS_KEY);
 
         return symbolInfos.stream().filter(symbolInfo -> {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleVariableDefinitionStatementContextResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleVariableDefinitionStatementContextResolver.java
@@ -18,7 +18,7 @@
 package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
 import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
 public class ParserRuleVariableDefinitionStatementContextResolver extends AbstractItemResolver {
     @Override
     @SuppressWarnings("unchecked")
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         PackageActionFunctionAndTypesFilter actionFunctionTypeFilter = new PackageActionFunctionAndTypesFilter();
         ConnectorInitExpressionItemFilter connectorInitItemFilter = new ConnectorInitExpressionItemFilter();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleWorkerReplyContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleWorkerReplyContext.java
@@ -18,7 +18,7 @@
 
 package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
 import org.eclipse.lsp4j.CompletionItem;
 
@@ -29,7 +29,7 @@ import java.util.ArrayList;
  */
 public class ParserRuleWorkerReplyContext extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+    public ArrayList<CompletionItem> resolveItems(LSServiceOperationContext completionContext) {
         return new ArrayList<>();
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/Snippet.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/Snippet.java
@@ -27,7 +27,7 @@ public enum Snippet {
     BREAK("break;"),
     CONNECTOR_ACTION("action ${1:name} (${2}) (${3}) {\n\t${4}\n}"),
     CONNECTOR_DEFINITION("connector ${1:name} (${2}) {\n\t${3}\n}"),
-    ENDPOINT("endpoint ${1:http:ServiceEndpoint} ${2:_endpoint} {\n\t${3}\n};"),
+    ENDPOINT("endpoint ${1:http:ServiceEndpoint} ${2:endpointName} {\n\t${3}\n};"),
     ENUM("enum ${1:name} {\n\t\n}"),
     FOREACH("foreach ${1:varRefList} in ${2:listReference} {\n\t${3}\n}"),
     FORK("fork {\n\t${1}\n} join (${2:all}) (map ${3:results}) {\n\t${4}\n}"),

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/filters/AbstractSymbolFilter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/filters/AbstractSymbolFilter.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.util.filters;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,5 +31,5 @@ public abstract class AbstractSymbolFilter {
      * @param completionContext - Completion operation context
      * @return {@link ArrayList}
      */
-    public abstract List filterItems(TextDocumentServiceContext completionContext);
+    public abstract List filterItems(LSServiceOperationContext completionContext);
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/filters/ConnectorInitExpressionItemFilter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/filters/ConnectorInitExpressionItemFilter.java
@@ -20,7 +20,7 @@ package org.ballerinalang.langserver.completions.util.filters;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.TokenStream;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BPackageType;
@@ -36,7 +36,7 @@ public class ConnectorInitExpressionItemFilter extends AbstractSymbolFilter {
 
     private static final String CREATE_KEYWORD = "create";
 
-    public List<SymbolInfo> filterItems(TextDocumentServiceContext context) {
+    public List<SymbolInfo> filterItems(LSServiceOperationContext context) {
         TokenStream tokenStream = context.get(DocumentServiceKeys.TOKEN_STREAM_KEY);
         int capturedTokenIndex = context.get(DocumentServiceKeys.TOKEN_INDEX_KEY);
         // Since the lang server is zero based indexing, we need to increase the line number to align with antlr token
@@ -100,7 +100,7 @@ public class ConnectorInitExpressionItemFilter extends AbstractSymbolFilter {
      * @param context           TextDocumentServiceCOntext
      * @return  {@link List}    List of filtered SymbolsInfos
      */
-    private List<SymbolInfo> getItemsList(Token evaluatorToken, TextDocumentServiceContext context) {
+    private List<SymbolInfo> getItemsList(Token evaluatorToken, LSServiceOperationContext context) {
         List<SymbolInfo> filteredList = new ArrayList<>();
         if (evaluatorToken == null) {
             return filteredList;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/filters/PackageActionFunctionAndTypesFilter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/filters/PackageActionFunctionAndTypesFilter.java
@@ -20,7 +20,7 @@ package org.ballerinalang.langserver.completions.util.filters;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.TokenStream;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.UtilSymbolKeys;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.completions.CompletionKeys;
@@ -57,7 +57,7 @@ import java.util.stream.Collectors;
 public class PackageActionFunctionAndTypesFilter extends AbstractSymbolFilter {
 
     @Override
-    public List<SymbolInfo> filterItems(TextDocumentServiceContext completionContext) {
+    public List<SymbolInfo> filterItems(LSServiceOperationContext completionContext) {
 
         TokenStream tokenStream = completionContext.get(DocumentServiceKeys.TOKEN_STREAM_KEY);
         int delimiterIndex = this.getPackageDelimiterTokenIndex(completionContext);
@@ -94,7 +94,7 @@ public class PackageActionFunctionAndTypesFilter extends AbstractSymbolFilter {
      * @param context       Document service context
      * @return {@link Boolean} connector init or not
      */
-    private boolean isConnectorInit(int startIndex, TextDocumentServiceContext context) {
+    private boolean isConnectorInit(int startIndex, LSServiceOperationContext context) {
         int nonHiddenTokenCount = 0;
         int counter = startIndex - 1;
         TokenStream tokenStream = context.get(DocumentServiceKeys.TOKEN_STREAM_KEY);
@@ -123,7 +123,7 @@ public class PackageActionFunctionAndTypesFilter extends AbstractSymbolFilter {
      * @param delimiterIndex        delimiter index (index of either . or :)
      * @return {@link ArrayList}    List of filtered symbol info
      */
-    private ArrayList<SymbolInfo> getActionsFunctionsAndTypes(TextDocumentServiceContext completionContext,
+    private ArrayList<SymbolInfo> getActionsFunctionsAndTypes(LSServiceOperationContext completionContext,
                                                               int delimiterIndex) {
         ArrayList<SymbolInfo> actionFunctionList = new ArrayList<>();
         TokenStream tokenStream = completionContext.get(DocumentServiceKeys.TOKEN_STREAM_KEY);
@@ -158,7 +158,7 @@ public class PackageActionFunctionAndTypesFilter extends AbstractSymbolFilter {
      * @param delimiterIndex        delimiter index (index of either . or :)
      * @return {@link ArrayList}    List of filtered symbol info
      */
-    private ArrayList<SymbolInfo> invocationsAndFieldsOnIdentifier(TextDocumentServiceContext context,
+    private ArrayList<SymbolInfo> invocationsAndFieldsOnIdentifier(LSServiceOperationContext context,
                                                                    int delimiterIndex) {
         ArrayList<SymbolInfo> actionFunctionList = new ArrayList<>();
         TokenStream tokenStream = context.get(DocumentServiceKeys.TOKEN_STREAM_KEY);
@@ -248,7 +248,7 @@ public class PackageActionFunctionAndTypesFilter extends AbstractSymbolFilter {
      * @param completionContext     Text Document Service context (Completion Context)
      * @return {@link Integer}      Index of the delimiter
      */
-    private int getPackageDelimiterTokenIndex(TextDocumentServiceContext completionContext) {
+    private int getPackageDelimiterTokenIndex(LSServiceOperationContext completionContext) {
         ArrayList<String> terminalTokens = new ArrayList<>(Arrays.asList(new String[]{";", "}", "{", "(", ")"}));
         int delimiterIndex = -1;
         int searchTokenIndex = completionContext.get(DocumentServiceKeys.TOKEN_INDEX_KEY);
@@ -301,7 +301,7 @@ public class PackageActionFunctionAndTypesFilter extends AbstractSymbolFilter {
      * @param completionCtx     Completion context
      * @return                  {@link Map} Scope entries map
      */
-    private Map<Name, Scope.ScopeEntry> getScopeEntries(BType bType, TextDocumentServiceContext completionCtx) {
+    private Map<Name, Scope.ScopeEntry> getScopeEntries(BType bType, LSServiceOperationContext completionCtx) {
         HashMap<Name, Scope.ScopeEntry> returnMap = new HashMap<>();
         completionCtx.get(CompletionKeys.VISIBLE_SYMBOLS_KEY)
                 .forEach(symbolInfo -> {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/filters/StatementTemplateFilter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/filters/StatementTemplateFilter.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.util.filters;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
 import org.ballerinalang.langserver.completions.util.Snippet;
@@ -33,7 +33,7 @@ import java.util.List;
  */
 public class StatementTemplateFilter extends AbstractSymbolFilter {
     @Override
-    public List filterItems(TextDocumentServiceContext completionContext) {
+    public List filterItems(LSServiceOperationContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
 
         // Populate the statement templates

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/BlockStatementScopeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/BlockStatementScopeResolver.java
@@ -16,7 +16,7 @@
 package org.ballerinalang.langserver.completions.util.positioning.resolvers;
 
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.completions.TreeVisitor;
 import org.ballerinalang.model.tree.Node;
@@ -49,7 +49,7 @@ public class BlockStatementScopeResolver extends CursorPositionResolver {
      */
     @Override
     public boolean isCursorBeforeNode(DiagnosticPos nodePosition, Node node, TreeVisitor treeVisitor,
-                                      TextDocumentServiceContext completionContext) {
+                                      LSServiceOperationContext completionContext) {
         int line = completionContext.get(DocumentServiceKeys.POSITION_KEY).getPosition().getLine();
         int col = completionContext.get(DocumentServiceKeys.POSITION_KEY).getPosition().getCharacter();
         DiagnosticPos zeroBasedPos = CommonUtil.toZeroBasedPosition(nodePosition);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/CursorPositionResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/CursorPositionResolver.java
@@ -15,7 +15,7 @@
  */
 package org.ballerinalang.langserver.completions.util.positioning.resolvers;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.TreeVisitor;
 import org.ballerinalang.model.tree.Node;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
@@ -34,5 +34,5 @@ public abstract class CursorPositionResolver {
      * @return {@link Boolean}      Whether the cursor is before the node start or not
      */
     public abstract boolean isCursorBeforeNode(DiagnosticPos nodePosition, Node node, TreeVisitor treeVisitor,
-                                               TextDocumentServiceContext completionContext);
+                                               LSServiceOperationContext completionContext);
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/MatchStatementScopeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/MatchStatementScopeResolver.java
@@ -18,7 +18,7 @@
 package org.ballerinalang.langserver.completions.util.positioning.resolvers;
 
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.completions.TreeVisitor;
 import org.ballerinalang.model.tree.Node;
@@ -46,7 +46,7 @@ public class MatchStatementScopeResolver extends CursorPositionResolver {
      */
     @Override
     public boolean isCursorBeforeNode(DiagnosticPos nodePosition, Node node, TreeVisitor treeVisitor,
-                                      TextDocumentServiceContext completionContext) {
+                                      LSServiceOperationContext completionContext) {
         if (!(treeVisitor.getBlockOwnerStack().peek() instanceof BLangMatch)) {
             // In the ideal case, this will not get triggered
             return false;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/ObjectTypeScopeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/ObjectTypeScopeResolver.java
@@ -18,7 +18,7 @@
 package org.ballerinalang.langserver.completions.util.positioning.resolvers;
 
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.completions.TreeVisitor;
 import org.ballerinalang.model.tree.Node;
@@ -46,7 +46,7 @@ public class ObjectTypeScopeResolver extends CursorPositionResolver {
      */
     @Override
     public boolean isCursorBeforeNode(DiagnosticPos nodePosition, Node node, TreeVisitor treeVisitor,
-                                      TextDocumentServiceContext completionContext) {
+                                      LSServiceOperationContext completionContext) {
         if (!(treeVisitor.getBlockOwnerStack().peek() instanceof BLangObject)) {
             return false;
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/PackageNodeScopeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/PackageNodeScopeResolver.java
@@ -16,7 +16,7 @@
 
 package org.ballerinalang.langserver.completions.util.positioning.resolvers;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.TreeVisitor;
 import org.ballerinalang.model.tree.Node;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
@@ -27,7 +27,7 @@ import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 public class PackageNodeScopeResolver extends CursorPositionResolver {
     @Override
     public boolean isCursorBeforeNode(DiagnosticPos nodePosition, Node node, TreeVisitor treeVisitor,
-                                      TextDocumentServiceContext completionContext) {
+                                      LSServiceOperationContext completionContext) {
         // TODO: Finalize the implementation
         return false;
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/ResourceParamScopeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/ResourceParamScopeResolver.java
@@ -16,7 +16,7 @@
 
 package org.ballerinalang.langserver.completions.util.positioning.resolvers;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.TreeVisitor;
 import org.ballerinalang.model.tree.Node;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
@@ -33,7 +33,7 @@ public class ResourceParamScopeResolver extends CursorPositionResolver {
      */
     @Override
     public boolean isCursorBeforeNode(DiagnosticPos nodePosition, Node node, TreeVisitor treeVisitor,
-                                      TextDocumentServiceContext completionContext) {
+                                      LSServiceOperationContext completionContext) {
         // TODO: Finalize the implementation
         return false;
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/ServiceScopeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/ServiceScopeResolver.java
@@ -16,7 +16,7 @@
 package org.ballerinalang.langserver.completions.util.positioning.resolvers;
 
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.completions.TreeVisitor;
 import org.ballerinalang.model.tree.Node;
@@ -38,7 +38,7 @@ import java.util.Map;
 public class ServiceScopeResolver extends CursorPositionResolver {
     @Override
     public boolean isCursorBeforeNode(DiagnosticPos nodePosition, Node node, TreeVisitor treeVisitor,
-                                      TextDocumentServiceContext completionContext) {
+                                      LSServiceOperationContext completionContext) {
         Position position = completionContext.get(DocumentServiceKeys.POSITION_KEY).getPosition();
         DiagnosticPos zeroBasedPo = CommonUtil.toZeroBasedPosition(nodePosition);
         int line = position.getLine();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/TopLevelNodeScopeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/TopLevelNodeScopeResolver.java
@@ -16,7 +16,7 @@
 package org.ballerinalang.langserver.completions.util.positioning.resolvers;
 
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.completions.TreeVisitor;
 import org.ballerinalang.model.tree.Node;
@@ -37,7 +37,7 @@ public class TopLevelNodeScopeResolver extends CursorPositionResolver {
      */
     @Override
     public boolean isCursorBeforeNode(DiagnosticPos nodePosition, Node node, TreeVisitor treeVisitor,
-                                      TextDocumentServiceContext completionContext) {
+                                      LSServiceOperationContext completionContext) {
         int line = completionContext.get(DocumentServiceKeys.POSITION_KEY).getPosition().getLine();
         int col = completionContext.get(DocumentServiceKeys.POSITION_KEY).getPosition().getCharacter();
         DiagnosticPos zeroBasedPos = CommonUtil.toZeroBasedPosition(nodePosition);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/AssignmentStmtContextSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/AssignmentStmtContextSorter.java
@@ -18,7 +18,7 @@
 package org.ballerinalang.langserver.completions.util.sorters;
 
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
@@ -37,7 +37,7 @@ class AssignmentStmtContextSorter extends VariableDefContextItemSorter {
      * @return {@link String} type of the variable
      */
     @Override
-    String getVariableType(TextDocumentServiceContext ctx) {
+    String getVariableType(LSServiceOperationContext ctx) {
         String variableName = ctx.get(DocumentServiceKeys.PARSER_RULE_CONTEXT_KEY).getStart().getText();
         List<SymbolInfo> visibleSymbols = ctx.get(CompletionKeys.VISIBLE_SYMBOLS_KEY);
         SymbolInfo filteredSymbol = visibleSymbols.stream().filter(symbolInfo -> {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/CallableUnitBodyItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/CallableUnitBodyItemSorter.java
@@ -20,7 +20,7 @@ package org.ballerinalang.langserver.completions.util.sorters;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.TokenStream;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
 import org.ballerinalang.langserver.completions.util.Priority;
@@ -39,7 +39,7 @@ import java.util.List;
  */
 class CallableUnitBodyItemSorter extends CompletionItemSorter {
     @Override
-    public void sortItems(TextDocumentServiceContext ctx, List<CompletionItem> completionItems) {
+    public void sortItems(LSServiceOperationContext ctx, List<CompletionItem> completionItems) {
         BLangNode previousNode = ctx.get(CompletionKeys.PREVIOUS_NODE_KEY);
         TokenStream tokenStream = ctx.get(DocumentServiceKeys.TOKEN_STREAM_KEY);
         
@@ -97,7 +97,7 @@ class CallableUnitBodyItemSorter extends CompletionItemSorter {
         return workerItem;
     }
     
-    private void clearItemsIfWorkerExists(TextDocumentServiceContext ctx, List<CompletionItem> completionItems) {
+    private void clearItemsIfWorkerExists(LSServiceOperationContext ctx, List<CompletionItem> completionItems) {
         BLangNode blockOwner = (BLangNode) ctx.get(CompletionKeys.BLOCK_OWNER_KEY);
         
         if (blockOwner instanceof BLangInvokableNode && !((BLangInvokableNode) blockOwner).getWorkers().isEmpty()) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/CompletionItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/CompletionItemSorter.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.util.sorters;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
 import org.ballerinalang.langserver.completions.util.Priority;
 import org.ballerinalang.langserver.completions.util.Snippet;
@@ -37,7 +37,7 @@ public abstract class CompletionItemSorter {
      * @param ctx               Completion context
      * @param completionItems   List of initial completion items
      */
-    public abstract void sortItems(TextDocumentServiceContext ctx, List<CompletionItem> completionItems);
+    public abstract void sortItems(LSServiceOperationContext ctx, List<CompletionItem> completionItems);
 
     /**
      * Assign the Priorities to the completion items.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/ConditionalStatementItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/ConditionalStatementItemSorter.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.util.sorters;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
 import org.ballerinalang.langserver.completions.util.Priority;
 import org.eclipse.lsp4j.CompletionItem;
@@ -40,7 +40,7 @@ public class ConditionalStatementItemSorter extends CompletionItemSorter {
      * @param completionItems List of initial completion items
      */
     @Override
-    public void sortItems(TextDocumentServiceContext ctx, List<CompletionItem> completionItems) {
+    public void sortItems(LSServiceOperationContext ctx, List<CompletionItem> completionItems) {
         this.setPriorities(completionItems);
         completionItems.forEach(completionItem -> {
             String detail = completionItem.getDetail();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/ConnectorContextItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/ConnectorContextItemSorter.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.util.sorters;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
 import org.ballerinalang.langserver.completions.util.Priority;
@@ -37,7 +37,7 @@ import java.util.List;
  */
 class ConnectorContextItemSorter extends CompletionItemSorter {
     @Override
-    public void sortItems(TextDocumentServiceContext ctx, List<CompletionItem> completionItems) {
+    public void sortItems(LSServiceOperationContext ctx, List<CompletionItem> completionItems) {
         BLangNode previousNode = ctx.get(CompletionKeys.PREVIOUS_NODE_KEY);
 
         /*

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/DefaultItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/DefaultItemSorter.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.util.sorters;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.eclipse.lsp4j.CompletionItem;
 
 import java.util.List;
@@ -27,7 +27,7 @@ import java.util.List;
  */
 public class DefaultItemSorter extends CompletionItemSorter {
     @Override
-    public void sortItems(TextDocumentServiceContext ctx, List<CompletionItem> completionItems) {
+    public void sortItems(LSServiceOperationContext ctx, List<CompletionItem> completionItems) {
         this.setPriorities(completionItems);
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/EndpointDefContextItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/EndpointDefContextItemSorter.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.util.sorters;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
 import org.ballerinalang.langserver.completions.util.Priority;
@@ -38,7 +38,7 @@ public class EndpointDefContextItemSorter extends CompletionItemSorter {
      * @param completionItems List of initial completion items
      */
     @Override
-    public void sortItems(TextDocumentServiceContext ctx, List<CompletionItem> completionItems) {
+    public void sortItems(LSServiceOperationContext ctx, List<CompletionItem> completionItems) {
         this.setPriorities(completionItems);
         BLangVariable bLangVariable = (BLangVariable) ctx.get(CompletionKeys.SYMBOL_ENV_NODE_KEY);
         if (!(bLangVariable.typeNode instanceof BLangEndpointTypeNode)) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/ServiceContextItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/ServiceContextItemSorter.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.util.sorters;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
 import org.ballerinalang.langserver.completions.util.Priority;
@@ -37,7 +37,7 @@ import java.util.List;
  */
 public class ServiceContextItemSorter extends CompletionItemSorter {
     @Override
-    public void sortItems(TextDocumentServiceContext ctx, List<CompletionItem> completionItems) {
+    public void sortItems(LSServiceOperationContext ctx, List<CompletionItem> completionItems) {
         BLangNode previousNode = ctx.get(CompletionKeys.PREVIOUS_NODE_KEY);
         
         /*

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/StatementContextItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/StatementContextItemSorter.java
@@ -18,7 +18,7 @@
 package org.ballerinalang.langserver.completions.util.sorters;
 
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.eclipse.lsp4j.CompletionItem;
 
 import java.util.List;
@@ -34,7 +34,7 @@ public class StatementContextItemSorter extends CompletionItemSorter {
      * @param completionItems List of initial completion items
      */
     @Override
-    public void sortItems(TextDocumentServiceContext ctx, List<CompletionItem> completionItems) {
+    public void sortItems(LSServiceOperationContext ctx, List<CompletionItem> completionItems) {
         int startTokenIndex = ctx.get(DocumentServiceKeys.PARSER_RULE_CONTEXT_KEY).getStart().getTokenIndex();
         int stopTokenIndex = ctx.get(DocumentServiceKeys.PARSER_RULE_CONTEXT_KEY).getStop().getTokenIndex();
         if (startTokenIndex > 0 && stopTokenIndex < 0) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/TransformerContextItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/TransformerContextItemSorter.java
@@ -19,7 +19,7 @@ package org.ballerinalang.langserver.completions.util.sorters;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
 import org.eclipse.lsp4j.CompletionItem;
 import org.wso2.ballerinalang.compiler.parser.antlr4.BallerinaParser;
@@ -39,7 +39,7 @@ class TransformerContextItemSorter extends CompletionItemSorter {
      * @param completionItems List of initial completion items
      */
     @Override
-    public void sortItems(TextDocumentServiceContext ctx, List<CompletionItem> completionItems) {
+    public void sortItems(LSServiceOperationContext ctx, List<CompletionItem> completionItems) {
         ParserRuleContext parserRuleContext = ctx.get(DocumentServiceKeys.PARSER_RULE_CONTEXT_KEY);
         if (parserRuleContext == null || parserRuleContext instanceof BallerinaParser.StatementContext) {
             List<String> typesToRemove = new ArrayList<>(Arrays.asList(ItemResolverConstants.STATEMENT_TYPE,

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/VariableDefContextItemSorter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/sorters/VariableDefContextItemSorter.java
@@ -19,7 +19,7 @@ package org.ballerinalang.langserver.completions.util.sorters;
 
 import org.antlr.v4.runtime.TokenStream;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
 import org.eclipse.lsp4j.CompletionItem;
 
@@ -36,7 +36,7 @@ public class VariableDefContextItemSorter extends CompletionItemSorter {
      * @param completionItems List of initial completion items
      */
     @Override
-    public void sortItems(TextDocumentServiceContext ctx, List<CompletionItem> completionItems) {
+    public void sortItems(LSServiceOperationContext ctx, List<CompletionItem> completionItems) {
         this.setPriorities(completionItems);
         String variableType = this.getVariableType(ctx);
         int startTokenIndex = ctx.get(DocumentServiceKeys.PARSER_RULE_CONTEXT_KEY).getStart().getTokenIndex();
@@ -84,7 +84,7 @@ public class VariableDefContextItemSorter extends CompletionItemSorter {
      * @param ctx   Document Service context (Completion context)
      * @return      {@link String} type of the variable
      */
-    String getVariableType(TextDocumentServiceContext ctx) {
+    String getVariableType(LSServiceOperationContext ctx) {
         return ctx.get(DocumentServiceKeys.PARSER_RULE_CONTEXT_KEY).start.getText();
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/definition/DefinitionTreeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/definition/DefinitionTreeVisitor.java
@@ -17,7 +17,7 @@
 package org.ballerinalang.langserver.definition;
 
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.LSNodeVisitor;
 import org.ballerinalang.langserver.common.constants.NodeContextKeys;
 import org.ballerinalang.model.tree.TopLevelNode;
@@ -60,10 +60,10 @@ import java.util.stream.Collectors;
 public class DefinitionTreeVisitor extends LSNodeVisitor {
 
     private boolean terminateVisitor = false;
-    private TextDocumentServiceContext context;
+    private LSServiceOperationContext context;
     private String fileName;
 
-    public DefinitionTreeVisitor(TextDocumentServiceContext context) {
+    public DefinitionTreeVisitor(LSServiceOperationContext context) {
         this.context = context;
         this.fileName = context.get(DocumentServiceKeys.FILE_NAME_KEY);
         this.context.put(NodeContextKeys.NODE_KEY, null);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/definition/util/DefinitionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/definition/util/DefinitionUtil.java
@@ -18,7 +18,7 @@ package org.ballerinalang.langserver.definition.util;
 
 import org.ballerinalang.langserver.DocumentServiceKeys;
 import org.ballerinalang.langserver.LSPackageCache;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.LSDocument;
 import org.ballerinalang.langserver.common.constants.ContextConstants;
 import org.ballerinalang.langserver.common.constants.NodeContextKeys;
@@ -49,7 +49,7 @@ public class DefinitionUtil {
      * @param lSPackageCache package context for language server.
      * @return position
      */
-    public static List<Location> getDefinitionPosition(TextDocumentServiceContext definitionContext,
+    public static List<Location> getDefinitionPosition(LSServiceOperationContext definitionContext,
                                                        LSPackageCache lSPackageCache) {
         List<Location> contents = new ArrayList<>();
         if (definitionContext.get(NodeContextKeys.SYMBOL_KIND_OF_NODE_KEY) == null) {
@@ -176,7 +176,7 @@ public class DefinitionUtil {
     /**
      * Get the package of the owner of given node.
      */
-    private static BLangPackage getPackageOfTheOwner(PackageID packageID, TextDocumentServiceContext definitionContext,
+    private static BLangPackage getPackageOfTheOwner(PackageID packageID, LSServiceOperationContext definitionContext,
                                                      LSPackageCache lSPackageCache) {
         return lSPackageCache.findPackage(definitionContext.get(DocumentServiceKeys.COMPILER_CONTEXT_KEY), packageID);
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/format/TextDocumentFormatUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/format/TextDocumentFormatUtil.java
@@ -20,7 +20,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.TextDocumentServiceUtil;
 import org.ballerinalang.langserver.common.LSCustomErrorStrategy;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
@@ -50,7 +50,7 @@ public class TextDocumentFormatUtil {
      * @return {@link JsonObject}   AST as a Json Object
      */
     public static JsonObject getAST(DocumentFormattingParams params, WorkspaceDocumentManager documentManager,
-                                    TextDocumentServiceContext context) {
+                                    LSServiceOperationContext context) {
         String documentUri = params.getTextDocument().getUri();
         String[] uriParts = documentUri.split(Pattern.quote(File.separator));
         String fileName = uriParts[uriParts.length - 1];

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/util/HoverUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/util/HoverUtil.java
@@ -17,7 +17,7 @@ package org.ballerinalang.langserver.hover.util;
 
 import org.ballerinalang.langserver.DocumentServiceKeys;
 import org.ballerinalang.langserver.LSPackageCache;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.constants.ContextConstants;
 import org.ballerinalang.langserver.common.constants.NodeContextKeys;
 import org.ballerinalang.langserver.common.position.PositionTreeVisitor;
@@ -60,7 +60,7 @@ public class HoverUtil {
      * @param hoverContext context of the hover.
      * @return hover content.
      */
-    public static Hover getHoverInformation(BLangPackage bLangPackage, TextDocumentServiceContext hoverContext) {
+    public static Hover getHoverInformation(BLangPackage bLangPackage, LSServiceOperationContext hoverContext) {
         Hover hover;
         switch (hoverContext.get(NodeContextKeys.SYMBOL_KIND_OF_NODE_PARENT_KEY)) {
             case ContextConstants.FUNCTION:
@@ -241,7 +241,7 @@ public class HoverUtil {
      * @param currentBLangPackage package which currently user working on.
      * @return return Hover object.
      */
-    public static Hover getHoverContent(TextDocumentServiceContext hoverContext, BLangPackage currentBLangPackage,
+    public static Hover getHoverContent(LSServiceOperationContext hoverContext, BLangPackage currentBLangPackage,
                                         LSPackageCache packageContext) {
         PositionTreeVisitor positionTreeVisitor = new PositionTreeVisitor(hoverContext);
         currentBLangPackage.accept(positionTreeVisitor);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/ReferencesTreeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/ReferencesTreeVisitor.java
@@ -16,7 +16,7 @@
 package org.ballerinalang.langserver.references;
 
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.LSDocument;
 import org.ballerinalang.langserver.common.LSNodeVisitor;
 import org.ballerinalang.langserver.common.constants.NodeContextKeys;
@@ -80,11 +80,11 @@ import java.util.List;
  */
 public class ReferencesTreeVisitor extends LSNodeVisitor {
     private boolean terminateVisitor = false;
-    private TextDocumentServiceContext context;
+    private LSServiceOperationContext context;
     private List<Location> locations;
 
 
-    public ReferencesTreeVisitor(TextDocumentServiceContext context) {
+    public ReferencesTreeVisitor(LSServiceOperationContext context) {
         this.context = context;
         this.locations = context.get(NodeContextKeys.REFERENCE_NODES_KEY);
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/util/ReferenceUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/references/util/ReferenceUtil.java
@@ -16,7 +16,7 @@
 
 package org.ballerinalang.langserver.references.util;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.constants.NodeContextKeys;
 import org.ballerinalang.langserver.references.ReferencesTreeVisitor;
 import org.eclipse.lsp4j.Location;
@@ -35,7 +35,7 @@ public class ReferenceUtil {
      * @param currentBLangPackage current package that is visiting.
      * @return position
      */
-    public static List<Location> getReferences(TextDocumentServiceContext referencesContext,
+    public static List<Location> getReferences(LSServiceOperationContext referencesContext,
                                                BLangPackage currentBLangPackage) {
         currentBLangPackage.accept(new ReferencesTreeVisitor(referencesContext));
         return referencesContext.get(NodeContextKeys.REFERENCE_NODES_KEY);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -16,7 +16,7 @@
 package org.ballerinalang.langserver.signature;
 
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.UtilSymbolKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
 import org.ballerinalang.model.elements.DocTag;
@@ -64,7 +64,7 @@ public class SignatureHelpUtil {
      * @param serviceContext    Text Document service context instance for the signature help operation
      */
     public static void captureCallableItemInfo(Position position, String fileContent,
-                                               TextDocumentServiceContext serviceContext) {
+                                               LSServiceOperationContext serviceContext) {
         int lineNumber = position.getLine();
         int character = position.getCharacter();
         int paramCounter = 0;
@@ -104,7 +104,7 @@ public class SignatureHelpUtil {
      * @param context                   Signature help context
      * @return {@link SignatureHelp}    Signature help for the completion
      */
-    public static SignatureHelp getFunctionSignatureHelp(TextDocumentServiceContext context) {
+    public static SignatureHelp getFunctionSignatureHelp(LSServiceOperationContext context) {
         // Get the functions List
         List<SymbolInfo> functions = context.get(SignatureKeys.FILTERED_FUNCTIONS);
         List<SignatureInformation> signatureInformationList = functions
@@ -130,7 +130,7 @@ public class SignatureHelpUtil {
      * @return {@link SignatureInformation}     Signature information for the function
      */
     private static SignatureInformation getSignatureInformation(BInvokableSymbol bInvokableSymbol,
-                                                                TextDocumentServiceContext signatureContext) {
+                                                                LSServiceOperationContext signatureContext) {
         List<ParameterInformation> parameterInformationList = new ArrayList<>();
         SignatureInformation signatureInformation = new SignatureInformation();
         SignatureInfoModel signatureInfoModel = getSignatureInfoModel(bInvokableSymbol, signatureContext);
@@ -160,7 +160,7 @@ public class SignatureHelpUtil {
      * @return {@link SignatureInfoModel}       SignatureInfoModel containing signature information
      */
     private static SignatureInfoModel getSignatureInfoModel(BInvokableSymbol bInvokableSymbol,
-                                                             TextDocumentServiceContext signatureContext) {
+                                                             LSServiceOperationContext signatureContext) {
         Map<String, String> paramDescMap = new HashMap<>();
         SignatureInfoModel signatureInfoModel = new SignatureInfoModel();
         List<ParameterInfoModel> paramModels = new ArrayList<>();
@@ -228,7 +228,7 @@ public class SignatureHelpUtil {
         return signatureInfoModel;
     }
 
-    private static void setItemInfo(String line, int startPosition, TextDocumentServiceContext signatureContext) {
+    private static void setItemInfo(String line, int startPosition, LSServiceOperationContext signatureContext) {
         int counter = startPosition;
         String callableItemName = "";
         String delimiter = "";
@@ -257,7 +257,7 @@ public class SignatureHelpUtil {
      * @param signatureContext  Signature help context
      */
     private static void captureIdentifierAgainst(String line, int startPosition,
-                                                 TextDocumentServiceContext signatureContext) {
+                                                 LSServiceOperationContext signatureContext) {
         int counter = startPosition;
         String identifier = "";
         if (".".equals(Character.toString(line.charAt(counter)))

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureKeys.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureKeys.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.signature;
 
-import org.ballerinalang.langserver.LanguageServerContext;
+import org.ballerinalang.langserver.LSContext;
 import org.ballerinalang.langserver.completions.SymbolInfo;
 
 import java.util.List;
@@ -27,22 +27,22 @@ import java.util.List;
  * @since 0.95.6
  */
 class SignatureKeys {
-    static final LanguageServerContext.Key<String> CALLABLE_ITEM_NAME
-            = new LanguageServerContext.Key<>();
-    static final LanguageServerContext.Key<String> ITEM_DELIMITER
-            = new LanguageServerContext.Key<>();
-    static final LanguageServerContext.Key<List<SymbolInfo>> FILTERED_FUNCTIONS
-            = new LanguageServerContext.Key<>();
+    static final LSContext.Key<String> CALLABLE_ITEM_NAME
+            = new LSContext.Key<>();
+    static final LSContext.Key<String> ITEM_DELIMITER
+            = new LSContext.Key<>();
+    static final LSContext.Key<List<SymbolInfo>> FILTERED_FUNCTIONS
+            = new LSContext.Key<>();
     /**
      * If os:get... then identifier against is os
      * If res.send(.. then identifier against is res
      */
-    static final LanguageServerContext.Key<String> IDENTIFIER_AGAINST
-            = new LanguageServerContext.Key<>();
-    static final LanguageServerContext.Key<String> IDENTIFIER_TYPE
-            = new LanguageServerContext.Key<>();
-    static final LanguageServerContext.Key<String> IDENTIFIER_PKGID
-            = new LanguageServerContext.Key<>();
-    static final LanguageServerContext.Key<Integer> PARAMETER_COUNT
-            = new LanguageServerContext.Key<>();
+    static final LSContext.Key<String> IDENTIFIER_AGAINST
+            = new LSContext.Key<>();
+    static final LSContext.Key<String> IDENTIFIER_TYPE
+            = new LSContext.Key<>();
+    static final LSContext.Key<String> IDENTIFIER_PKGID
+            = new LSContext.Key<>();
+    static final LSContext.Key<Integer> PARAMETER_COUNT
+            = new LSContext.Key<>();
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureTreeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureTreeVisitor.java
@@ -18,7 +18,7 @@
 package org.ballerinalang.langserver.signature;
 
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.common.LSNodeVisitor;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.completions.SymbolInfo;
@@ -71,14 +71,14 @@ public class SignatureTreeVisitor extends LSNodeVisitor {
     private boolean terminateVisitor = false;
     private SymbolEnter symbolEnter;
     private SymbolTable symTable;
-    private TextDocumentServiceContext documentServiceContext;
+    private LSServiceOperationContext documentServiceContext;
     private Stack<Node> blockOwnerStack;
 
     /**
      * Public constructor.
      * @param textDocumentServiceContext    Document service context for the signature operation
      */
-    public SignatureTreeVisitor(TextDocumentServiceContext textDocumentServiceContext) {
+    public SignatureTreeVisitor(LSServiceOperationContext textDocumentServiceContext) {
         blockOwnerStack = new Stack<>();
         this.documentServiceContext = textDocumentServiceContext;
         init(documentServiceContext.get(DocumentServiceKeys.COMPILER_CONTEXT_KEY));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/symbols/SymbolFindingVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/symbols/SymbolFindingVisitor.java
@@ -19,7 +19,7 @@
 package org.ballerinalang.langserver.symbols;
 
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -110,7 +110,7 @@ public class SymbolFindingVisitor extends BLangNodeVisitor {
     private List<SymbolInformation> symbols = new ArrayList<SymbolInformation>();
     private String uri = "";
 
-    public SymbolFindingVisitor(TextDocumentServiceContext documentServiceContext) {
+    public SymbolFindingVisitor(LSServiceOperationContext documentServiceContext) {
         this.symbols = documentServiceContext.get(DocumentServiceKeys.SYMBOL_LIST_KEY);
         this.uri = documentServiceContext.get(DocumentServiceKeys.FILE_URI_KEY);
     }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/CompletionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/CompletionTest.java
@@ -31,6 +31,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 import org.testng.log4testng.Logger;
 
 import java.io.File;
@@ -59,7 +60,7 @@ public abstract class CompletionTest {
         org.apache.commons.io.FileUtils.copyDirectory(source, destination);
     }
 
-//    @Test(dataProvider = "completion-data-provider")
+    @Test(dataProvider = "completion-data-provider")
     public void test(String config, String configPath) {
         String configJsonPath = SAMPLES_COPY_DIR + File.separator + configPath + File.separator + config;
         JsonObject jsonObject = FileUtils.fileContentAsObject(configJsonPath);

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/util/CompletionTestUtil.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/util/CompletionTestUtil.java
@@ -20,7 +20,7 @@ package org.ballerinalang.langserver.completion.util;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import org.ballerinalang.langserver.DocumentServiceKeys;
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.ballerinalang.langserver.TextDocumentServiceUtil;
 import org.ballerinalang.langserver.completions.CompletionCustomErrorStrategy;
 import org.ballerinalang.langserver.completions.CompletionKeys;
@@ -113,7 +113,7 @@ public class CompletionTestUtil {
     public static List<CompletionItem> getCompletions(WorkspaceDocumentManagerImpl documentManager,
                                                       TextDocumentPositionParams pos) {
         List<CompletionItem> completions;
-        TextDocumentServiceContext completionContext = new TextDocumentServiceContext();
+        LSServiceOperationContext completionContext = new LSServiceOperationContext();
         completionContext.put(DocumentServiceKeys.POSITION_KEY, pos);
         completionContext.put(DocumentServiceKeys.FILE_URI_KEY, pos.getTextDocument().getUri());
         BLangPackage bLangPackage = TextDocumentServiceUtil.getBLangPackage(completionContext,

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/signature/SignatureHelpUtilTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/signature/SignatureHelpUtilTest.java
@@ -15,7 +15,7 @@
  */
 package org.ballerinalang.langserver.signature;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.LSServiceOperationContext;
 import org.eclipse.lsp4j.Position;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -38,7 +38,7 @@ public class SignatureHelpUtilTest {
         URI fileLocation = CLASS_LOADER.getResource("signature" + File.separator + "util"
                 + File.separator + "testUtil.bal").toURI();
         String stringContent = new String(Files.readAllBytes(Paths.get(fileLocation)));
-        TextDocumentServiceContext serviceContext = new TextDocumentServiceContext();
+        LSServiceOperationContext serviceContext = new LSServiceOperationContext();
         SignatureHelpUtil.captureCallableItemInfo(position, stringContent, serviceContext);
         String capturedFunctionName = serviceContext.get(SignatureKeys.CALLABLE_ITEM_NAME);
         Assert.assertEquals(funcName, capturedFunctionName);

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/languageConstructsEmptyLine.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/languageConstructsEmptyLine.json
@@ -79,7 +79,7 @@
       "label":"endpoint",
       "detail":"Snippet",
       "sortText":"190",
-      "insertText":"endpoint ${1:EndpointType} ${2:__endpoint} {\n\t${3}\n}",
+      "insertText":"endpoint ${1:http:ServiceEndpoint} ${2:endpointName} {\n\t${3}\n};",
       "insertTextFormat":"Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/languageConstructsNonEmptyLine.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/languageConstructsNonEmptyLine.json
@@ -79,7 +79,7 @@
       "label":"endpoint",
       "detail":"Snippet",
       "sortText":"190",
-      "insertText":"endpoint ${1:EndpointType} ${2:__endpoint} {\n\t${3}\n}",
+      "insertText":"endpoint ${1:http:ServiceEndpoint} ${2:endpointName} {\n\t${3}\n};",
       "insertTextFormat":"Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/resource/languageConstructsEmptyLine.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/resource/languageConstructsEmptyLine.json
@@ -79,7 +79,7 @@
       "label":"endpoint",
       "detail":"Snippet",
       "sortText":"190",
-      "insertText":"endpoint ${1:EndpointType} ${2:__endpoint} {\n\t${3}\n}",
+      "insertText":"endpoint ${1:http:ServiceEndpoint} ${2:endpointName} {\n\t${3}\n};",
       "insertTextFormat":"Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/resource/languageConstructsNonEmptyLine.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/resource/languageConstructsNonEmptyLine.json
@@ -79,7 +79,7 @@
       "label":"endpoint",
       "detail":"Snippet",
       "sortText":"190",
-      "insertText":"endpoint ${1:EndpointType} ${2:__endpoint} {\n\t${3}\n}",
+      "insertText":"endpoint ${1:http:ServiceEndpoint} ${2:endpointName} {\n\t${3}\n};",
       "insertTextFormat":"Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/toplevel/topLevelEmptyFirstLine.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/toplevel/topLevelEmptyFirstLine.json
@@ -3,7 +3,7 @@
     "line": 0,
     "character": 0
   },
-  "source": "topLevelEmptyFirstLine.bal",
+  "source": "toplevel/source/topLevelEmptyFirstLine.bal",
   "items": [
     {
       "label":"import",
@@ -51,7 +51,7 @@
       "label":"service",
       "detail":"Snippet",
       "sortText":"190",
-      "insertText":"service\u003c${1:ServiceType}\u003e ${2:serviceName}{\n\t${3:newResource} () {\n\t}\n}",
+      "insertText":"service\u003c${1:http:Service}\u003e ${2:serviceName}{\n\t${3:newResource} (endpoint ${4:epReference}, ${5:http:Request request}) {\n\t}\n}",
       "insertTextFormat":"Snippet"
     },
     {
@@ -94,6 +94,13 @@
       "detail":"Snippet",
       "sortText":"190",
       "insertText":"type ${1:ObjectTypeName} object {\n\t${2}\n}",
+      "insertTextFormat":"Snippet"
+    },
+    {
+      "label":"endpoint",
+      "detail":"Snippet",
+      "sortText":"190",
+      "insertText":"endpoint ${1:http:ServiceEndpoint} ${2:endpointName} {\n\t${3}\n};",
       "insertTextFormat":"Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/toplevel/topLevelNonEmptyFirstLine.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/toplevel/topLevelNonEmptyFirstLine.json
@@ -3,7 +3,7 @@
     "line": 0,
     "character": 1
   },
-  "source": "completions/toplevel/source/topLevelNonEmptyFirstLine.bal",
+  "source": "toplevel/source/topLevelNonEmptyFirstLine.bal",
   "items": [
     {
       "label":"import",
@@ -51,7 +51,7 @@
       "label":"service",
       "detail":"Snippet",
       "sortText":"190",
-      "insertText":"service\u003c${1:ServiceType}\u003e ${2:serviceName}{\n\t${3:newResource} () {\n\t}\n}",
+      "insertText":"service\u003c${1:http:Service}\u003e ${2:serviceName}{\n\t${3:newResource} (endpoint ${4:epReference}, ${5:http:Request request}) {\n\t}\n}",
       "insertTextFormat":"Snippet"
     },
     {
@@ -94,6 +94,13 @@
       "detail":"Snippet",
       "sortText":"190",
       "insertText":"type ${1:ObjectTypeName} object {\n\t${2}\n}",
+      "insertTextFormat":"Snippet"
+    },
+    {
+      "label":"endpoint",
+      "detail":"Snippet",
+      "sortText":"190",
+      "insertText":"endpoint ${1:http:ServiceEndpoint} ${2:endpointName} {\n\t${3}\n};",
       "insertTextFormat":"Snippet"
     },
     {


### PR DESCRIPTION
## Purpose
> With this we cleanup the language server context API and add the initial annotation caching layer.
Annotation Caching layer will be coupled with the Package cache as well.

## Goals
> Add a cleaner approach to pass the global parameters via Global context and add the initial annotation cache