### PR TITLE
Change 'checkAuth' method name to 'authorize'

### DIFF
--- a/stdlib/ballerina-builtin/src/main/ballerina/auth.authz/authz-checker.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/auth.authz/authz-checker.bal
@@ -40,7 +40,7 @@ public function createChecker (permissionstore:PermissionStore permissionstore, 
 @Param {value:"username: user name"}
 @Param {value:"scopes: array of scope names"}
 @Return {value:"boolean: true if authorization check is a success, else false"}
-public function <AuthzChecker authzChecker> checkAuth (string username, string[] scopes) returns (boolean) {
+public function <AuthzChecker authzChecker> authorize (string username, string[] scopes) returns (boolean) {
     // TODO: check if there are any groups set in the SecurityContext and if so, match against those.
     return authzChecker.permissionstore.isAuthorized(username, scopes);
 }

--- a/stdlib/ballerina-http/src/main/ballerina/http/authz-handler.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/authz-handler.bal
@@ -80,7 +80,7 @@ public function <HttpAuthzHandler httpAuthzHandler> handle (Request req,
         }
         any|null => {
             log:printDebug("Authz cache miss for request URL: " + resourceName);
-            boolean isAuthorized = authzChecker.checkAuth(username, scopes);
+            boolean isAuthorized = authzChecker.authorize(username, scopes);
             if (isAuthorized) {
                 log:printDebug("Successfully authorized to access resource: " + resourceName);
             } else {

--- a/tests/ballerina-test/src/test/resources/test-src/auth/authorization-test.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/auth/authorization-test.bal
@@ -30,7 +30,7 @@ function testAuthorizationForNonExistingUser () returns (boolean) {
     permissionstore:PermissionStore permissionStore = <permissionstore:PermissionStore>fileBasedPermissionstore;
     authz:AuthzChecker checker = authz:createChecker(permissionStore, utils:createCache("authz_cache"));
     string[] scopes = ["scope1"];
-    return checker.checkAuth("ayoma", scopes);
+    return checker.authorize("ayoma", scopes);
 }
 
 function testAuthorizationForNonExistingScope () returns (boolean) {
@@ -38,7 +38,7 @@ function testAuthorizationForNonExistingScope () returns (boolean) {
     permissionstore:PermissionStore permissionStore = <permissionstore:PermissionStore>fileBasedPermissionstore;
     authz:AuthzChecker checker = authz:createChecker(permissionStore, utils:createCache("authz_cache"));
     string[] scopes = ["scope-y"];
-    return checker.checkAuth("ishara", scopes);
+    return checker.authorize("ishara", scopes);
 }
 
 function testAuthorizationSuccess () returns (boolean) {
@@ -46,7 +46,7 @@ function testAuthorizationSuccess () returns (boolean) {
     permissionstore:PermissionStore permissionStore = <permissionstore:PermissionStore>fileBasedPermissionstore;
     authz:AuthzChecker checker = authz:createChecker(permissionStore, utils:createCache("authz_cache"));
     string[] scopes = ["scope2"];
-    return checker.checkAuth("isuru", scopes);
+    return checker.authorize("isuru", scopes);
 }
 
 function testAuthorizationSuccessWithMultipleScopes () returns (boolean) {
@@ -54,5 +54,5 @@ function testAuthorizationSuccessWithMultipleScopes () returns (boolean) {
     permissionstore:PermissionStore permissionStore = <permissionstore:PermissionStore>fileBasedPermissionstore;
     authz:AuthzChecker checker = authz:createChecker(permissionStore, utils:createCache("authz_cache"));
     string[] scopes = ["scope2", "scope1"];
-    return checker.checkAuth("isuru", scopes);
+    return checker.authorize("isuru", scopes);
 }


### PR DESCRIPTION
## Purpose
> The term 'check' is a reserved word now, hence the method check has been rename to checkAuth. Changed it to authorize to properly reflect what it does.