### PR TITLE
Remove model import from generated service

### DIFF
--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/skeleton/skeleton.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/main/resources/templates/skeleton/skeleton.mustache
@@ -1,7 +1,6 @@
 {{#apiPackage}}package {{apiPackage}};
 
-{{/apiPackage}}{{#modelPackage}}import {{modelPackage}};{{/modelPackage}}
-import ballerina/http;
+{{/apiPackage}}import ballerina/http;
 import ballerina/http.swagger;
 
 {{#servers}}endpoint http:ServiceEndpoint ep{{@index}} {

--- a/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/test/resources/templates/skeleton/skeleton.mustache
+++ b/misc/swagger-ballerina/modules/swagger-to-ballerina-generator/src/test/resources/templates/skeleton/skeleton.mustache
@@ -1,7 +1,6 @@
 {{#apiPackage}}package {{apiPackage}};
 
-{{/apiPackage}}{{#modelPackage}}import {{modelPackage}};{{/modelPackage}}
-import ballerina/http;
+{{/apiPackage}}import ballerina/http;
 import ballerina/http.swagger;
 
 {{#servers}}endpoint http:ServiceEndpoint ep{{@index}} {


### PR DESCRIPTION
## Purpose
> Skip importing models till we get the package structure correct. If users need to use models they should create package structure and add import for the model package manually. This is a temporary action. This behavior will be changed after moving to ballerina init based project generation.

## Goals
> Avoid errors in generated service with models, due to invalid package structure