### PR TITLE
Add dedicated CSV channel

### DIFF
--- a/stdlib/ballerina-builtin/src/main/ballerina/io/natives.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/io/natives.bal
@@ -16,6 +16,13 @@
 
 package ballerina.io;
 
+@Description {value:"Specifies the format for the csv files"}
+public enum RecordFormat{
+    DEFAULT,
+    RFC4180,
+    TDF
+}
+
 @Description {value:"Ballerina ByteChannel represents a channel which will allow I/O operations to be done"}
 public struct ByteChannel {
 }
@@ -101,6 +108,14 @@ public native function createCharacterChannel (ByteChannel byteChannel,
 @Return {value:"Returns an IOError if DelimitedRecordChannel could not be created"}
 public native function createDelimitedRecordChannel (CharacterChannel channel, string recordSeparator,
                                                      string fieldSeparator) returns (DelimitedRecordChannel | IOError);
+
+@Description {value:"Function to create CSV channel to read CSV input"}
+@Param {value:"path: Specfies the path to the CSV file"}
+@Param {value: "rf: Specifies the format of the CSV file"}
+@Return {value:"DelimitedRecordChannel converted from CSV Channel"}
+@Return {value:"Returns an IOError if DelimitedRecordChannel could not be created"}
+public native function createCsvChannel (string path, RecordFormat rf,string charset="UTF-8")
+returns (DelimitedRecordChannel | IOError);
 
 @Description {value:"Function to read bytes"}
 @Param {value:"channel: The ByteChannel to read bytes from"}

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CreateCsvChannel.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/CreateCsvChannel.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.nativeimpl.io;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
+import org.ballerinalang.connector.api.BLangConnectorSPIUtil;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BEnumerator;
+import org.ballerinalang.model.values.BStruct;
+import org.ballerinalang.nativeimpl.io.channels.base.DelimitedRecordChannel;
+import org.ballerinalang.nativeimpl.io.csv.Format;
+import org.ballerinalang.nativeimpl.io.utils.IOUtils;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Native function ballerina.io#createCsvChannel.
+ *
+ * @since 0.970.0-alpha1
+ */
+@BallerinaFunction(
+        orgName = "ballerina", packageName = "io",
+        functionName = "createCsvChannel",
+        args = {
+                @Argument(name = "path", type = TypeKind.STRING),
+                @Argument(name = "rf", type = TypeKind.ENUM),
+                @Argument(name = "charset", type = TypeKind.STRING)
+        },
+        returnType = {
+                @ReturnType(type = TypeKind.STRUCT, structType = "DelimitedRecordChannel",
+                        structPackage = "ballerina.io"),
+                @ReturnType(type = TypeKind.STRUCT, structType = "IOError", structPackage = "ballerina.io")},
+        isPublic = true
+)
+public class CreateCsvChannel extends BlockingNativeCallableUnit {
+    private static final Logger log = LoggerFactory.getLogger(CreateDelimitedRecordChannel.class);
+
+    /**
+     * The index od the text record channel in ballerina.io#createDelimitedRecordChannel().
+     */
+    private static final int PATH_INDEX = 0;
+    /**
+     * Specifies the index of the format enum.
+     */
+    private static final int FORMAT_INDEX = 0;
+    /**
+     * Specifies the index in which the charset is defined.
+     */
+    private static final int CHARSET_INDEX = 1;
+    /**
+     * The package path of the delimited record channel.
+     */
+    private static final String RECORD_CHANNEL_PACKAGE = "ballerina.io";
+    /**
+     * The type of the delimited record channel.
+     */
+    private static final String STRUCT_TYPE = "DelimitedRecordChannel";
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void execute(Context context) {
+        try {
+            //File which holds access to the channel information
+            String filePath = context.getStringArgument(PATH_INDEX);
+            BEnumerator format = (BEnumerator) context.getRefArgument(FORMAT_INDEX);
+            String charset = context.getStringArgument(CHARSET_INDEX);
+            BStruct textRecordChannel = BLangConnectorSPIUtil.createBStruct(context, RECORD_CHANNEL_PACKAGE,
+                    STRUCT_TYPE);
+            DelimitedRecordChannel delimitedRecordChannel = IOUtils.createDelimitedRecordChannel(filePath, charset,
+                    Format.valueOf(format.getName()));
+            textRecordChannel.addNativeData(IOConstants.TXT_RECORD_CHANNEL_NAME, delimitedRecordChannel);
+            context.setReturnValues(textRecordChannel);
+        } catch (Throwable e) {
+            String message =
+                    "Error occurred while converting character channel to textRecord channel:" + e.getMessage();
+            log.error(message, e);
+            context.setReturnValues(IOUtils.createError(context, message));
+        }
+    }
+
+}

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/LoadToTable.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/LoadToTable.java
@@ -28,8 +28,6 @@ import org.ballerinalang.model.types.TypeTags;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BTable;
 import org.ballerinalang.model.values.BTypeDescValue;
-import org.ballerinalang.nativeimpl.io.channels.FileIOChannel;
-import org.ballerinalang.nativeimpl.io.channels.base.CharacterChannel;
 import org.ballerinalang.nativeimpl.io.channels.base.DelimitedRecordChannel;
 import org.ballerinalang.nativeimpl.io.events.EventContext;
 import org.ballerinalang.nativeimpl.io.events.EventManager;
@@ -43,13 +41,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.channels.FileChannel;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.InvalidPathException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -77,26 +68,12 @@ public class LoadToTable implements NativeCallableUnit {
     @Override
     public void execute(Context context, CallableUnitCallback callback) {
         final String filePath = context.getStringArgument(0);
-        Path path;
+        final String recordSeparator = context.getStringArgument(1);
+        final String fieldSeparator = context.getStringArgument(2);
+        final String encoding = context.getStringArgument(3);
         try {
-            path = Paths.get(filePath);
-        } catch (InvalidPathException e) {
-            String msg = "Unable to resolve the file path[" + filePath + "]: " + e.getMessage();
-            context.setReturnValues(IOUtils.createError(context, msg));
-            callback.notifySuccess();
-            return;
-        }
-        if (Files.notExists(path)) {
-            String msg = "Unable to find a file in given path: " + filePath;
-            context.setReturnValues(IOUtils.createError(context, msg));
-            callback.notifySuccess();
-            return;
-        }
-        try {
-            FileChannel sourceChannel = FileChannel.open(path, StandardOpenOption.READ);
-            // FileChannel will close once we completely read the content.
-            // Close will happen in DelimitedRecordReadAllEvent.
-            DelimitedRecordChannel recordChannel = getDelimitedRecordChannel(context, sourceChannel);
+            DelimitedRecordChannel recordChannel = IOUtils.createDelimitedRecordChannel(filePath, encoding,
+                    recordSeparator, fieldSeparator);
             EventContext eventContext = new EventContext(context, callback);
             DelimitedRecordReadAllEvent event = new DelimitedRecordReadAllEvent(recordChannel, eventContext);
             CompletableFuture<EventResult> future = EventManager.getInstance().publish(event);
@@ -195,12 +172,4 @@ public class LoadToTable implements NativeCallableUnit {
         return struct;
     }
 
-    private DelimitedRecordChannel getDelimitedRecordChannel(Context context, FileChannel sourceChannel) {
-        final String recordSeparator = context.getStringArgument(1);
-        final String fieldSeparator = context.getStringArgument(2);
-        final String encoding = context.getStringArgument(3);
-        FileIOChannel fileIOChannel = new FileIOChannel(sourceChannel);
-        CharacterChannel characterChannel = new CharacterChannel(fileIOChannel, Charset.forName(encoding).name());
-        return new DelimitedRecordChannel(characterChannel, recordSeparator, fieldSeparator);
-    }
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/DelimitedRecordChannel.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/channels/base/DelimitedRecordChannel.java
@@ -19,6 +19,7 @@ package org.ballerinalang.nativeimpl.io.channels.base;
 
 import org.ballerinalang.model.values.BStringArray;
 import org.ballerinalang.nativeimpl.io.BallerinaIOException;
+import org.ballerinalang.nativeimpl.io.csv.Format;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,14 +87,72 @@ public class DelimitedRecordChannel {
      */
     private int numberOfRecordsWrittenToChannel = 0;
 
+    /**
+     * Specifies the format for the record. This will be optional
+     */
+    private Format format;
+
     private static final Logger log = LoggerFactory.getLogger(DelimitedRecordChannel.class);
 
+    public DelimitedRecordChannel(CharacterChannel channel, Format format) {
+        this.channel = channel;
+        this.format = format;
+        this.persistentCharSequence = new StringBuilder();
+    }
 
     public DelimitedRecordChannel(CharacterChannel channel, String recordSeparator, String fieldSeparator) {
         this.recordSeparator = recordSeparator;
         this.fieldSeparator = fieldSeparator;
         this.channel = channel;
         this.persistentCharSequence = new StringBuilder();
+    }
+
+    /**
+     * Retrieves the record separator for reading records.
+     *
+     * @return the record separator.
+     */
+    private String getRecordSeparatorForReading() {
+        if (null == format) {
+            return recordSeparator;
+        }
+        return format.getReadRecSeparator();
+    }
+
+    /**
+     * Retrieves field separator for reading.
+     *
+     * @return the field separator.
+     */
+    private String getFieldSeparatorForReading() {
+        if (null == format) {
+            return fieldSeparator;
+        }
+        return format.getReadFieldSeparator();
+    }
+
+    /**
+     * Retrieves record separator for writing.
+     *
+     * @return the record separator.
+     */
+    private String getRecordSeparatorForWriting() {
+        if (null == format) {
+            return recordSeparator;
+        }
+        return format.getWriteRecSeparator();
+    }
+
+    /**
+     * Retrieves field separator for writing.
+     *
+     * @return the field separator.
+     */
+    private String getFieldSeparatorForWriting() {
+        if (null == format) {
+            return fieldSeparator;
+        }
+        return format.getWriteFieldSeparator();
     }
 
     /**
@@ -114,7 +173,8 @@ public class DelimitedRecordChannel {
                 log.trace("char[] remaining in memory " + persistentCharSequence);
             }
             //We need to split the string into 2
-            String[] delimitedRecord = persistentCharSequence.toString().split(recordSeparator, numberOfSplits);
+            String[] delimitedRecord = persistentCharSequence.toString().
+                    split(getRecordSeparatorForReading(), numberOfSplits);
             if (delimitedRecord.length > minimumRecordCount) {
                 record = processIdentifiedRecord(delimitedRecord);
                 int recordCharacterLength = record.length();
@@ -219,7 +279,7 @@ public class DelimitedRecordChannel {
      * @return fields which are separated as records.
      */
     private String[] getFields(String record) {
-        return record.split(fieldSeparator);
+        return record.split(getFieldSeparatorForReading());
     }
 
     /**
@@ -285,7 +345,7 @@ public class DelimitedRecordChannel {
             recordConsolidator.append(currentFieldString);
             if (fieldCount < secondLastFieldIndex) {
                 //The idea here is to omit appending the field separator after the final field
-                recordConsolidator.append(fieldSeparator);
+                recordConsolidator.append(getFieldSeparatorForWriting());
             }
         }
         finalizedRecord = recordConsolidator.toString();
@@ -301,7 +361,7 @@ public class DelimitedRecordChannel {
     public void write(BStringArray fields) throws IOException {
         final int writeOffset = 0;
         String record = composeRecord(fields);
-        record = record + recordSeparator;
+        record = record + getRecordSeparatorForWriting();
         if (log.isTraceEnabled()) {
             log.trace("The record " + numberOfRecordsWrittenToChannel + " composed for writing, " + record);
         }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/csv/Format.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/csv/Format.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.nativeimpl.io.csv;
+
+/**
+ * Holds the format which should be supported for CSV.
+ */
+public enum Format {
+    /**
+     * The format would be similar to RFC4180, however empty lines will be allowed.
+     */
+    DEFAULT(",", "\\r?\\n", false),
+    /**
+     * CSV should conform with RFC4180 specification.
+     */
+    RFC4180(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)", "\\r?\\n", true),
+    /**
+     * Tab delimited records.
+     */
+    TDF("\\t", "\\r?\\n", true);
+
+    /**
+     * Defines the record separator for the format.
+     */
+    private String recordSeparator;
+    /**
+     * Defines the field separator for the format.
+     */
+    private String fieldSeparator;
+    /**
+     * Specifies whether white spaces should be ignored.
+     */
+    private boolean ignoreSpaces;
+
+    Format(String fs, String rs, boolean ignoreSpaces) {
+        this.fieldSeparator = fs;
+        this.recordSeparator = rs;
+        this.ignoreSpaces = ignoreSpaces;
+    }
+
+    public String getRecordSeparator() {
+        return recordSeparator;
+    }
+
+    public String getFieldSeparator() {
+        return fieldSeparator;
+    }
+
+    public boolean isIgnoreSpaces() {
+        return ignoreSpaces;
+    }
+}

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/csv/Format.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/csv/Format.java
@@ -25,41 +25,59 @@ public enum Format {
     /**
      * The format would be similar to RFC4180, however empty lines will be allowed.
      */
-    DEFAULT(",", "\\r?\\n", false),
+    DEFAULT(",", "\\r?\\n", ",", "\n", false),
     /**
      * CSV should conform with RFC4180 specification.
      */
-    RFC4180(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)", "\\r?\\n", true),
+    RFC4180(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)", "\\r?\\n", ",", "\n", true),
     /**
      * Tab delimited records.
      */
-    TDF("\\t", "\\r?\\n", true);
+    TDF("\\t", "\\r?\\n", "\t", "\n", true);
 
     /**
      * Defines the record separator for the format.
      */
-    private String recordSeparator;
+    private String readRecSeparator;
     /**
      * Defines the field separator for the format.
      */
-    private String fieldSeparator;
+    private String readFieldSeparator;
+    /**
+     * Defines the record separator which should be used when writing.
+     */
+    private String writeRecSeparator;
+    /**
+     * Defines the field separator which should be used when writing.
+     */
+    private String writeFieldSeparator;
     /**
      * Specifies whether white spaces should be ignored.
      */
     private boolean ignoreSpaces;
 
-    Format(String fs, String rs, boolean ignoreSpaces) {
-        this.fieldSeparator = fs;
-        this.recordSeparator = rs;
+    Format(String rfs, String rrs, String wfs, String wrs, boolean ignoreSpaces) {
+        this.readFieldSeparator = rfs;
+        this.readRecSeparator = rrs;
+        this.writeFieldSeparator = wfs;
+        this.writeRecSeparator = wrs;
         this.ignoreSpaces = ignoreSpaces;
     }
 
-    public String getRecordSeparator() {
-        return recordSeparator;
+    public String getReadRecSeparator() {
+        return readRecSeparator;
     }
 
-    public String getFieldSeparator() {
-        return fieldSeparator;
+    public String getReadFieldSeparator() {
+        return readFieldSeparator;
+    }
+
+    public String getWriteRecSeparator() {
+        return writeRecSeparator;
+    }
+
+    public String getWriteFieldSeparator() {
+        return writeFieldSeparator;
     }
 
     public boolean isIgnoreSpaces() {

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/utils/IOUtils.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/utils/IOUtils.java
@@ -22,9 +22,11 @@ import org.ballerinalang.bre.Context;
 import org.ballerinalang.bre.bvm.BLangVMStructs;
 import org.ballerinalang.model.values.BStringArray;
 import org.ballerinalang.model.values.BStruct;
+import org.ballerinalang.nativeimpl.io.channels.FileIOChannel;
 import org.ballerinalang.nativeimpl.io.channels.base.Channel;
 import org.ballerinalang.nativeimpl.io.channels.base.CharacterChannel;
 import org.ballerinalang.nativeimpl.io.channels.base.DelimitedRecordChannel;
+import org.ballerinalang.nativeimpl.io.csv.Format;
 import org.ballerinalang.nativeimpl.io.events.EventContext;
 import org.ballerinalang.nativeimpl.io.events.EventManager;
 import org.ballerinalang.nativeimpl.io.events.EventResult;
@@ -40,6 +42,13 @@ import org.ballerinalang.nativeimpl.io.events.records.DelimitedRecordWriteEvent;
 import org.ballerinalang.util.codegen.PackageInfo;
 import org.ballerinalang.util.codegen.StructInfo;
 
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
@@ -51,7 +60,6 @@ import static org.ballerinalang.nativeimpl.io.IOConstants.IO_PACKAGE;
  * Represents the util functions of IO operations.
  */
 public class IOUtils {
-
     /**
      * Returns the error struct for the corresponding message.
      *
@@ -295,6 +303,51 @@ public class IOUtils {
         CloseDelimitedRecordEvent closeEvent = new CloseDelimitedRecordEvent(charChannel, eventContext);
         CompletableFuture<EventResult> future = EventManager.getInstance().publish(closeEvent);
         future.thenApply(function);
+    }
+
+    /**
+     * Creates a delimited record channel to read from CSV file.
+     *
+     * @param filePath path to the CSV file.
+     * @param encoding the encoding of CSV file.
+     * @param format   format of the CSV file.
+     * @return delimited record channel to read from CSV.
+     * @throws IOException during I/O error.
+     */
+    public static DelimitedRecordChannel createDelimitedRecordChannel(String filePath, String encoding, Format format)
+            throws IOException {
+        Path path = Paths.get(filePath);
+        if (Files.notExists(path)) {
+            String msg = "Unable to find a file in given path: " + filePath;
+            throw new IOException(msg);
+        }
+        FileChannel sourceChannel = FileChannel.open(path, StandardOpenOption.READ);
+        FileIOChannel fileIOChannel = new FileIOChannel(sourceChannel);
+        CharacterChannel characterChannel = new CharacterChannel(fileIOChannel, Charset.forName(encoding).name());
+        return new DelimitedRecordChannel(characterChannel, format.getRecordSeparator(), format.getFieldSeparator());
+    }
+
+    /**
+     * Creates a delimited record channel to read from CSV file.
+     *
+     * @param filePath path to the CSV file.
+     * @param encoding the encoding of CSV file.
+     * @param rs       record separator.
+     * @param fs       field separator.
+     * @return delimited record channel to read from CSV.
+     * @throws IOException during I/O error.
+     */
+    public static DelimitedRecordChannel createDelimitedRecordChannel(String filePath, String encoding, String rs,
+                                                                      String fs) throws IOException {
+        Path path = Paths.get(filePath);
+        if (Files.notExists(path)) {
+            String msg = "Unable to find a file in given path: " + filePath;
+            throw new IOException(msg);
+        }
+        FileChannel sourceChannel = FileChannel.open(path, StandardOpenOption.READ);
+        FileIOChannel fileIOChannel = new FileIOChannel(sourceChannel);
+        CharacterChannel characterChannel = new CharacterChannel(fileIOChannel, Charset.forName(encoding).name());
+        return new DelimitedRecordChannel(characterChannel, rs, fs);
     }
 
 }

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/utils/IOUtils.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/io/utils/IOUtils.java
@@ -321,9 +321,9 @@ public class IOUtils {
             throws IOException {
         Path path = Paths.get(filePath);
         Set<OpenOption> opts = new HashSet<>();
-        if(Files.exists(path)){
+        if (Files.exists(path)) {
             opts.add(StandardOpenOption.READ);
-        }else {
+        } else {
             opts.add(StandardOpenOption.CREATE);
             opts.add(StandardOpenOption.WRITE);
         }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/records/CsvChannelTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/records/CsvChannelTest.java
@@ -40,10 +40,12 @@ import java.nio.file.Paths;
  */
 public class CsvChannelTest {
     private CompileResult recordsInputOutputProgramFile;
+    private String currentDirectoryPath = "/tmp";
 
     @BeforeClass
     public void setup() {
         recordsInputOutputProgramFile = BCompileUtil.compile("test-src/io/record_io.bal");
+        currentDirectoryPath = System.getProperty("user.dir") + "/target";
     }
 
     private String getAbsoluteFilePath(String relativePath) throws URISyntaxException {
@@ -56,7 +58,7 @@ public class CsvChannelTest {
         return pathValue;
     }
 
-    @Test(description = "Test successful data load")
+    @Test(description = "Test 'readDefaultCSVRecords'")
     public void readDefaultCsvTest() throws URISyntaxException {
         String resourceToRead = "datafiles/io/records/sample.csv";
         BStringArray records;
@@ -96,7 +98,23 @@ public class CsvChannelTest {
         BRunUtil.invoke(recordsInputOutputProgramFile, "close");
     }
 
-    @Test(description = "Test successful data load")
+    @Test(description = "Test 'writeDefaultCSVRecords'")
+    public void testWriteDefaultCsv() {
+        String[] content = {"Name", "Email", "Telephone"};
+        BStringArray record = new BStringArray(content);
+        String sourceToWrite = currentDirectoryPath + "/recordsDefault.csv";
+
+        //Will initialize the channel
+        BValue[] args = {new BString(sourceToWrite)};
+        BRunUtil.invoke(recordsInputOutputProgramFile, "initDefaultCsv", args);
+
+        args = new BValue[]{record};
+        BRunUtil.invoke(recordsInputOutputProgramFile, "writeRecord", args);
+
+        BRunUtil.invoke(recordsInputOutputProgramFile, "close");
+    }
+
+    @Test(description = "Test 'readRfcCSVRecords'")
     public void readRfcTest() throws URISyntaxException {
         String resourceToRead = "datafiles/io/records/sampleRfc.csv";
         BStringArray records;
@@ -136,7 +154,23 @@ public class CsvChannelTest {
         BRunUtil.invoke(recordsInputOutputProgramFile, "close");
     }
 
-    @Test(description = "Test successful data load")
+    @Test(description = "Test 'writeRfcCSVRecords'")
+    public void testWriteRfc() {
+        String[] content = {"Name", "Email", "Telephone"};
+        BStringArray record = new BStringArray(content);
+        String sourceToWrite = currentDirectoryPath + "/recordsRfc.csv";
+
+        //Will initialize the channel
+        BValue[] args = {new BString(sourceToWrite)};
+        BRunUtil.invoke(recordsInputOutputProgramFile, "initRfc", args);
+
+        args = new BValue[]{record};
+        BRunUtil.invoke(recordsInputOutputProgramFile, "writeRecord", args);
+
+        BRunUtil.invoke(recordsInputOutputProgramFile, "close");
+    }
+
+    @Test(description = "Test 'readTdfCSVRecords'")
     public void readTdfTest() throws URISyntaxException {
         String resourceToRead = "datafiles/io/records/sampleTdf.tsv";
         BStringArray records;
@@ -175,5 +209,22 @@ public class CsvChannelTest {
 
         BRunUtil.invoke(recordsInputOutputProgramFile, "close");
     }
+
+    @Test(description = "Test 'writeTdfCSVRecords'")
+    public void testWriteTdf() {
+        String[] content = {"Name", "Email", "Telephone"};
+        BStringArray record = new BStringArray(content);
+        String sourceToWrite = currentDirectoryPath + "/recordsTdf.csv";
+
+        //Will initialize the channel
+        BValue[] args = {new BString(sourceToWrite)};
+        BRunUtil.invoke(recordsInputOutputProgramFile, "initTdf", args);
+
+        args = new BValue[]{record};
+        BRunUtil.invoke(recordsInputOutputProgramFile, "writeRecord", args);
+
+        BRunUtil.invoke(recordsInputOutputProgramFile, "close");
+    }
+
 
 }

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/records/CsvChannelTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/io/records/CsvChannelTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.test.nativeimpl.functions.io.records;
+
+import org.ballerinalang.launcher.util.BCompileUtil;
+import org.ballerinalang.launcher.util.BRunUtil;
+import org.ballerinalang.launcher.util.BServiceUtil;
+import org.ballerinalang.launcher.util.CompileResult;
+import org.ballerinalang.model.values.BBoolean;
+import org.ballerinalang.model.values.BString;
+import org.ballerinalang.model.values.BStringArray;
+import org.ballerinalang.model.values.BValue;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Tests the CSV channel with the specified values.
+ */
+public class CsvChannelTest {
+    private CompileResult recordsInputOutputProgramFile;
+
+    @BeforeClass
+    public void setup() {
+        recordsInputOutputProgramFile = BCompileUtil.compile("test-src/io/record_io.bal");
+    }
+
+    private String getAbsoluteFilePath(String relativePath) throws URISyntaxException {
+        URL fileResource = BServiceUtil.class.getClassLoader().getResource(relativePath);
+        String pathValue = "";
+        if (null != fileResource) {
+            Path path = Paths.get(fileResource.toURI());
+            pathValue = path.toAbsolutePath().toString();
+        }
+        return pathValue;
+    }
+
+    @Test(description = "Test successful data load")
+    public void readDefaultCsvTest() throws URISyntaxException {
+        String resourceToRead = "datafiles/io/records/sample.csv";
+        BStringArray records;
+        BBoolean hasNextRecord;
+        int expectedRecordLength = 3;
+
+        //Will initialize the channel
+        BValue[] args = {new BString(getAbsoluteFilePath(resourceToRead))};
+        BRunUtil.invoke(recordsInputOutputProgramFile, "initDefaultCsv", args);
+
+        BValue[] returns = BRunUtil.invoke(recordsInputOutputProgramFile, "nextRecord");
+        records = (BStringArray) returns[0];
+        Assert.assertEquals(records.size(), expectedRecordLength);
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "hasNextRecord");
+        hasNextRecord = (BBoolean) returns[0];
+        Assert.assertTrue(hasNextRecord.booleanValue(), "Expecting more records");
+
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "nextRecord");
+        records = (BStringArray) returns[0];
+        Assert.assertEquals(records.size(), expectedRecordLength);
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "hasNextRecord");
+        hasNextRecord = (BBoolean) returns[0];
+        Assert.assertTrue(hasNextRecord.booleanValue(), "Expecting more records");
+
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "nextRecord");
+        records = (BStringArray) returns[0];
+
+        Assert.assertEquals(records.size(), expectedRecordLength);
+
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "nextRecord");
+        records = (BStringArray) returns[0];
+        Assert.assertEquals(records.size(), 0);
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "hasNextRecord");
+        hasNextRecord = (BBoolean) returns[0];
+        Assert.assertFalse(hasNextRecord.booleanValue(), "Not expecting anymore records");
+
+        BRunUtil.invoke(recordsInputOutputProgramFile, "close");
+    }
+
+    @Test(description = "Test successful data load")
+    public void readRfcTest() throws URISyntaxException {
+        String resourceToRead = "datafiles/io/records/sampleRfc.csv";
+        BStringArray records;
+        BBoolean hasNextRecord;
+        int expectedRecordLength = 3;
+
+        //Will initialize the channel
+        BValue[] args = {new BString(getAbsoluteFilePath(resourceToRead))};
+        BRunUtil.invoke(recordsInputOutputProgramFile, "initRfc", args);
+
+        BValue[] returns = BRunUtil.invoke(recordsInputOutputProgramFile, "nextRecord");
+        records = (BStringArray) returns[0];
+        Assert.assertEquals(records.size(), expectedRecordLength);
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "hasNextRecord");
+        hasNextRecord = (BBoolean) returns[0];
+        Assert.assertTrue(hasNextRecord.booleanValue(), "Expecting more records");
+
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "nextRecord");
+        records = (BStringArray) returns[0];
+        Assert.assertEquals(records.size(), expectedRecordLength);
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "hasNextRecord");
+        hasNextRecord = (BBoolean) returns[0];
+        Assert.assertTrue(hasNextRecord.booleanValue(), "Expecting more records");
+
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "nextRecord");
+        records = (BStringArray) returns[0];
+
+        Assert.assertEquals(records.size(), expectedRecordLength);
+
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "nextRecord");
+        records = (BStringArray) returns[0];
+        Assert.assertEquals(records.size(), 0);
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "hasNextRecord");
+        hasNextRecord = (BBoolean) returns[0];
+        Assert.assertFalse(hasNextRecord.booleanValue(), "Not expecting anymore records");
+
+        BRunUtil.invoke(recordsInputOutputProgramFile, "close");
+    }
+
+    @Test(description = "Test successful data load")
+    public void readTdfTest() throws URISyntaxException {
+        String resourceToRead = "datafiles/io/records/sampleTdf.tsv";
+        BStringArray records;
+        BBoolean hasNextRecord;
+        int expectedRecordLength = 3;
+
+        //Will initialize the channel
+        BValue[] args = {new BString(getAbsoluteFilePath(resourceToRead))};
+        BRunUtil.invoke(recordsInputOutputProgramFile, "initTdf", args);
+
+        BValue[] returns = BRunUtil.invoke(recordsInputOutputProgramFile, "nextRecord");
+        records = (BStringArray) returns[0];
+        Assert.assertEquals(records.size(), expectedRecordLength);
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "hasNextRecord");
+        hasNextRecord = (BBoolean) returns[0];
+        Assert.assertTrue(hasNextRecord.booleanValue(), "Expecting more records");
+
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "nextRecord");
+        records = (BStringArray) returns[0];
+        Assert.assertEquals(records.size(), expectedRecordLength);
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "hasNextRecord");
+        hasNextRecord = (BBoolean) returns[0];
+        Assert.assertTrue(hasNextRecord.booleanValue(), "Expecting more records");
+
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "nextRecord");
+        records = (BStringArray) returns[0];
+
+        Assert.assertEquals(records.size(), expectedRecordLength);
+
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "nextRecord");
+        records = (BStringArray) returns[0];
+        Assert.assertEquals(records.size(), 0);
+        returns = BRunUtil.invoke(recordsInputOutputProgramFile, "hasNextRecord");
+        hasNextRecord = (BBoolean) returns[0];
+        Assert.assertFalse(hasNextRecord.booleanValue(), "Not expecting anymore records");
+
+        BRunUtil.invoke(recordsInputOutputProgramFile, "close");
+    }
+
+}

