### PR TITLE
 Make websocket upgrade non-blocking 

### DIFF
--- a/docs/ballerina-by-example/examples/websocket-proxy-server/websocket-proxy-server.bal
+++ b/docs/ballerina-by-example/examples/websocket-proxy-server/websocket-proxy-server.bal
@@ -18,7 +18,7 @@ service<http:WebSocketService> SimpleProxyServer bind serviceEndpoint {
             url:remoteUrl,
             callbackService:typeof ClientService
         };
-        ep -> upgradeToWebSocket({"custom":"header"});
+        ep = ep -> upgradeToWebSocket({"custom":"header"});
         ep.attributes[ASSOCIATED_CONNECTION] = wsEndpoint;
         wsEndpoint.attributes[ASSOCIATED_CONNECTION] = ep;
     }

--- a/stdlib/ballerina-http/src/main/ballerina/http/websocket_connector.bal
+++ b/stdlib/ballerina-http/src/main/ballerina/http/websocket_connector.bal
@@ -37,7 +37,7 @@ public native function <WebSocketConnector wsConnector> closeConnection (int sta
 
 @Description {value:"Sends a upgrade request with custom headers"}
 @Param {value:"headers: a map of custom headers for handshake."}
-public native function <WebSocketConnector conn> upgradeToWebSocket (map headers);
+public native function <WebSocketConnector conn> upgradeToWebSocket (map headers) returns WebSocketEndpoint;
 
 @Description {value:"Cancels the handshake"}
 @Param {value:"statusCode: Status code for closing the connection"}

--- a/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/UpgradeToWebSocket.java
+++ b/stdlib/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/websocketconnector/UpgradeToWebSocket.java
@@ -18,7 +18,8 @@ package org.ballerinalang.net.http.actions.websocketconnector;
 
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import org.ballerinalang.bre.Context;
-import org.ballerinalang.bre.bvm.BlockingNativeCallableUnit;
+import org.ballerinalang.bre.bvm.CallableUnitCallback;
+import org.ballerinalang.model.NativeCallableUnit;
 import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BString;
@@ -45,10 +46,10 @@ import java.util.Set;
         },
         isPublic = true
 )
-public class UpgradeToWebSocket extends BlockingNativeCallableUnit {
+public class UpgradeToWebSocket implements NativeCallableUnit {
 
     @Override
-    public void execute(Context context) {
+    public void execute(Context context, CallableUnitCallback callback) {
         BStruct serverConnector = (BStruct) context.getRefArgument(0);
         WebSocketService webSocketService = (WebSocketService) serverConnector.getNativeData(
                 WebSocketConstants.WEBSOCKET_SERVICE);
@@ -59,8 +60,11 @@ public class UpgradeToWebSocket extends BlockingNativeCallableUnit {
             httpHeaders.add(key, headers.get(key));
         }
 
-        WebSocketUtil.handleHandshake(webSocketService, httpHeaders, serverConnector);
+        WebSocketUtil.handleHandshake(webSocketService, httpHeaders, serverConnector, context, callback);
+    }
 
-        context.setReturnValues();
+    @Override
+    public boolean isBlocking() {
+        return false;
     }
 }


### PR DESCRIPTION
## Purpose
> Resolve https://github.com/ballerina-lang/ballerina/issues/6213
>UpgradeToWebSocket method now returns the WebSocket endpoint

## Goals
> Prevent the function from blocking

## Approach
> Use NativeCallableUnit to make the function non-blocking