### PR TITLE
Add API for retrieving a table from config registry

### DIFF
--- a/stdlib/ballerina-builtin/src/main/ballerina/config/natives.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/config/natives.bal
@@ -17,9 +17,14 @@
 package ballerina.config;
 
 @Description {value:"Retrieves the specified configuration value as a string"}
-@Param { value:"configKey: The configuration to be retrieved" }
-@Return { value:"Configuration value mapped by the configKey" }
+@Param {value:"configKey: The configuration to be retrieved" }
+@Return {value:"Configuration value mapped by the configKey" }
 public native function getAsString(string configKey) returns (string|null);
+
+@Description {value:"Retrieves the specified table of configurations as a map"}
+@Param {value:"tableHeader: The table to be retrieved"}
+@Return {value:"The specified table"}
+public native function getTable (string tableHeader) returns map;
 
 @Description {value:"Checks whether the given key is in the configuration registry"}
 @Param {value:"configKey: The configuration key to be looked-up"}

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/config/GetTable.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/config/GetTable.java
@@ -1,0 +1,40 @@
+package org.ballerinalang.nativeimpl.config;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
+import org.ballerinalang.config.ConfigRegistry;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BString;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+import java.util.Map;
+
+/**
+ * Native function ballerina.config:getTable.
+ *
+ * @since 0.970.0-alpha2
+ */
+@BallerinaFunction(
+        orgName = "ballerina", packageName = "config",
+        functionName = "getTable",
+        args = {@Argument(name = "table", type = TypeKind.STRING)},
+        returnType = {@ReturnType(type = TypeKind.MAP)},
+        isPublic = true
+)
+public class GetTable extends BlockingNativeCallableUnit {
+
+    private static final ConfigRegistry configRegistry = ConfigRegistry.getInstance();
+
+    @Override
+    public void execute(Context context) {
+        String tableHeader = context.getStringArgument(0);
+        Map<String, String> table = configRegistry.getConfigTable(tableHeader);
+        BMap<String, BString> bTable = new BMap<>();
+        // TODO: modify BMap to create one from a Map.
+        table.entrySet().forEach(entry -> bTable.put(entry.getKey(), new BString(entry.getValue())));
+        context.setReturnValues(bTable);
+    }
+}