--- a/tests/ballerina-test/src/test/resources/datafiles/io/records/sampleRfc.csv
+++ b/tests/ballerina-test/src/test/resources/datafiles/io/records/sampleRfc.csv
@@ -1,0 +1,3 @@
+"User1,12", WSO2, 07xxxxxx
+User2, "WSO2,Colombo", 07xxxxxxx
+User3, WSO2, "07xxxxxxx,SL"

--- a/tests/ballerina-test/src/test/resources/datafiles/io/records/sampleTdf.tsv
+++ b/tests/ballerina-test/src/test/resources/datafiles/io/records/sampleTdf.tsv
@@ -1,0 +1,3 @@
+"User1,12"	WSO2	07xxxxxx
+User2	"WSO2,Colombo"	07xxxxxxx
+User3	WSO2	"07xxxxxxx,SL"

--- a/tests/ballerina-test/src/test/resources/test-src/io/record_io.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/record_io.bal
@@ -46,21 +46,21 @@ function initDefaultCsv(string filePath) returns (boolean|io:IOError){
 }
 
 function initRfc(string filePath) returns (boolean|io:IOError){
-  var csvDefaultChannel = io:createCsvChannel(filePath, io:RecordFormat.RFC4180);
-  match csvDefaultChannel {
-     io:DelimitedRecordChannel delimChannel =>{
-        txtChannel = delimChannel;
-        return true;
-     }
-     io:IOError err =>{
-        return err;
-     }
-  }
+    var csvDefaultChannel = io:createCsvChannel(filePath, io:RecordFormat.RFC4180);
+    match csvDefaultChannel {
+       io:DelimitedRecordChannel delimChannel =>{
+          txtChannel = delimChannel;
+          return true;
+       }
+       io:IOError err =>{
+          return err;
+       }
+    }
 }
 
 function initTdf(string filePath) returns (boolean|io:IOError){
-   var csvDefaultChannel = io:createCsvChannel(filePath, io:RecordFormat.TDF);
-   match csvDefaultChannel {
+    var csvDefaultChannel = io:createCsvChannel(filePath, io:RecordFormat.TDF);
+    match csvDefaultChannel {
        io:DelimitedRecordChannel delimChannel =>{
          txtChannel = delimChannel;
          return true;
@@ -68,7 +68,7 @@ function initTdf(string filePath) returns (boolean|io:IOError){
        io:IOError err =>{
          return err;
        }
-   }
+    }
 }
 
 function nextRecord () returns (string[]|io:IOError) {

--- a/tests/ballerina-test/src/test/resources/test-src/io/record_io.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/io/record_io.bal
@@ -32,6 +32,45 @@ returns (boolean|io:IOError){
     }
 }
 
+function initDefaultCsv(string filePath) returns (boolean|io:IOError){
+    var csvDefaultChannel = io:createCsvChannel(filePath, io:RecordFormat.DEFAULT);
+    match csvDefaultChannel {
+       io:DelimitedRecordChannel delimChannel =>{
+          txtChannel = delimChannel;
+          return true;
+       }
+       io:IOError err =>{
+          return err;
+       }
+    }
+}
+
+function initRfc(string filePath) returns (boolean|io:IOError){
+  var csvDefaultChannel = io:createCsvChannel(filePath, io:RecordFormat.RFC4180);
+  match csvDefaultChannel {
+     io:DelimitedRecordChannel delimChannel =>{
+        txtChannel = delimChannel;
+        return true;
+     }
+     io:IOError err =>{
+        return err;
+     }
+  }
+}
+
+function initTdf(string filePath) returns (boolean|io:IOError){
+   var csvDefaultChannel = io:createCsvChannel(filePath, io:RecordFormat.TDF);
+   match csvDefaultChannel {
+       io:DelimitedRecordChannel delimChannel =>{
+         txtChannel = delimChannel;
+         return true;
+       }
+       io:IOError err =>{
+         return err;
+       }
+   }
+}
+
 function nextRecord () returns (string[]|io:IOError) {
     string[] empty = [];
     match txtChannel {


### PR DESCRIPTION
## Purpose
Add a dedicated CSV channel which will provide the following outcome,

1. Simplified API design 
    Currently to read CSV, delimited record channel is used. However, due to it's generic nature it 
    requires a few LoC to be written prior to reading. Given CSV is widely used use case, a dedicated 
    channel was written to simplify the number of steps which should be taken to read/write CSV
2. Support Composite Types 
    Resolves the issue described in #3819

## Goals

1. Simplify API design 
2. Support Composite Types 

## Approach

Introduce the following API to created a CSV channel.

```
io:createCsvChannel(filePath, io:RecordFormat.TDF);
```

This would create a corresponding DelimitedRecordChannel that will allow reading and writing 

The relevant record formats currently supported will be described through the following,

```
@Description {value:"Specifies the format for the csv files"}
public enum RecordFormat{
    DEFAULT,
    RFC4180,
    TDF
}
```

## User stories
Users will be able to read a CSV file through a simplified API design.

## Release note
Introduces a CSV channel with a simplified API and this channel would support reading composite CSV types 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
1.8
