### PR TITLE
Introduce object based endpoint

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -73,11 +73,12 @@ public enum DiagnosticCode {
     INVALID_RETRY_COUNT("invalid.retry.count"),
 
     // Service, endpoint related errors codes
-    SERVICE_STRUCT_TYPE_REQUIRED("service.struct.type.required"),
-    SERVICE_INVALID_STRUCT_TYPE("service.invalid.struct.type"),
+    SERVICE_OBJECT_TYPE_REQUIRED("service.object.type.required"),
+    SERVICE_INVALID_OBJECT_TYPE("service.invalid.object.type"),
     SERVICE_INVALID_ENDPOINT_TYPE("service.invalid.endpoint.type"),
     SERVICE_SERVICE_TYPE_REQUIRED_ANONYMOUS("service.service.type.required.anonymous"),
-    ENDPOINT_STRUCT_TYPE_REQUIRED("endpoint.struct.type.required"),
+    ENDPOINT_OBJECT_TYPE_REQUIRED("endpoint.object.type.required"),
+    ENDPOINT_OBJECT_NEW_HAS_PARAM("endpoint.object.new.has.param"),
     ENDPOINT_INVALID_TYPE("endpoint.invalid.type"),
     ENDPOINT_INVALID_TYPE_NO_FUNCTION("endpoint.invalid.type.no.function"),
     ENDPOINT_SPI_INVALID_FUNCTION("endpoint.spi.invalid.function"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/EndpointSPIAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/EndpointSPIAnalyzer.java
@@ -76,15 +76,14 @@ public class EndpointSPIAnalyzer {
             dlog.error(endpoint.pos, DiagnosticCode.ENDPOINT_INVALID_TYPE, "");
             return;
         }
-        if (isValidEndpointType(endpoint.pos, endpoint.symbol.type)) {
-            // Update endpoint variable symbol
-            populateEndpointSymbol((BStructSymbol) endpoint.symbol.type.tsymbol, endpoint.symbol);
-        }
+        isValidEndpointType(endpoint.pos, endpoint.symbol.type);
+        // Update endpoint variable symbol
+        populateEndpointSymbol((BStructSymbol) endpoint.symbol.type.tsymbol, endpoint.symbol);
     }
 
     public BStructType getEndpointTypeFromServiceType(DiagnosticPos pos, BType type) {
         if (type.tag != TypeTags.STRUCT) {
-            dlog.error(pos, DiagnosticCode.ENDPOINT_STRUCT_TYPE_REQUIRED);
+            dlog.error(pos, DiagnosticCode.ENDPOINT_OBJECT_TYPE_REQUIRED);
             return null;
         }
         final BStructSymbol serviceType = (BStructSymbol) type.tsymbol;
@@ -92,7 +91,7 @@ public class EndpointSPIAnalyzer {
             if (Names.EP_SERVICE_GET_ENDPOINT.equals(attachedFunc.funcName)) {
                 if (attachedFunc.type.getParameterTypes().size() != 0
                         || attachedFunc.type.retType.tag != TypeTags.STRUCT) {
-                    dlog.error(pos, DiagnosticCode.SERVICE_INVALID_STRUCT_TYPE, serviceType);
+                    dlog.error(pos, DiagnosticCode.SERVICE_INVALID_OBJECT_TYPE, serviceType);
                     return null;
                 }
                 final BStructSymbol endPointType = (BStructSymbol) attachedFunc.type.retType.tsymbol;
@@ -102,7 +101,7 @@ public class EndpointSPIAnalyzer {
                 break;
             }
         }
-        dlog.error(pos, DiagnosticCode.SERVICE_INVALID_STRUCT_TYPE, serviceType);
+        dlog.error(pos, DiagnosticCode.SERVICE_INVALID_OBJECT_TYPE, serviceType);
         return null;
     }
 
@@ -113,7 +112,7 @@ public class EndpointSPIAnalyzer {
 
     public boolean isValidEndpointType(DiagnosticPos pos, BType type) {
         if (type.tag != TypeTags.STRUCT) {
-            dlog.error(pos, DiagnosticCode.ENDPOINT_STRUCT_TYPE_REQUIRED);
+            dlog.error(pos, DiagnosticCode.ENDPOINT_OBJECT_TYPE_REQUIRED);
             return false;
         }
         return isValidEndpointSPI(pos, (BStructSymbol) type.tsymbol);
@@ -156,11 +155,21 @@ public class EndpointSPIAnalyzer {
                 ep.attachedFunctionMap.put(Names.EP_SPI_STOP, attachedFunc);
             } else if (Names.EP_SPI_REGISTER.equals(attachedFunc.funcName)) {
                 ep.attachedFunctionMap.put(Names.EP_SPI_REGISTER, attachedFunc);
+            } else if (Names.OBJECT_INIT_SUFFIX.equals(attachedFunc.funcName)) {
+                ep.attachedFunctionMap.put(Names.OBJECT_INIT_SUFFIX, attachedFunc);
             }
         }
     }
 
     private void checkValidBaseEndpointSPI(Endpoint ep) {
+        if (ep.attachedFunctionMap.containsKey(Names.OBJECT_INIT_SUFFIX)) {
+            final BStructSymbol.BAttachedFunction newFunc = ep.attachedFunctionMap.get(Names.OBJECT_INIT_SUFFIX);
+            if (newFunc.symbol.getParameters().size() > 0) {
+                dlog.error(ep.pos, DiagnosticCode.ENDPOINT_OBJECT_NEW_HAS_PARAM);
+                invalidSPIs.putIfAbsent(ep.structSymbol, ep);
+            }
+        }
+
         if (!ep.attachedFunctionMap.containsKey(Names.EP_SPI_INIT)) {
             dlog.error(ep.pos, DiagnosticCode.ENDPOINT_INVALID_TYPE_NO_FUNCTION, ep.structSymbol, Names.EP_SPI_INIT);
             invalidSPIs.putIfAbsent(ep.structSymbol, ep);
@@ -241,6 +250,10 @@ public class EndpointSPIAnalyzer {
 
     BType getEndpointConfigType(BStructSymbol structSymbol) {
         if (!isProcessedValidEndpoint(structSymbol)) {
+            final Endpoint endpoint = invalidSPIs.get(structSymbol);
+            if (endpoint != null && endpoint.initFunction != null && endpoint.initFunction.getParameters().size() > 0) {
+                return endpoint.initFunction.getParameters().get(0).type;
+            }
             return symTable.errType;
         }
         final Endpoint endpoint = validSPIs.get(structSymbol);
@@ -256,21 +269,24 @@ public class EndpointSPIAnalyzer {
     }
 
     public void populateEndpointSymbol(BStructSymbol structSymbol, BEndpointVarSymbol endpointVarSymbol) {
-        final Endpoint endpoint = validSPIs.get(structSymbol);
-        if (endpoint != null) {
-            final Endpoint endPoint = validSPIs.get(structSymbol);
-            endpointVarSymbol.initFunction = endPoint.initFunction;
-
-            endpointVarSymbol.interactable = endPoint.interactable;
-            endpointVarSymbol.getClientFunction = endPoint.getClientFunction;
-            endpointVarSymbol.clientSymbol = (BStructSymbol) endPoint.clientStruct.tsymbol;
-
-            endpointVarSymbol.startFunction = endPoint.startFunction;
-            endpointVarSymbol.stopFunction = endPoint.stopFunction;
-
-            endpointVarSymbol.registrable = endPoint.registrable;
-            endpointVarSymbol.registerFunction = endPoint.registerFunction;
+        Endpoint endPoint = validSPIs.get(structSymbol);
+        if (endPoint == null) {
+            endPoint = invalidSPIs.get(structSymbol);
         }
+        if (endPoint == null) {
+            return;
+        }
+        endpointVarSymbol.initFunction = endPoint.initFunction;
+
+        endpointVarSymbol.interactable = endPoint.interactable;
+        endpointVarSymbol.getClientFunction = endPoint.getClientFunction;
+        endpointVarSymbol.clientSymbol = (BStructSymbol) endPoint.clientStruct.tsymbol;
+
+        endpointVarSymbol.startFunction = endPoint.startFunction;
+        endpointVarSymbol.stopFunction = endPoint.stopFunction;
+
+        endpointVarSymbol.registrable = endPoint.registrable;
+        endpointVarSymbol.registerFunction = endPoint.registerFunction;
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -824,7 +824,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         if (serviceNode.anonymousEndpointBind == null) {
             return;
         }
-        if (serviceNode.endpoints == null) {
+        if (serviceNode.endpointType == null) {
             dlog.error(serviceNode.pos, DiagnosticCode.SERVICE_SERVICE_TYPE_REQUIRED_ANONYMOUS, serviceNode.name);
             return;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -36,6 +36,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BStructSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTransformerSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BXMLNSSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.SymTag;
@@ -116,7 +117,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import javax.xml.XMLConstants;
 
 /**
@@ -1332,7 +1332,8 @@ public class TypeChecker extends BLangNodeVisitor {
         if (conSymbol == null
                 || conSymbol == symTable.notFoundSymbol
                 || conSymbol == symTable.errSymbol
-                || conSymbol.tag != SymTag.STRUCT) {
+                || !(conSymbol.tag == SymTag.OBJECT || conSymbol.tag == SymTag.STRUCT)) {
+            // TODO : Remove struct dependency.
             dlog.error(iExpr.pos, DiagnosticCode.INVALID_ACTION_INVOCATION);
             resultType = actualType;
             return;
@@ -1344,6 +1345,9 @@ public class TypeChecker extends BLangNodeVisitor {
         BPackageSymbol packageSymbol = (BPackageSymbol) conSymbol.owner;
         BSymbol actionSym = symResolver.lookupMemberSymbol(iExpr.pos, packageSymbol.scope, this.env,
                 uniqueFuncName, SymTag.FUNCTION);
+        if (actionSym == symTable.notFoundSymbol) {
+            actionSym = symResolver.resolveStructField(iExpr.pos, env, uniqueFuncName, (BTypeSymbol) conSymbol);
+        }
         if (actionSym == symTable.errSymbol || actionSym == symTable.notFoundSymbol) {
             dlog.error(iExpr.pos, DiagnosticCode.UNDEFINED_ACTION, actionName, epSymbol.name, conSymbol.type);
             resultType = actualType;

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -380,11 +380,11 @@ error.transformer.conflicts.with.conversion=\
 error.transformer.unsupported.types=\
   incompatible types: ''{0}'' is not supported by the transformer
 
-error.service.struct.type.required=\
-  incompatible types: requires a struct type
+error.service.object.type.required=\
+  incompatible types: requires an object type
 
-error.service.invalid.struct.type=\
-  service struct ''{0}'' does not match with service type interface
+error.service.invalid.object.type=\
+  given type ''{0}'' does not match with service type interface
 
 error.service.invalid.endpoint.type=\
   cannot infer type of the endpoint from the service type or binds of the service {0}
@@ -392,8 +392,11 @@ error.service.invalid.endpoint.type=\
 error.service.service.type.required.anonymous=\
   cannot infer type of the anonymous endpoint, requires a valid service type for service {0}
 
-error.endpoint.struct.type.required=\
-  incompatible types: requires a struct type
+error.endpoint.object.type.required=\
+  incompatible types: requires an object type
+
+error.endpoint.object.new.has.param=\
+  endpoint type should have a 'new' function with no param
 
 error.endpoint.invalid.type=\
   invalid endpoint type {0}

--- a/tests/ballerina-test/src/test/java/org/ballerinalang/test/endpoint/EndpointTest.java
+++ b/tests/ballerina-test/src/test/java/org/ballerinalang/test/endpoint/EndpointTest.java
@@ -82,7 +82,7 @@ public class EndpointTest {
     public void testAnonymousEndpointNegative() {
         CompileResult compileResult = BCompileUtil.compile("test-src/endpoint/test_anonymous_endpoint_negative.bal");
         Assert.assertEquals(compileResult.getDiagnostics().length, 1);
-        BAssertUtil.validateError(compileResult, 0, "undefined field 'confX' in struct 'DummyEndpointConfig'", 63, 39);
+        BAssertUtil.validateError(compileResult, 0, "undefined field 'confX' in struct 'DummyEndpointConfig'", 62, 39);
     }
 
 }

--- a/tests/ballerina-test/src/test/resources/test-src/endpoint/testEndpointInFunction.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/endpoint/testEndpointInFunction.bal
@@ -8,31 +8,34 @@ function main (string[] args) {
     exFlow = exFlow + result;
 }
 
-public struct DummyEndpoint {
-    string prop1;
-    int prop2;
-}
-public function <DummyEndpoint ep> init (DummyEndpointConfig conf) {
-    exFlow = exFlow + "init:DummyEndpoint;";
-    ep.prop1 = conf.conf1;
-    ep.prop2 = conf.conf3;
-}
+type DummyEndpoint object {
+    public {
+        string prop1;
+        int prop2;
+    }
 
-public function <DummyEndpoint ep> start () {
-    exFlow = exFlow + "start:DummyEndpoint;";
-}
+    public function init (DummyEndpointConfig conf) {
+        exFlow = exFlow + "init:DummyEndpoint;";
+        prop1 = conf.conf1;
+        prop2 = conf.conf3;
+    }
 
-public function <DummyEndpoint ep> stop () {
-    exFlow = exFlow + "stop:DummyEndpoint;";
-}
+    public function start () {
+        exFlow = exFlow + "start:DummyEndpoint;";
+    }
 
-public function <DummyEndpoint ep> register (typedesc ser) {
-    exFlow = exFlow + "register:DummyEndpoint;";
-}
+    public function stop () {
+        exFlow = exFlow + "stop:DummyEndpoint;";
+    }
 
-public function <DummyEndpoint ep> getClient () returns (DummyClient) {
-    exFlow = exFlow + "getClient:DummyEndpoint;";
-    return {};
+    public function register (typedesc ser) {
+        exFlow = exFlow + "register:DummyEndpoint;";
+    }
+
+    public function getClient () returns (DummyClient) {
+        exFlow = exFlow + "getClient:DummyEndpoint;";
+        return {};
+    }
 }
 
 public struct DummyEndpointConfig {
@@ -41,18 +44,18 @@ public struct DummyEndpointConfig {
     int conf3;
 }
 
-public struct DummyClient {
-    string conf1;
-}
+type DummyClient object {
+    public {string conf1; }
 
-public function <DummyClient c> invoke1 (string a, int b) {
-    exFlow = exFlow + "invoke1:DummyClient;";
-}
+    public function invoke1 (string a, int b) {
+        exFlow = exFlow + "invoke1:DummyClient;";
+    }
 
-public function <DummyClient c> invoke2 (string a, int b) returns (string) {
-    exFlow = exFlow + "invoke2:DummyClient;";
-    string result = a + b;
-    return result;
+    public function invoke2 (string a, int b) returns (string) {
+        exFlow = exFlow + "invoke2:DummyClient;";
+        string result = a + b;
+        return result;
+    }
 }
 
 function test1 () returns (string) {

--- a/tests/ballerina-test/src/test/resources/test-src/endpoint/testEndpointWithService.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/endpoint/testEndpointWithService.bal
@@ -1,30 +1,33 @@
 string exFlow = "";
 
-public struct DummyEndpoint {
-    string prop1;
-    int prop2;
-}
-public function <DummyEndpoint ep> init (DummyEndpointConfig conf) {
-    exFlow = exFlow + "init:DummyEndpoint;";
-    ep.prop1 = conf.conf1;
-    ep.prop2 = conf.conf3;
-}
+type DummyEndpoint object {
+    public {
+        string prop1;
+        int prop2;
+    }
 
-public function <DummyEndpoint ep> start () {
-    exFlow = exFlow + "start:DummyEndpoint;";
-}
+    public function init (DummyEndpointConfig conf) {
+        exFlow = exFlow + "init:DummyEndpoint;";
+        prop1 = conf.conf1;
+        prop2 = conf.conf3;
+    }
 
-public function <DummyEndpoint ep> stop () {
-    exFlow = exFlow + "stop:DummyEndpoint;";
-}
+    public function start () {
+        exFlow = exFlow + "start:DummyEndpoint;";
+    }
 
-public function <DummyEndpoint ep> register (typedesc ser) {
-    exFlow = exFlow + "register:DummyEndpoint;";
-}
+    public function stop () {
+        exFlow = exFlow + "stop:DummyEndpoint;";
+    }
 
-public function <DummyEndpoint ep> getClient () returns (DummyClient) {
-    exFlow = exFlow + "getClient:DummyEndpoint;";
-    return {};
+    public function register (typedesc ser) {
+        exFlow = exFlow + "register:DummyEndpoint;";
+    }
+
+    public function getClient () returns (DummyClient) {
+        exFlow = exFlow + "getClient:DummyEndpoint;";
+        return {};
+    }
 }
 
 public struct DummyEndpointConfig {
@@ -33,18 +36,22 @@ public struct DummyEndpointConfig {
     int conf3;
 }
 
-public struct DummyClient {
-    string conf1;
+type DummyClient object {
+    public {string conf1; }
+
+    public function invoke1 (string a, int b) {
+        exFlow = exFlow + "invoke1:DummyClient;";
+    }
+
+    public function invoke2 (string a, int b) returns (string) {
+        exFlow = exFlow + "invoke2:DummyClient;";
+        string result = a + b;
+        return result;
+    }
 }
 
-public function <DummyClient c> invoke1 (string a, int b) {
-    exFlow = exFlow + "invoke1:DummyClient;";
-}
-
-public function <DummyClient c> invoke2 (string a, int b) returns (string) {
-    exFlow = exFlow + "invoke2:DummyClient;";
-    string result = a + b;
-    return result;
+type DummyServiceType object {
+    function getEndpoint () returns (DummyEndpoint);
 }
 
 function test1 () returns (string) {
@@ -52,16 +59,8 @@ function test1 () returns (string) {
     return exFlow;
 }
 
-
 endpoint DummyEndpoint ep { conf1 : "test1"};
 
-struct DummyServiceType {
-}
-
-function <DummyServiceType s> getEndpoint() returns (DummyEndpoint){
-    DummyEndpoint ep = {};
-    return ep;
-}
 
 service<DummyServiceType> foo bind ep {
     getAction (endpoint client, string x, float y){

--- a/tests/ballerina-test/src/test/resources/test-src/endpoint/test_anonymous_endpoint.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/endpoint/test_anonymous_endpoint.bal
@@ -1,30 +1,33 @@
 string exFlow = "";
 
-public struct DummyEndpoint {
-    string prop1;
-    int prop2;
-}
-public function <DummyEndpoint ep> init (DummyEndpointConfig conf) {
-    exFlow = exFlow + "init:DummyEndpoint;";
-    ep.prop1 = conf.conf1;
-    ep.prop2 = conf.conf3;
-}
+type DummyEndpoint object {
+    public {
+        string prop1;
+        int prop2;
+    }
 
-public function <DummyEndpoint ep> start () {
-    exFlow = exFlow + "start:DummyEndpoint;";
-}
+    public function init (DummyEndpointConfig conf) {
+        exFlow = exFlow + "init:DummyEndpoint;";
+        prop1 = conf.conf1;
+        prop2 = conf.conf3;
+    }
 
-public function <DummyEndpoint ep> stop () {
-    exFlow = exFlow + "stop:DummyEndpoint;";
-}
+    public function start () {
+        exFlow = exFlow + "start:DummyEndpoint;";
+    }
 
-public function <DummyEndpoint ep> register (typedesc ser) {
-    exFlow = exFlow + "register:DummyEndpoint;";
-}
+    public function stop () {
+        exFlow = exFlow + "stop:DummyEndpoint;";
+    }
 
-public function <DummyEndpoint ep> getClient () returns (DummyClient) {
-    exFlow = exFlow + "getClient:DummyEndpoint;";
-    return {};
+    public function register (typedesc ser) {
+        exFlow = exFlow + "register:DummyEndpoint;";
+    }
+
+    public function getClient () returns (DummyClient) {
+        exFlow = exFlow + "getClient:DummyEndpoint;";
+        return {};
+    }
 }
 
 public struct DummyEndpointConfig {
@@ -33,18 +36,22 @@ public struct DummyEndpointConfig {
     int conf3;
 }
 
-public struct DummyClient {
-    string conf1;
+type DummyClient object {
+    public {string conf1; }
+
+    public function invoke1 (string a, int b) {
+        exFlow = exFlow + "invoke1:DummyClient;";
+    }
+
+    public function invoke2 (string a, int b) returns (string) {
+        exFlow = exFlow + "invoke2:DummyClient;";
+        string result = a + b;
+        return result;
+    }
 }
 
-public function <DummyClient c> invoke1 (string a, int b) {
-    exFlow = exFlow + "invoke1:DummyClient;";
-}
-
-public function <DummyClient c> invoke2 (string a, int b) returns (string) {
-    exFlow = exFlow + "invoke2:DummyClient;";
-    string result = a + b;
-    return result;
+type DummyServiceType object {
+    function getEndpoint () returns (DummyEndpoint);
 }
 
 function test1 () returns (string) {
@@ -52,13 +59,6 @@ function test1 () returns (string) {
     return exFlow;
 }
 
-struct DummyServiceType {
-}
-
-function <DummyServiceType s> getEndpoint() returns (DummyEndpoint){
-    DummyEndpoint ep = {};
-    return ep;
-}
 
 service<DummyServiceType> foo bind  { conf1 : "test1"} {
     getAction (endpoint client, string x, float y){

--- a/tests/ballerina-test/src/test/resources/test-src/endpoint/test_anonymous_endpoint_negative.bal
+++ b/tests/ballerina-test/src/test/resources/test-src/endpoint/test_anonymous_endpoint_negative.bal
@@ -1,30 +1,33 @@
 string exFlow = "";
 
-public struct DummyEndpoint {
-    string prop1;
-    int prop2;
-}
-public function <DummyEndpoint ep> init (DummyEndpointConfig conf) {
-    exFlow = exFlow + "init:DummyEndpoint;";
-    ep.prop1 = conf.conf1;
-    ep.prop2 = conf.conf3;
-}
+type DummyEndpoint object {
+    public {
+        string prop1;
+        int prop2;
+    }
 
-public function <DummyEndpoint ep> start () {
-    exFlow = exFlow + "start:DummyEndpoint;";
-}
+    public function init (DummyEndpointConfig conf) {
+        exFlow = exFlow + "init:DummyEndpoint;";
+        prop1 = conf.conf1;
+        prop2 = conf.conf3;
+    }
 
-public function <DummyEndpoint ep> stop () {
-    exFlow = exFlow + "stop:DummyEndpoint;";
-}
+    public function start () {
+        exFlow = exFlow + "start:DummyEndpoint;";
+    }
 
-public function <DummyEndpoint ep> register (typedesc ser) {
-    exFlow = exFlow + "register:DummyEndpoint;";
-}
+    public function stop () {
+        exFlow = exFlow + "stop:DummyEndpoint;";
+    }
 
-public function <DummyEndpoint ep> getClient () returns (DummyClient) {
-    exFlow = exFlow + "getClient:DummyEndpoint;";
-    return {};
+    public function register (typedesc ser) {
+        exFlow = exFlow + "register:DummyEndpoint;";
+    }
+
+    public function getClient () returns (DummyClient) {
+        exFlow = exFlow + "getClient:DummyEndpoint;";
+        return {};
+    }
 }
 
 public struct DummyEndpointConfig {
@@ -33,31 +36,27 @@ public struct DummyEndpointConfig {
     int conf3;
 }
 
-public struct DummyClient {
-    string conf1;
+type DummyClient object {
+    public {string conf1; }
+
+    public function invoke1 (string a, int b) {
+        exFlow = exFlow + "invoke1:DummyClient;";
+    }
+
+    public function invoke2 (string a, int b) returns (string) {
+        exFlow = exFlow + "invoke2:DummyClient;";
+        string result = a + b;
+        return result;
+    }
 }
 
-public function <DummyClient c> invoke1 (string a, int b) {
-    exFlow = exFlow + "invoke1:DummyClient;";
-}
-
-public function <DummyClient c> invoke2 (string a, int b) returns (string) {
-    exFlow = exFlow + "invoke2:DummyClient;";
-    string result = a + b;
-    return result;
+type DummyServiceType object {
+    function getEndpoint () returns (DummyEndpoint);
 }
 
 function test1 () returns (string) {
     exFlow = exFlow + "<test1>";
     return exFlow;
-}
-
-struct DummyServiceType {
-}
-
-function <DummyServiceType s> getEndpoint() returns (DummyEndpoint){
-    DummyEndpoint ep = {};
-    return ep;
 }
 
 service<DummyServiceType> foo bind  { confX : "test1"} {


### PR DESCRIPTION
With this PR endpoints can be defined using objects. Struct support will be removed in next version. 

eg:
```ballerina
import ballerina/io;

endpoint MockEndpoint ep {port:9090};

function main (string[] args) {
    io:println("main invoked");
    ep -> action1("s");
}

struct MockEndpointConfig {
     int port;
}

type MockServiceType object {
    function getEndpoint() returns (MockEndpoint);
}

type MockEndpoint object {
    public { int port = 9090, int value; }
    private { int somePort; }

    new (int i) {}

    function init(MockEndpointConfig config) {
        io:println("mockEP init");
    }
    function start() {
        io:println("mockEP start");
    }
    function stop() {
        io:println("mockEP stop");
    }
    function register(typedesc serviceType) {
        io:println("mockEP register");
    }
    function getClient() returns (MockClient) {
        io:println("mockEP getClient");
        return new MockClient();
    }
}

type MockClient object {
    new () {}
    function action1(string x) {
        io:println("mockClient action1");
    }
    function action2(string x) returns (string) {
        io:println("mockClient action2");
        return x + " modified";
    }
}
``` 