--- a/stdlib/ballerina-config/src/main/java/org/ballerinalang/config/ConfigRegistry.java
+++ b/stdlib/ballerina-config/src/main/java/org/ballerinalang/config/ConfigRegistry.java
@@ -266,6 +266,26 @@ public class ConfigRegistry {
     }
 
     /**
+     * Retrieve the table of configurations specified by the table header.
+     *
+     * @param tableHeader The table name to retrieve
+     * @return The config entries in the specified table
+     */
+    public Map<String, String> getConfigTable(String tableHeader) {
+        Map<String, String> table = new HashMap<>();
+        int subStringIndex = tableHeader.length() + 1;
+
+        // TODO: handle tables properly at the config parsing level
+        configEntries.entrySet().forEach(entry -> {
+            if (entry.getKey().startsWith(tableHeader)) {
+                table.put(entry.getKey().substring(subStringIndex), entry.getValue());
+            }
+        });
+
+        return table;
+    }
+
+    /**
      * Removes the specified key from the Config Registry.
      *
      * @param key The key for the configuration value to be removed

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/config/ConfigTableTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/config/ConfigTableTest.java
@@ -1,0 +1,93 @@
+package org.ballerinalang.test.config;
+
+import org.ballerinalang.config.ConfigRegistry;
+import org.ballerinalang.launcher.util.BCompileUtil;
+import org.ballerinalang.launcher.util.BRunUtil;
+import org.ballerinalang.launcher.util.CompileResult;
+import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BString;
+import org.ballerinalang.model.values.BValue;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+
+/**
+ * Test cases for retrieving tables from the config API.
+ */
+public class ConfigTableTest {
+
+    private static final ConfigRegistry registry = ConfigRegistry.getInstance();
+    private static final String BALLERINA_CONF = "ballerina.conf";
+    private CompileResult compileResult;
+    private String resourceRoot;
+    private Path sourceRoot;
+    private Path ballerinaConfPath;
+
+    @BeforeClass
+    public void setup() throws IOException {
+        resourceRoot = getClass().getProtectionDomain().getCodeSource().getLocation().getPath();
+        sourceRoot = Paths.get(resourceRoot, "test-src", "config");
+        ballerinaConfPath = Paths.get(resourceRoot, "datafiles", "config", BALLERINA_CONF);
+
+        compileResult = BCompileUtil.compile(sourceRoot.resolve("config.bal").toString());
+    }
+
+    @Test
+    public void testGetTable() throws IOException {
+        BString key = new BString("http1");
+        BValue[] inputArg = {key};
+
+        registry.initRegistry(new HashMap<>(), null, ballerinaConfPath);
+
+        BValue[] returnVals = BRunUtil.invoke(compileResult, "testGetTable", inputArg);
+
+        Assert.assertFalse(returnVals == null || returnVals.length == 0 || returnVals[0] == null,
+                           "Invalid Return Values.");
+        Assert.assertTrue(returnVals[0] instanceof BMap);
+
+        BMap table = (BMap) returnVals[0];
+        Assert.assertEquals(table.get("host").stringValue(), "localhost");
+        Assert.assertEquals(Integer.parseInt(table.get("port").stringValue()), 8080);
+    }
+
+    @Test(description = "Test retrieving a non-existent table")
+    public void testGetNonExistentTable() throws IOException {
+        BString key = new BString("https");
+        BValue[] inputArg = {key};
+
+        registry.initRegistry(new HashMap<>(), null, ballerinaConfPath);
+
+        BValue[] returnVals = BRunUtil.invoke(compileResult, "testGetTable", inputArg);
+        BMap table = (BMap) returnVals[0];
+
+        Assert.assertFalse(returnVals == null || returnVals.length == 0 || returnVals[0] == null,
+                           "Invalid Return Values.");
+        Assert.assertTrue(returnVals[0] instanceof BMap);
+        Assert.assertEquals(table.size(), 0);
+    }
+
+    @Test(description = "Test retrieving a table with nested tables")
+    public void testGetNestedTables() throws IOException {
+        BString key = new BString("http1");
+        BValue[] inputArg = {key};
+
+        registry.initRegistry(new HashMap<>(), null, ballerinaConfPath);
+
+        BValue[] returnVals = BRunUtil.invoke(compileResult, "testGetTable", inputArg);
+
+        Assert.assertFalse(returnVals == null || returnVals.length == 0 || returnVals[0] == null,
+                           "Invalid Return Values.");
+        Assert.assertTrue(returnVals[0] instanceof BMap);
+
+        BMap table = (BMap) returnVals[0];
+        Assert.assertEquals(table.size(), 3);
+        Assert.assertEquals(table.get("host").stringValue(), "localhost");
+        Assert.assertEquals(Integer.parseInt(table.get("port").stringValue()), 8080);
+        Assert.assertEquals(table.get("hello.basePath").stringValue(), "/hello");
+    }
+}

--- a/tests/ballerina-test/src/test/resources/datafiles/config/ballerina.conf
+++ b/tests/ballerina-test/src/test/resources/datafiles/config/ballerina.conf
@@ -16,14 +16,18 @@
 # under the License.
 #
 
-ballerina.http.host="10.100.1.200"
+ballerina_http_host="10.100.1.200"
 
-ballerina.http.instances="http1,http2"
-ballerina.env.PATH="Path variable: ${env:PATH}"
-ballerina.log.format="{{timestamp}}[yyyy-MM-dd HH:mm:ss,SSS] {{level}} [{{package}}:{{unit}}] [{{file}}:{{line}}] [{{worker}}] - \"{{msg}}\" {{err}}"
+ballerina_http_instances="http1,http2"
+ballerina_env_PATH="Path variable: ${env:PATH}"
+ballerina_log_format="{{timestamp}}[yyyy-MM-dd HH:mm:ss,SSS] {{level}} [{{package}}:{{unit}}] [{{file}}:{{line}}] [{{worker}}] - \"{{msg}}\" {{err}}"
 
 [http1]
-ballerina.http.port=8080
+host="localhost"
+port=8080
 
 [http2]
-ballerina.http.port=8081
+port=8081
+
+[http1.hello]
+basePath="/hello"

--- a/tests/ballerina-test/src/test/resources/test-src/config/config.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/config/config.bal
@@ -11,3 +11,7 @@ function testSetConfig(string key, string value) {
 function testContains(string key) returns (boolean) {
     return config:contains(key);
 }
+
+function testGetTable(string tableHeader) returns map {
+    return config:getTable(tableHeader);
+}


### PR DESCRIPTION
## Purpose
> Adds a new function, `getTable(string key)`, to the config API to retrieve a table from the config registry. Fix #6182 

## Sample
```ballerina
import ballerina/config;
import ballerina/io;

function main(string[] args) {
	map t = config:getTable("http");
	io:println(t["http_host"]);
}
```

The config file:
```
[ballerina_http."hello.world"]
http_port=8080

[http]
http_port=8081
http_host="localhost"
```